### PR TITLE
Add spider for Joinville/SC

### DIFF
--- a/CITIES.md
+++ b/CITIES.md
@@ -42,7 +42,7 @@ Tracking of the crawlers and parsers for the top 100 cities.
 | 33 | Aracaju | | | | |
 | 34 | Feira de Santana | :white_check_mark: | | | https://github.com/okfn-brasil/diario-oficial/pull/25 |
 | 35 | Cuiabá | | | | |
-| 36 | Joinville | :soon: | | | https://github.com/okfn-brasil/diario-oficial/pull/30 |
+| 36 | Joinville | :white_check_mark: | | | [#30](https://github.com/okfn-brasil/diario-oficial/pull/30) |
 | 37 | Juiz de Fora | :soon: | | https://github.com/okfn-brasil/diario-oficial/issues/12 | https://github.com/okfn-brasil/diario-oficial/pull/13 |
 | 38 | Londrina | | | | |
 | 39 | Aparecida de Goiânia | | | | |

--- a/CITIES.md
+++ b/CITIES.md
@@ -42,7 +42,7 @@ Tracking of the crawlers and parsers for the top 100 cities.
 | 33 | Aracaju | | | | |
 | 34 | Feira de Santana | :white_check_mark: | | | https://github.com/okfn-brasil/diario-oficial/pull/25 |
 | 35 | Cuiabá | | | | |
-| 36 | Joinville | :white_check_mark: | | | [#63](https://github.com/okfn-brasil/diario-oficial/pull/63) |
+| 36 | Joinville | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/63) |
 | 37 | Juiz de Fora | :soon: | | https://github.com/okfn-brasil/diario-oficial/issues/12 | https://github.com/okfn-brasil/diario-oficial/pull/13 |
 | 38 | Londrina | | | | |
 | 39 | Aparecida de Goiânia | | | | |

--- a/CITIES.md
+++ b/CITIES.md
@@ -42,7 +42,7 @@ Tracking of the crawlers and parsers for the top 100 cities.
 | 33 | Aracaju | | | | |
 | 34 | Feira de Santana | :white_check_mark: | | | https://github.com/okfn-brasil/diario-oficial/pull/25 |
 | 35 | Cuiabá | | | | |
-| 36 | Joinville | :white_check_mark: | | | [#30](https://github.com/okfn-brasil/diario-oficial/pull/30) |
+| 36 | Joinville | :white_check_mark: | | | [#63](https://github.com/okfn-brasil/diario-oficial/pull/63) |
 | 37 | Juiz de Fora | :soon: | | https://github.com/okfn-brasil/diario-oficial/issues/12 | https://github.com/okfn-brasil/diario-oficial/pull/13 |
 | 38 | Londrina | | | | |
 | 39 | Aparecida de Goiânia | | | | |

--- a/processing/data_collection/gazette/spiders/sc_joinville.py
+++ b/processing/data_collection/gazette/spiders/sc_joinville.py
@@ -3,10 +3,11 @@ import dateparser
 from datetime import datetime
 from scrapy import Request, Spider
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class ScJoinvilleSpider(Spider):
-    MUNICIPALITY_ID = "4209102"
+class ScJoinvilleSpider(BaseGazetteSpider):
+    TERRITORY_ID = "4209102"
     PDF_URL = "https://www.joinville.sc.gov.br{}"
 
     GAZETTE_ELEMENT_CSS = "ul.jornal li"
@@ -22,7 +23,7 @@ class ScJoinvilleSpider(Spider):
         """
         @url http://www.joinville.sc.gov.br/jornal/index/page/1
         @returns requests 1
-        @scrapes date file_urls is_extra_edition municipality_id power scraped_at
+        @scrapes date file_urls is_extra_edition territory_id power scraped_at
         """
 
         for element in response.css(self.GAZETTE_ELEMENT_CSS):
@@ -33,7 +34,7 @@ class ScJoinvilleSpider(Spider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=False,
-                municipality_id=self.MUNICIPALITY_ID,
+                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
                 scraped_at=datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/sc_joinville.py
+++ b/processing/data_collection/gazette/spiders/sc_joinville.py
@@ -31,8 +31,9 @@ class GazetteElement:
             scraped_at=datetime.utcnow(),
         )
 
+
 class ScJoinvilleSpider(Spider):
-    ELEMENT_CSS = 'ul.jornal li'
+    GAZETTE_ELEMENT_CSS = 'ul.jornal li'
     NEXT_PAGE_CSS = 'ul.pagination li.next a::attr(href)'
 
     allowed_domains = ['joinville.sc.gov.br']
@@ -46,13 +47,10 @@ class ScJoinvilleSpider(Spider):
         @scrapes date file_urls is_extra_edition municipality_id power scraped_at
         """
 
-        for element in self.get_gazettes_elements(response):
+        for element in response.css(self.GAZETTE_ELEMENT_CSS):
             yield GazetteElement(element).to_gazette()
 
-        yield Request(self.next_page_url(response), callback=self.parse)
+        for url in response.css(self.NEXT_PAGE_CSS).extract():
+            yield Request(url)
 
-    def get_gazettes_elements(self, response):
-        return response.css(self.ELEMENT_CSS)
 
-    def next_page_url(self, response):
-        return response.css(self.NEXT_PAGE_CSS).extract_first()

--- a/processing/data_collection/gazette/spiders/sc_joinville.py
+++ b/processing/data_collection/gazette/spiders/sc_joinville.py
@@ -1,0 +1,58 @@
+import re
+import dateparser
+
+from datetime import datetime
+from scrapy import Request, Spider
+from gazette.items import Gazette
+
+class GazetteElement:
+    DATE_CSS = 'span.article-date::text'
+    MUNICIPALITY_ID = '4209102'
+    PDF_URL = 'https://www.joinville.sc.gov.br{}'
+
+    def __init__(self, element):
+        self.element = element
+
+    def date(self):
+        date_str = self.element.css(self.DATE_CSS)[-1].extract()
+        return dateparser.parse(date_str, languages=['pt']).date()
+
+    def url(self):
+        path = self.element.css('a::attr(href)').extract_first()
+        return self.PDF_URL.format(path)
+
+    def to_gazette(self):
+        return Gazette(
+            date=self.date(),
+            file_urls=[self.url()],
+            is_extra_edition=False,
+            municipality_id=self.MUNICIPALITY_ID,
+            power='executive_legislature',
+            scraped_at=datetime.utcnow(),
+        )
+
+class ScJoinvilleSpider(Spider):
+    ELEMENT_CSS = 'ul.jornal li'
+    NEXT_PAGE_CSS = 'ul.pagination li.next a::attr(href)'
+
+    allowed_domains = ['joinville.sc.gov.br']
+    name = 'sc_joinville'
+    start_urls = ['https://www.joinville.sc.gov.br/jornal/index/page/1']
+
+    def parse(self, response):
+        """
+        @url http://www.joinville.sc.gov.br/jornal/index/page/1
+        @returns requests 1
+        @scrapes date file_urls is_extra_edition municipality_id power scraped_at
+        """
+
+        for element in self.get_gazettes_elements(response):
+            yield GazetteElement(element).to_gazette()
+
+        yield Request(self.next_page_url(response), callback=self.parse)
+
+    def get_gazettes_elements(self, response):
+        return response.css(self.ELEMENT_CSS)
+
+    def next_page_url(self, response):
+        return response.css(self.NEXT_PAGE_CSS).extract_first()

--- a/processing/data_collection/gazette/spiders/sc_joinville.py
+++ b/processing/data_collection/gazette/spiders/sc_joinville.py
@@ -44,7 +44,7 @@ class ScJoinvilleSpider(BaseGazetteSpider):
 
     def extract_date(self, element):
         date = element.css(self.DATE_CSS).re(self.DATE_REGEX)
-        date = '/'.join(date)
+        date = "/".join(date)
         return dateparser.parse(date, languages=["pt"]).date()
 
     def extract_url(self, element):

--- a/processing/data_collection/gazette/spiders/sc_joinville.py
+++ b/processing/data_collection/gazette/spiders/sc_joinville.py
@@ -1,44 +1,22 @@
-import re
 import dateparser
 
 from datetime import datetime
 from scrapy import Request, Spider
 from gazette.items import Gazette
 
-class GazetteElement:
-    DATE_CSS = 'span.article-date::text'
-    MUNICIPALITY_ID = '4209102'
-    PDF_URL = 'https://www.joinville.sc.gov.br{}'
-
-    def __init__(self, element):
-        self.element = element
-
-    def date(self):
-        date_str = self.element.css(self.DATE_CSS)[-1].extract()
-        return dateparser.parse(date_str, languages=['pt']).date()
-
-    def url(self):
-        path = self.element.css('a::attr(href)').extract_first()
-        return self.PDF_URL.format(path)
-
-    def to_gazette(self):
-        return Gazette(
-            date=self.date(),
-            file_urls=[self.url()],
-            is_extra_edition=False,
-            municipality_id=self.MUNICIPALITY_ID,
-            power='executive_legislature',
-            scraped_at=datetime.utcnow(),
-        )
-
 
 class ScJoinvilleSpider(Spider):
-    GAZETTE_ELEMENT_CSS = 'ul.jornal li'
-    NEXT_PAGE_CSS = 'ul.pagination li.next a::attr(href)'
+    MUNICIPALITY_ID = "4209102"
+    PDF_URL = "https://www.joinville.sc.gov.br{}"
 
-    allowed_domains = ['joinville.sc.gov.br']
-    name = 'sc_joinville'
-    start_urls = ['https://www.joinville.sc.gov.br/jornal/index/page/1']
+    GAZETTE_ELEMENT_CSS = "ul.jornal li"
+    NEXT_PAGE_CSS = "ul.pagination li.next a::attr(href)"
+    DATE_CSS = "span.article-date::text"
+    DATE_REGEX = "([\d]+)[ |]+([\w]+)[ |]+([\d]+)"
+
+    allowed_domains = ["joinville.sc.gov.br"]
+    name = "sc_joinville"
+    start_urls = ["https://www.joinville.sc.gov.br/jornal/index/page/1"]
 
     def parse(self, response):
         """
@@ -48,9 +26,26 @@ class ScJoinvilleSpider(Spider):
         """
 
         for element in response.css(self.GAZETTE_ELEMENT_CSS):
-            yield GazetteElement(element).to_gazette()
+            date = self.extract_date(element)
+            url = self.extract_url(element)
+
+            yield Gazette(
+                date=date,
+                file_urls=[url],
+                is_extra_edition=False,
+                municipality_id=self.MUNICIPALITY_ID,
+                power="executive_legislature",
+                scraped_at=datetime.utcnow(),
+            )
 
         for url in response.css(self.NEXT_PAGE_CSS).extract():
             yield Request(url)
 
+    def extract_date(self, element):
+        date = element.css(self.DATE_CSS).re(self.DATE_REGEX)
+        date = '/'.join(date)
+        return dateparser.parse(date, languages=["pt"]).date()
 
+    def extract_url(self, element):
+        path = element.css("a::attr(href)").extract_first()
+        return self.PDF_URL.format(path)


### PR DESCRIPTION
Hey people,

In this PR we add the spider to collect data from [Joinville/SC gazette](https://www.joinville.sc.gov.br/jornal/index/page/1).

Re opening this from https://github.com/okfn-brasil/diario-oficial/pull/30