### PR TITLE
Add crawler for Canoas/RS

### DIFF
--- a/CITIES.md
+++ b/CITIES.md
@@ -85,7 +85,7 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 | 75 | Franca | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/5) |
 | 76 | Pelotas | | | | |
 | 77 | Ponta Grossa | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/45) |
-| 78 | Canoas | :soon: | | [issue](https://github.com/okfn-brasil/diario-oficial/issues/10) | |
+| 78 | Canoas | :soon: | | [issue](https://github.com/okfn-brasil/diario-oficial/issues/10) | [PR](https://github.com/okfn-brasil/diario-oficial/pull/91) |
 | 79 | Petrolina | | | | |
 | 80 | Boa Vista | | | | |
 | 81 | Ribeirão das Neves | | | | |

--- a/CITIES.md
+++ b/CITIES.md
@@ -85,7 +85,7 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 | 75 | Franca | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/5) |
 | 76 | Pelotas | | | | |
 | 77 | Ponta Grossa | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/45) |
-| 78 | Canoas | | | [issue](https://github.com/okfn-brasil/diario-oficial/issues/10) | |
+| 78 | Canoas | :soon: | | [issue](https://github.com/okfn-brasil/diario-oficial/issues/10) | |
 | 79 | Petrolina | | | | |
 | 80 | Boa Vista | | | | |
 | 81 | Ribeirão das Neves | | | | |

--- a/processing/data_collection/gazette/spiders/rs_canoas.py
+++ b/processing/data_collection/gazette/spiders/rs_canoas.py
@@ -1,0 +1,48 @@
+import json
+from datetime import date, datetime, timedelta
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RsCanoasSpider(BaseGazetteSpider):
+    TERRITORY_ID = '4304606'
+    name = 'rs_canoas'
+    START_DATE = date(2018, 5, 29)
+    BASE_URL = 'https://sistemas.canoas.rs.gov.br/domc/api/'
+
+    def start_requests(self):
+        today = date.today()
+        day = self.START_DATE
+        while day < today:
+            url = '{}public/diary-by-day?day={}'.format(
+                self.BASE_URL, day.strftime('%d/%m/%Y'))
+            yield scrapy.Request(url)
+            day = day + timedelta(days=1)
+
+    def parse(self, response):
+        """
+        @url https://sistemas.canoas.rs.gov.br/domc/api/public/diary-by-day?day=08/06/2018  # noqa
+        @returns items 3 3
+        @scrapes date file_urls is_extra_edition territory_id power scraped_at
+        """
+        data = json.loads(response.body_as_unicode())
+        items = []
+
+        for edition in data['editions']:
+            file_url = '{}edition-file/{}'.format(self.BASE_URL, edition['id'])
+            is_extra_edition = edition['type'] == 'C'
+
+            items.append(
+                Gazette(
+                    date=data['day'],
+                    file_urls=[file_url],
+                    is_extra_edition=is_extra_edition,
+                    territory_id=self.TERRITORY_ID,
+                    power='executive',
+                    scraped_at=datetime.utcnow(),
+                )
+            )
+        return items


### PR DESCRIPTION
Segue o crawler para o [novo site](https://sistemas.canoas.rs.gov.br/domc/) de Canoas/RS com diários a partir de 29/05/2018, como discutido aqui #10.
Me atrapalhei com o Docker e não consegui testar muito bem, se alguém puder ajudar nisso. Sei q os arquivos foram baixados, mas não consegui acessar.