### PR TITLE
Add spider for Campos dos Goytacazes/RJ

### DIFF
--- a/CITIES.md
+++ b/CITIES.md
@@ -51,7 +51,7 @@ Tracking of the crawlers and parsers for the top 100 cities.
 | 42 | Serra | :white_check_mark: | | | |
 | 43 | Niterói | | | | |
 | 44 | Belford Roxo | | | | |
-| 45 | Campos dos Goytacazes Campos dos Goytacazes | | | | |
+| 45 | Campos dos Goytacazes | :white_check_mark: | | | https://github.com/okfn-brasil/diario-oficial/pull/70 |
 | 46 | Vila Velha | :white_check_mark: | | | |
 | 47 | Florianópolis | :white_check_mark: | | | https://github.com/okfn-brasil/diario-oficial/pull/17 |
 | 48 | Caxias do Sul | | | | |

--- a/processing/data_collection/gazette/spiders/rj_campos_goytacazes.py
+++ b/processing/data_collection/gazette/spiders/rj_campos_goytacazes.py
@@ -1,0 +1,44 @@
+import re
+import dateparser
+
+from datetime import datetime
+from scrapy import Request
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+class RjCampoGoytacazesSpider(BaseGazetteSpider):
+    GAZETTE_ELEMENT_CSS = 'ul.ul-licitacoes li'
+    MUNICIPALITY_ID = '3301009'
+
+    allowed_domains = ['www.campos.rj.gov.br']
+    name = 'rj_campos_goytacazes'
+    start_urls = ['https://www.campos.rj.gov.br/diario-oficial.php?PGpagina=1']
+
+    def parse(self, response):
+        """
+        @url https://www.campos.rj.gov.br/diario-oficial.php?PGpagina=1
+        @returns requests 1
+        @scrapes date file_urls is_extra_edition municipality_id power scraped_at
+        """
+
+        for element in response.css(self.GAZETTE_ELEMENT_CSS):
+            url = element.css('a::attr(href)').extract_first()
+            gazette_text = element.css("h4::text").extract_first()
+            date_text = gazette_text.split(' - ')[0].split('Eletrônico de ')[1]
+            date = dateparser.parse(date_text, languages=['pt']).date()
+
+            extra_edition = gazette_text.startswith('Suplemento')
+
+            yield Gazette(
+              date=date,
+              file_urls=[url],
+              is_extra_edition=extra_edition,
+              municipality_id=self.MUNICIPALITY_ID,
+              power='executive',
+              scraped_at=datetime.utcnow(),
+            )
+
+        next_url = response.css('.pagination').xpath("//a[contains(text(), 'Proxima')]/@href").extract_first()
+
+        if next_url:
+            yield  Request(response.urljoin(next_url))

--- a/processing/data_collection/gazette/spiders/rj_campos_goytacazes.py
+++ b/processing/data_collection/gazette/spiders/rj_campos_goytacazes.py
@@ -12,11 +12,11 @@ class RjCampoGoytacazesSpider(BaseGazetteSpider):
 
     allowed_domains = ['www.campos.rj.gov.br']
     name = 'rj_campos_goytacazes'
-    start_urls = ['https://www.campos.rj.gov.br/diario-oficial.php?PGpagina=1']
+    start_urls = ['https://www.campos.rj.gov.br/diario-oficial.php?PGpagina=1&PGporPagina=15']
 
     def parse(self, response):
         """
-        @url https://www.campos.rj.gov.br/diario-oficial.php?PGpagina=1
+        @url https://www.campos.rj.gov.br/diario-oficial.php?PGpagina=1&PGporPagina=15
         @returns requests 1
         @scrapes date file_urls is_extra_edition municipality_id power scraped_at
         """
@@ -24,21 +24,22 @@ class RjCampoGoytacazesSpider(BaseGazetteSpider):
         for element in response.css(self.GAZETTE_ELEMENT_CSS):
             url = element.css('a::attr(href)').extract_first()
             gazette_text = element.css("h4::text").extract_first()
-            date_text = gazette_text.split(' - ')[0].split('Eletrônico de ')[1]
-            date = dateparser.parse(date_text, languages=['pt']).date()
-
             extra_edition = gazette_text.startswith('Suplemento')
 
-            yield Gazette(
-              date=date,
-              file_urls=[url],
-              is_extra_edition=extra_edition,
-              municipality_id=self.MUNICIPALITY_ID,
-              power='executive',
-              scraped_at=datetime.utcnow(),
-            )
+            date_re = re.search(r'(\d{2} de (.*) de \d{4})', gazette_text)
+            if date_re:
+                date = dateparser.parse(date_re.group(0), languages=['pt']).date()
+
+                yield Gazette(
+                  date=date,
+                  file_urls=[url],
+                  is_extra_edition=extra_edition,
+                  municipality_id=self.MUNICIPALITY_ID,
+                  power='executive',
+                  scraped_at=datetime.utcnow(),
+                )
 
         next_url = response.css('.pagination').xpath("//a[contains(text(), 'Proxima')]/@href").extract_first()
-
         if next_url:
+            print(next_url)
             yield  Request(response.urljoin(next_url))


### PR DESCRIPTION
In this PR we add the spider to collect data from [Campos dos Goytacazes/RJ gazette](https://www.campos.rj.gov.br/diario-oficial.php)