### PR TITLE
Add spider for Mossoró/RN

### DIFF
--- a/CITIES.md
+++ b/CITIES.md
@@ -100,7 +100,7 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 | 90 | Petrópolis | | | | |
 | 91 | Camaçari | | | | |
 | 92 | Santarém | | | | |
-| 93 | Mossoró | | | | |
+| 93 | Mossoró | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/85) |
 | 94 | Suzano | | | | |
 | 95 | Palmas | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/1) |
 | 96 | Governador Valadares | :soon: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/19) |

--- a/processing/data_collection/gazette/spiders/rn_mossoro.py
+++ b/processing/data_collection/gazette/spiders/rn_mossoro.py
@@ -12,7 +12,7 @@ class RnMossoroSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '2408003'
     PDF_URL = 'https://www.prefeiturademossoro.com.br/jom/{}'
 
-    GAZETTES_CSS = 'body > div > table:first-child > tr > td > table:last-child > tr > td > div > table > tr > td'
+    GAZETTES_CSS = 'table:first-child > tr > td > table:last-child > tr > td > div > table > tr > td'
     PDF_INFO_CSS = 'td.TextoLink'
     PDF_RELATIVE_PATH_CSS = 'a::attr(href)'
     DATE_REGEX = r'[0-9]{1,2} de [A-Za-z].* de [0-9]{4}'

--- a/processing/data_collection/gazette/spiders/rn_mossoro.py
+++ b/processing/data_collection/gazette/spiders/rn_mossoro.py
@@ -1,0 +1,56 @@
+from dateparser import parse
+import datetime as dt
+
+import scrapy
+from scrapy.http import Request
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RnMossoroSpider(BaseGazetteSpider):
+    MUNICIPALITY_ID = '2408003'
+    PDF_URL = 'https://www.prefeiturademossoro.com.br/jom/{}'
+
+    GAZETTES_CSS = 'body > div > table:first-child > tr > td > table:last-child > tr > td > div > table > tr > td'
+    PDF_INFO_CSS = 'td.TextoLink'
+    PDF_REALTIVE_PATH_CSS = 'a::attr(href)'
+    DATE_REGEX = r'[0-9]{1,2} de [A-Za-z].* de [0-9]{4}'
+    IS_EXTRA_REGEX = r'-[A-Za-z]'
+
+    allowed_domains = ['prefeiturademossoro.com.br']
+    name = 'rn_mossoro'
+    start_urls = ['https://www.prefeiturademossoro.com.br/jom/alljoms.php']
+
+    def parse(self, response):
+        dates = set()
+        for element in response.css(self.GAZETTES_CSS):
+            url = self.extract_url(element)
+            date = self.extract_date(element)
+            if url and date and date not in dates:
+                dates.add(date)
+                yield Gazette(
+                    date=date,
+                    file_urls=[url],
+                    is_extra_edition=self.is_extra_edition(element),
+                    municipality_id=self.MUNICIPALITY_ID,
+                    power='executive_legislature',
+                    scraped_at=dt.datetime.utcnow(),
+                )
+
+    def extract_url(self, element):
+        realtive_path = element.css(self.PDF_REALTIVE_PATH_CSS).extract_first()
+        if not realtive_path:
+            return None
+
+        return self.PDF_URL.format(realtive_path)
+
+    def extract_date(self, element):
+        date = element.css(self.PDF_INFO_CSS).re(self.DATE_REGEX)
+        if not date:
+            return None
+
+        return parse(date[0], languages=['pt']).date()
+
+    def is_extra_edition(self, element):
+        return bool(element.css(self.PDF_INFO_CSS).re(self.IS_EXTRA_REGEX))

--- a/processing/data_collection/gazette/spiders/rn_mossoro.py
+++ b/processing/data_collection/gazette/spiders/rn_mossoro.py
@@ -14,7 +14,7 @@ class RnMossoroSpider(BaseGazetteSpider):
 
     GAZETTES_CSS = 'body > div > table:first-child > tr > td > table:last-child > tr > td > div > table > tr > td'
     PDF_INFO_CSS = 'td.TextoLink'
-    PDF_REALTIVE_PATH_CSS = 'a::attr(href)'
+    PDF_RELATIVE_PATH_CSS = 'a::attr(href)'
     DATE_REGEX = r'[0-9]{1,2} de [A-Za-z].* de [0-9]{4}'
     IS_EXTRA_REGEX = r'-[A-Za-z]'
 
@@ -39,11 +39,11 @@ class RnMossoroSpider(BaseGazetteSpider):
                 )
 
     def extract_url(self, element):
-        realtive_path = element.css(self.PDF_REALTIVE_PATH_CSS).extract_first()
-        if not realtive_path:
+        relative_path = element.css(self.PDF_RELATIVE_PATH_CSS).extract_first()
+        if not relative_path:
             return None
 
-        return self.PDF_URL.format(realtive_path)
+        return self.PDF_URL.format(relative_path)
 
     def extract_date(self, element):
         date = element.css(self.PDF_INFO_CSS).re(self.DATE_REGEX)


### PR DESCRIPTION
In this PR we add the spider to collect data from [Mossoró/RN gazettes](https://www.prefeiturademossoro.com.br/jom/alljoms.php).

We have found that the gazette's dates in the website are not  trustworthy:
- We have a gazette with a date that doesn't exist, `June 31st, 2017`. But inside the gazette the date is `May 31st, 2017`. Right now, it breaks the code when it tries to parse the date.
How should we proceed? We thought about reading the gazette content and get the date from there. But right now we couldn't find a way to do that. Any thoughts?

- We have dates in future, like `December 17th, 2018`.  But inside the gazette the date is `January 17th, 2018`. It is similar to the previous problem.

- We have gazettes that are duplicated, like 2018-01-12, 2017-12-20, 2017-10-31, etc...
About that, we thought that we could check if a given gazette's date has the same date from another gazette that was already processed, if so we ignore it. Is it a good approach?

Co-authored-by: @LucasSedrez and @rhogeranacleto