### PR TITLE
Add spider for João Pessoa/PB

### DIFF
--- a/CITIES.md
+++ b/CITIES.md
@@ -29,7 +29,7 @@ Tracking of the crawlers and parsers for the top 100 cities.
 | 20 | Campo Grande | | | | https://github.com/okfn-brasil/diario-oficial/pull/35 |
 | 21 | Teresina | :soon: | | | https://github.com/okfn-brasil/diario-oficial/pull/53 |
 | 22 | São Bernardo do Campo | | | | |
-| 23 | João Pessoa | | | | |
+| 23 | João Pessoa | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/72) |
 | 24 | Nova Iguaçu | | | | |
 | 25 | Santo André | | | | |
 | 26 | São José dos Campos | | | | |

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -7,7 +7,7 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class PbJoaoPessoaSpider(BaseGazetteSpider):
-    MUNICIPALITY_ID = '2507507'
+    TERRITORY_ID = '2507507'
 
     EXTRA_EDITION_CSS = 'td:first-child'
     GAZETTE_ROW_CSS = '.table-semanarios table tbody tr'
@@ -24,7 +24,7 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
         """
         @url http://www.joaopessoa.pb.gov.br/semanariooficial/
         @returns requests 1
-        @scrapes date file_urls is_extra_edition municipality_id power scraped_at
+        @scrapes date file_urls is_extra_edition territory_id power scraped_at
         """
 
         for element in response.css(self.GAZETTE_ROW_CSS):
@@ -37,7 +37,7 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra_edition,
-                territory_id=self.MUNICIPALITY_ID,
+                territory_id=self.TERRITORY_ID,
                 power='executive_legislature',
                 scraped_at=datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -7,18 +7,18 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class PbJoaoPessoaSpider(BaseGazetteSpider):
-    TERRITORY_ID = '2507507'
+    TERRITORY_ID = "2507507"
 
-    EXTRA_EDITION_CSS = 'td:first-child'
-    GAZETTE_ROW_CSS = '.table-semanarios table tbody tr'
-    GAZETTE_URL_CSS = 'td:last-child a::attr(href)'
-    NEXT_PAGE_CSS = '.pagination a.next::attr(href)'
-    DATE_CSS = 'td:nth-last-child(2)::text'
-    DATE_REGEX = r'[0-9]{2}/[0-9]{2}/[0-9]{4}'
+    EXTRA_EDITION_CSS = "td:first-child"
+    GAZETTE_ROW_CSS = ".table-semanarios table tbody tr"
+    GAZETTE_URL_CSS = "td:last-child a::attr(href)"
+    NEXT_PAGE_CSS = ".pagination a.next::attr(href)"
+    DATE_CSS = "td:nth-last-child(2)::text"
+    DATE_REGEX = r"[0-9]{2}/[0-9]{2}/[0-9]{4}"
 
-    allowed_domains = ['www.joaopessoa.pb.gov.br']
-    name = 'pb_joao_pessoa'
-    start_urls = ['http://www.joaopessoa.pb.gov.br/semanariooficial/']
+    allowed_domains = ["www.joaopessoa.pb.gov.br"]
+    name = "pb_joao_pessoa"
+    start_urls = ["http://www.joaopessoa.pb.gov.br/semanariooficial/"]
 
     def parse(self, response):
         """
@@ -30,15 +30,15 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
         for element in response.css(self.GAZETTE_ROW_CSS):
             url = element.css(self.GAZETTE_URL_CSS).extract_first()
             date = element.css(self.DATE_CSS).re(self.DATE_REGEX).pop()
-            date = dateparser.parse(date, languages=['pt']).date()
-            is_extra_edition = 'Especial' in element.css(self.EXTRA_EDITION_CSS).extract_first()
+            date = dateparser.parse(date, languages=["pt"]).date()
+            is_extra = "Especial" in element.css(self.EXTRA_EDITION_CSS).extract_first()
 
             yield Gazette(
                 date=date,
                 file_urls=[url],
-                is_extra_edition=is_extra_edition,
+                is_extra_edition=is_extra,
                 territory_id=self.TERRITORY_ID,
-                power='executive_legislature',
+                power="executive_legislature",
                 scraped_at=datetime.utcnow(),
             )
 

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -3,9 +3,10 @@ import dateparser
 from datetime import datetime
 from scrapy import Request, Spider
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class PbJoaoPessoaSpider(Spider):
+class PbJoaoPessoaSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '2507507'
 
     EXTRA_EDITION_CSS = 'td:first-child'

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -1,7 +1,6 @@
 import dateparser
 
 from datetime import datetime
-from scrapy import Request, Spider
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
@@ -23,6 +22,7 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
     def parse(self, response):
         """
         @url http://www.joaopessoa.pb.gov.br/semanariooficial/
+        @returns items 10
         @returns requests 1
         @scrapes date file_urls is_extra_edition territory_id power scraped_at
         """
@@ -43,4 +43,4 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
             )
 
         for url in response.css(self.NEXT_PAGE_CSS).extract():
-            yield Request(url)
+            yield response.follow(url)

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -1,0 +1,45 @@
+import dateparser
+
+from datetime import datetime
+from scrapy import Request, Spider
+from gazette.items import Gazette
+
+
+class PbJoaoPessoaSpider(Spider):
+    MUNICIPALITY_ID = '2507507'
+
+    EXTRA_EDITION_CSS = 'td:first-child'
+    GAZETTE_ROW_CSS = '.table-semanarios table tbody tr'
+    GAZETTE_URL_CSS = 'td:last-child a::attr(href)'
+    NEXT_PAGE_CSS = '.pagination a.next::attr(href)'
+    DATE_CSS = 'td:nth-last-child(2)::text'
+    DATE_REGEX = r'[0-9]{2}/[0-9]{2}/[0-9]{4}'
+
+    allowed_domains = ['www.joaopessoa.pb.gov.br']
+    name = 'pb_joao_pessoa'
+    start_urls = ['http://www.joaopessoa.pb.gov.br/semanariooficial/']
+
+    def parse(self, response):
+        """
+        @url http://www.joaopessoa.pb.gov.br/semanariooficial/
+        @returns requests 1
+        @scrapes date file_urls is_extra_edition municipality_id power scraped_at
+        """
+
+        for element in response.css(self.GAZETTE_ROW_CSS):
+            url = element.css(self.GAZETTE_URL_CSS).extract_first()
+            date = element.css(self.DATE_CSS).re(self.DATE_REGEX).pop()
+            date = dateparser.parse(date, languages=['pt']).date()
+            is_extra_edition = 'Especial' in element.css(self.EXTRA_EDITION_CSS).extract_first()
+
+            yield Gazette(
+                date=date,
+                file_urls=[url],
+                is_extra_edition=is_extra_edition,
+                territory_id=self.MUNICIPALITY_ID,
+                power='executive_legislature',
+                scraped_at=datetime.utcnow(),
+            )
+
+        for url in response.css(self.NEXT_PAGE_CSS).extract():
+            yield Request(url)


### PR DESCRIPTION
Hey people,

In this PR we add the spider to collect data from [João Pessoa/PB gazette](http://www.joaopessoa.pb.gov.br/semanariooficial/).