### PR TITLE
Add SIGPub (diariomunicipal.com.br) base spider and subspiders

### DIFF
--- a/CITIES.md
+++ b/CITIES.md
@@ -414,7 +414,1865 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 | 404 | Sarutaiá | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/232) |
 | 405 | Vera Cruz (RS) | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/232) |
 | 406 | Votorantim | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/232) |
-| 407 | Presidente Prudente | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/233) |
+| 407 | Abadia Dos Dourados - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 408 | Abadia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 409 | Abadiania - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 410 | Abaetetuba - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 411 | Abaiara - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 412 | Abatiá - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 413 | Abel Figueiredo - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 414 | Abreu E Lima - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 415 | Acaiaca - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 416 | Acari - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 417 | Acopiara - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 418 | Acorizal - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 419 | Acreúna - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 420 | Afogados Da Ingazeira - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 421 | Afonso Bezerra - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 422 | Afrânio - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 423 | Agrestina - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 424 | Água Azul Do Norte - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 425 | Água Boa - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 426 | Água Branca - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 427 | Água Branca - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 428 | Água Clara - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 429 | Água Comprida - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 430 | Água Fria - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 431 | Água Nova - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 432 | Água Preta - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 433 | Águas Belas - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 434 | Águas Vermelhas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 435 | Agudos Do Sul - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 436 | Alagoa Nova - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 437 | Alagoa - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 438 | Alagoinha - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 439 | Alcântaras - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 440 | Alecrim - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 441 | Alegrete - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 442 | Alegria - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 443 | Alexandria - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 444 | Alexânia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 445 | Alhandra - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 446 | Aliança - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 447 | Almadina - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 448 | Almino Afonso - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 449 | Almirante Tamandaré Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 450 | Almirante Tamandaré - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 451 | Alta Floresta D'Oeste - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 452 | Alta Floresta - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 453 | Altamira Do Paraná - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 454 | Altaneira - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 455 | Altinho - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 456 | Alto Alegre Dos Parecis - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 457 | Alto Alegre - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 458 | Alto Araguaia - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 459 | Alto Boa Vista - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 460 | Alto Garças - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 461 | Alto Horizonte - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 462 | Alto Paraguai - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 463 | Alto Paraíso - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 464 | Alto Taquari - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 465 | Alvarães - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 466 | Alvorada D'Oeste - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 467 | Alvorada De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 468 | Alvorada Do Gurguéia - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 469 | Alvorada Do Norte - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 470 | Alvorada - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 471 | Além Paraíba - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 472 | Amajari - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 473 | Amaje - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 474 | Amambai - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 475 | Amaporã - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 476 | Amaraji - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 477 | Amaralina - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 478 | Amaturá - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 479 | Amorinopolis - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 480 | Ampére - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 481 | Anadia - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 482 | Anamã - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 483 | Anapú - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 484 | Anastácio - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 485 | Andirá - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 486 | Andradas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 487 | Angelim - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 488 | Angicos - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 489 | Angélica - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 490 | Anicuns - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 491 | Anori - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 492 | Antonina Do Norte - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 493 | Antonina - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 494 | Antônio João - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 495 | Antônio Martins - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 496 | Aparecida Do Rio Doce - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 497 | Aparecida Do Taboado - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 498 | Aparecida - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 499 | Aperibé - RJ | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 500 | Apiacás - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 501 | Apodi - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 502 | Aporé - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 503 | Apuí - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 504 | Aquidauana - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 505 | Aracoiaba - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 506 | Aragarças - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 507 | Aragoiânia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 508 | Araguaiana - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 509 | Araguainha - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 510 | Araguapaz - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 511 | Arambaré - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 512 | Arapiraca - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 513 | Araporã - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 514 | Araputanga - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 515 | Arara - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 516 | Ararendá - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 517 | Araricá - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 518 | Araripina - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 519 | Arataca - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 520 | Aratiba - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 521 | Aratuba - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 522 | Araxá - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 523 | Araçai - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 524 | Araçoiaba - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 525 | Araçu - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 526 | Araçuaí - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 527 | Araújos - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 528 | Arcos - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 529 | Arcoverde - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 530 | Areal - RJ | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 531 | Areia Branca - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 532 | Arenápolis - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 533 | Arez - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 534 | Argirita - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 535 | Arinos - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 536 | Aripuanã - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 537 | Ariquemes - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 538 | Arneiroz - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 539 | Arroio Dos Ratos - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 540 | Assaré - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 541 | Assú - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 542 | Astolfo Dutra - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 543 | Astorga - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 544 | Atalaia Do Norte - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 545 | Atalaia - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 546 | Atalaia - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 547 | Ataléia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 548 | Augusto Pestana - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 549 | Aurelino Leal - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 550 | Aurilândia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 551 | Aurora Do Pará - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 552 | Autazes - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 553 | Açucena - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 554 | Baependi - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 555 | Baixa Grande Do Ribeiro - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 556 | Baliza - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 557 | Balsa Nova - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 558 | Banabuiú - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 559 | Bandeira Do Sul - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 560 | Bandeira - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 561 | Bandeirantes - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 562 | Bandeirantes - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 563 | Baraúna - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 564 | Barbacena - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 565 | Barbalha - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 566 | Barbosa Ferraz - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 567 | Barcarena - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 568 | Barcelona - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 569 | Barcelos - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 570 | Barra D` Alcântara - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 571 | Barra De Guabiraba - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 572 | Barra De Santa Rosa - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 573 | Barra De São Miguel - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 574 | Barra Do Bugres - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 575 | Barra Do Garças - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 576 | Barra Do Guarita - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 577 | Barra Do Jacaré - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 578 | Barra Do Rocha - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 579 | Barra Do Turvo - SP | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 580 | Barra Funda - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 581 | Barra Longa - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 582 | Barracão - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 583 | Barreirinha - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 584 | Barreiros - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 585 | Barro Duro - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 586 | Barro - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 587 | Barroquinha - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 588 | Barros Cassal - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 589 | Barroso - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 590 | Barão De Cocais - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 591 | Barão De Cotegipe - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 592 | Barão De Melgaço - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 593 | Barão Do Monte Alto - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 594 | Barão Do Triunfo - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 595 | Barão - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 596 | Bataguassu - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 597 | Batalha - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 598 | Batayporã - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 599 | Baturité - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 600 | Bayeux - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 601 | Baía Formosa - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 602 | Bela Vista Da Caroba - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 603 | Bela Vista - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 604 | Belo Jardim - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 605 | Belo Monte - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 606 | Belo Oriente - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 607 | Belterra - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 608 | Belém De Maria - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 609 | Belém Do São Francisco - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 610 | Belém - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 611 | Benjamin Constant - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 612 | Bento Fernandes - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 613 | Berilo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 614 | Berizal - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 615 | Bernardino Batista - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 616 | Bertolínia - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 617 | Beruri - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 618 | Betânia - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 619 | Bezerros - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 620 | Bituruna - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 621 | Boa Esperança - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 622 | Boa Saúde - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 623 | Boa Ventura De São Roque - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 624 | Boa Vista Da Aparecida - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 625 | Boa Vista Do Cadeado - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 626 | Boa Vista Do Ramos - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 627 | Boa Vista Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 628 | Boa Vista - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 629 | Boa Vista - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 630 | Boca Da Mata - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 631 | Boca Do Acre - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 632 | Bocaina - SP | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 633 | Bodocó - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 634 | Bodoquena - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 635 | Bodó - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 636 | Bom Jardim De Goiás - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 637 | Bom Jardim - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 638 | Bom Jesus Do Amparo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 639 | Bom Jesus Do Araguaia - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 640 | Bom Jesus Do Itabapoana - RJ | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 641 | Bom Jesus Do Sul - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 642 | Bom Jesus Do Tocantins - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 643 | Bom Jesus - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 644 | Bom Jesus - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 645 | Bom Jesus - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 646 | Bom Princípio - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 647 | Bom Repouso - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 648 | Bom Sucesso Do Sul - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 649 | Bom Sucesso - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 650 | Bonfim Do Piauí - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 651 | Bonfim - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 652 | Bonfinópolis De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 653 | Bonfinópolis - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 654 | Bonito De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 655 | Bonito De Santa Fé - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 656 | Bonito - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 657 | Bonito - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 658 | Bonópolis - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 659 | Boqueirão Do Piauí - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 660 | Borba - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 661 | Borda Da Mata - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 662 | Botumirim - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 663 | Braga - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 664 | Braganey - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 665 | Bragança - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 666 | Branquinha - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 667 | Brasil Novo - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 668 | Brasilândia De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 669 | Brasilândia - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 670 | Brasnorte - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 671 | Brazópolis - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 672 | Braúnas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 673 | Brejinho - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 674 | Brejinho - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 675 | Brejo Da Madre De Deus - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 676 | Brejo Santo - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 677 | Brejão - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 678 | Breu Branco - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 679 | Breves - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 680 | Britania - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 681 | Brás Pires - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 682 | Bueno Brandão - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 683 | Buenos Aires - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 684 | Buenópolis - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 685 | Bujaru - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 686 | Buriti Alegre - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 687 | Buritinópolis - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 688 | Buritis - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 689 | Buritis - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 690 | Buritizeiro - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 691 | Buíque - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 692 | Caapiranga - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 693 | Caaporã - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 694 | Cabaceiras - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 695 | Cabeceira Grande - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 696 | Cabixi - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 697 | Cabo De Santo Agostinho - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 698 | Cabo Verde - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 699 | Cacaulândia - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 700 | Cachoeira Alta - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 701 | Cachoeira De Goiás - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 702 | Cachoeira De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 703 | Cachoeira Dourada - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 704 | Cachoeirinha - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 705 | Cacimba De Areia - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 706 | Cacimbas - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 707 | Cacimbinhas - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 708 | Cacoal - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 709 | Caetés - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 710 | Cafeara - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 711 | Cafelândia - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 712 | Caibaté - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 713 | Caicó - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 714 | Caiçara Do Norte - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 715 | Caiçara Do Rio Do Vento - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 716 | Caiçara - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 717 | Cajazeirinhas - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 718 | Cajueiro - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 719 | Cajuri - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 720 | Caldas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 721 | Caldazinha - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 722 | Califórnia - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 723 | Calumbi - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 724 | Calçado - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 725 | Camapuã - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 726 | Camaragibe - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 727 | Cametá - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 728 | Camocim De São Félix - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 729 | Campanha - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 730 | Campanário - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 731 | Campestre - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 732 | Campestre - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 733 | Campestre - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 734 | Campina Do Simão - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 735 | Campina Grande Do Sul - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 736 | Campinaçu - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 737 | Campinápolis - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 738 | Campo Alegre De Goiás - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 739 | Campo Alegre - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 740 | Campo Bom - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 741 | Campo Do Brito - SE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 742 | Campo Do Meio - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 743 | Campo Do Tenente - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 744 | Campo Florido - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 745 | Campo Grande - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 746 | Campo Magro - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 747 | Campo Novo De Rondônia - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 748 | Campo Novo Do Parecis - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 749 | Campo Novo - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 750 | Campo Redondo - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 751 | Campo Verde - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 752 | Campos Altos - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 753 | Campos Belos - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 754 | Campos De Júlio - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 755 | Campos Verdes - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 756 | Camutanga - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 757 | Canabrava Do Norte - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 758 | Canapi - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 759 | Canarana - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 760 | Canaã Dos Carajás - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 761 | Canaã - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 762 | Candeias Do Jamari - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 763 | Candeias - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 764 | Candiota - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 765 | Candói - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 766 | Canela - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 767 | Canguaretama - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 768 | Canhotinho - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 769 | Cantá - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 770 | Canutama - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 771 | Capanema - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 772 | Capela - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 773 | Capitão Andrade - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 774 | Capitão Enéas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 775 | Capitão Leônidas Marques - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 776 | Capitão - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 777 | Capoeiras - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 778 | Capão Bonito Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 779 | Capão Da Canoa - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 780 | Caracaraí - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 781 | Caracol - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 782 | Carauari - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 783 | Caraúbas - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 784 | Carbonita - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 785 | Careiro Da Várzea - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 786 | Careiro - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 787 | Cariré - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 788 | Cariús - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 789 | Carlinda - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 790 | Carlos Chagas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 791 | Carlópolis - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 792 | Carmo Da Cachoeira - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 793 | Carmo Da Mata - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 794 | Carmo De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 795 | Carmo Do Cajuru - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 796 | Carmo Do Paranaíba - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 797 | Carmo Do Rio Verde - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 798 | Carnaiba - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 799 | Carnaúba Dos Dantas - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 800 | Carneirinho - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 801 | Carneiros - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 802 | Caroebe - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 803 | Carpina - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 804 | Casa Grande - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 805 | Cascalho Rico - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 806 | Caseiros - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 807 | Casinhas - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 808 | Cassilândia - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 809 | Castanheira - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 810 | Castanheiras - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 811 | Castelândia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 812 | Cataguases - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 813 | Catanduvas - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 814 | Catas Altas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 815 | Catende - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 816 | Catingueira - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 817 | Catunda - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 818 | Caçu - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 819 | Ceará-Mirim - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 820 | Cedro - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 821 | Cedro - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 822 | Centenário Do Sul - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 823 | Central De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 824 | Centralina - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 825 | Cerejeiras - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 826 | Cerro Azul - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 827 | Cerro Corá - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 828 | Cerro Grande - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 829 | Cerro Largo - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 830 | Cerro-Corá - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 831 | Cezarina - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 832 | Chapada Do Norte - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 833 | Chapada Dos Guimarães - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 834 | Chapada Gaúcha - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 835 | Chapadão Do Céu - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 836 | Chaval - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 837 | Chaves - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 838 | Chiapetta - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 839 | Chopinzinho - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 840 | Chorozinho - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 841 | Chupinguaia - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 842 | Chuí - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 843 | Chácara - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 844 | Chã De Alegria - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 845 | Chã Grande - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 846 | Cipotânea - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 847 | Claraval - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 848 | Claro Dos Poções - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 849 | Cláudia - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 850 | Cláudio - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 851 | Coaraci - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 852 | Coari - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 853 | Cocalinho - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 854 | Codajás - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 855 | Coité Do Nóia - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 856 | Colares - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 857 | Colniza - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 858 | Colombo - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 859 | Colorado Do Oeste - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 860 | Colorado - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 861 | Colorado - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 862 | Colíder - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 863 | Colônia Do Piauí - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 864 | Colônia Leopoldina - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 865 | Comendador Gomes - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 866 | Comodoro - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 867 | Conceição Do Araguaia - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 868 | Conceição Do Mato Dentro - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 869 | Conceição - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 870 | Condado - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 871 | Condado - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 872 | Confins - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 873 | Confresa - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 874 | Congonhal - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 875 | Conquista D`Oeste - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 876 | Conquista - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 877 | Conselheiro Lafaiete - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 878 | Consolação - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 879 | Contenda - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 880 | Coqueiral - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 881 | Coqueiro Seco - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 882 | Coração De Jesus - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 883 | Coreaú - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 884 | Coremas - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 885 | Corinto - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 886 | Coroaci - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 887 | Coronel Barros - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 888 | Coronel Bicaco - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 889 | Coronel Ezequiel - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 890 | Coronel José Dias - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 891 | Coronel João Pessoa - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 892 | Coronel Pacheco - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 893 | Coronel Sapucaia - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 894 | Coronel Xavier Chaves - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 895 | Corrego Danta - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 896 | Corrego Do Ouro - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 897 | Correntes - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 898 | Cortês - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 899 | Corumbaíba - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 900 | Corumbiara - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 901 | Corumbá - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 902 | Coruripe - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 903 | Costa Marques - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 904 | Cotiporã - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 905 | Cotriguaçu - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 906 | Couto De Magalhães De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 907 | Coxilha - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 908 | Coxim - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 909 | Crateús - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 910 | Craíbas - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 911 | Crissiumal - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 912 | Cristiano Otoni - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 913 | Cristália - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 914 | Crixas - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 915 | Croatá - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 916 | Crominia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 917 | Cruzeta - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 918 | Cruzilia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 919 | Cuiabá - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 920 | Cujubim - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 921 | Cumaru - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 922 | Cumarú Do Norte - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 923 | Cupira - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 924 | Curionópolis - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 925 | Currais Novos - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 926 | Curuá - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 927 | Curvelo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 928 | Curvelândia - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 929 | Custódia - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 930 | Cáceres - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 931 | Cássia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 932 | Cândido Godói - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 933 | Cônego Marinho - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 934 | Damianopolis - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 935 | Damolândia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 936 | De Iracema - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 937 | De Pedra Mole - SE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 938 | De Serra Dos Aimorés - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 939 | Delmiro Gouveia - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 940 | Demerval Lobão - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 941 | Denise - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 942 | Deodápolis - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 943 | Derrubadas - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 944 | Desterro De Entre Rios - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 945 | Desterro Do Melo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 946 | Diamante D'Oeste - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 947 | Diamante - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 948 | Diamantina - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 949 | Diamantino - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 950 | Diogo De Vasconcelos - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 951 | Dionísio - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 952 | Diorama - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 953 | Dirceu Arcoverde - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 954 | Divino Das Laranjeiras - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 955 | Divinésia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 956 | Divinópolis - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 957 | Divinópolis - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 958 | Divisa Alegre - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 959 | Dois Irmãos Das Missões - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 960 | Dois Irmãos Do Buriti - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 961 | Dois Lajeados - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 962 | Dois Riachos - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 963 | Dom Aquino - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 964 | Dom Bosco - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 965 | Dom Eliseu - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 966 | Dom Feliciano - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 967 | Dom Joaquim - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 968 | Dona Euzébia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 969 | Dores Do Indaiá - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 970 | Dores Do Turvo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 971 | Dormentes - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 972 | Douradina - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 973 | Doutor Maurício Cardoso - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 974 | Doutor Severiano - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 975 | Doutor Ulysses - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 976 | Doverlandia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 977 | Duas Barras - RJ | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 978 | Eirunepé - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 979 | Eldorado Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 980 | Eldorado - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 981 | Encanto - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 982 | Engenheiro Caldas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 983 | Engenheiro Paulo De Frontin - RJ | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 984 | Entre Rios Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 985 | Envira - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 986 | Equador - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 987 | Ereré - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 988 | Ernestina - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 989 | Erval Seco - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 990 | Ervália - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 991 | Escada - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 992 | Esperança - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 993 | Espigão Do Oeste - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 994 | Espírito Santo - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 995 | Esteio - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 996 | Estrela Dalva - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 997 | Estrela Do Indaiá - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 998 | Estrela Do Sul - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 999 | Extremoz - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1000 | Exu - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1001 | Fagundes Varela - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1002 | Farias Brito - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1003 | Faxinal Do Soturno - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1004 | Faxinalzinho - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1005 | Feira Grande - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1006 | Feira Nova - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1007 | Felipe Guerra - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1008 | Felisburgo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1009 | Felixlândia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1010 | Feliz Deserto - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1011 | Feliz Natal - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1012 | Felício Dos Santos - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1013 | Fernandes Pinheiro - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1014 | Fernando Pedroza - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1015 | Ferreiros - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1016 | Figueirão - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1017 | Figueirópolis D´Oeste - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1018 | Firmino Alves - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1019 | Firminópolis - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1020 | Flexeiras - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1021 | Flores Da Cunha - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1022 | Flores Do Piauí - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1023 | Flores - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1024 | Floresta - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1025 | Floriano Peixoto - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1026 | Florânia - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1027 | Flórida - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1028 | Fonte Boa - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1029 | Formiga - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1030 | Formigueiro - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1031 | Formosa - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1032 | Formoso - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1033 | Formoso - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1034 | Fortim - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1035 | Francisco Badaró - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1036 | Francisco Beltrão - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1037 | Francisco Dantas - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1038 | Francisco Sa - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1039 | Frecheirinha - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1040 | Frei Gaspar - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1041 | Frei Inocêncio - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1042 | Frei Miguelinho - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1043 | Fronteira Dos Vales - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1044 | Fronteira - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1045 | Frutuoso Gomes - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1046 | Funilândia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1047 | Fátima Do Sul - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1048 | Galileia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1049 | Galinhos - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1050 | Gameleira - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1051 | Gameleira - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1052 | Garanhuns - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1053 | Garibaldi - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1054 | Gaúcha Do Norte - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1055 | General Carneiro - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1056 | General Carneiro - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1057 | General Sampaio - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1058 | Girau Do Ponciano - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1059 | Giruá - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1060 | Glorinha - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1061 | Glória Do Goitá - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1062 | Glória D´Oeste - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1063 | Goiabeira - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1064 | Goiandira - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1065 | Goianinha - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1066 | Goianésia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1067 | Goiatuba - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1068 | Goioerê - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1069 | Goioxim - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1070 | Gouveia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1071 | Gouvelândia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1072 | Governador Dix-Sept Rosado - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1073 | Governador Jorge Teixeira - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1074 | Gramado Xavier - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1075 | Grangeiro - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1076 | Granito - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1077 | Groaíras - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1078 | Grossos - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1079 | Grão Mogol - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1080 | Guadalupe - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1081 | Guaira - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1082 | Guajará - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1083 | Guajará-Mirim - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1084 | Guamaré - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1085 | Guamiranga - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1086 | Guaraci - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1087 | Guaraciaba Do Norte - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1088 | Guaraciaba - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1089 | Guaraita - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1090 | Guarani Das Missões - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1091 | Guarani - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1092 | Guarani - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1093 | Guaraniaçu - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1094 | Guarantã Do Norte - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1095 | Guaraqueçaba - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1096 | Guarda-Mor - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1097 | Guarinos - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1098 | Guaxupé - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1099 | Guia Lopes Da Laguna - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1100 | Guiratinga - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1101 | Gurinhatã - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1102 | Harmonia - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1103 | Heitoraí - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1104 | Heliodora - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1105 | Hidrolandia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1106 | Hidrolândia - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1107 | Honório Serpa - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1108 | Humaitá - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1109 | Iaciara - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1110 | Iati - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1111 | Ibaretama - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1112 | Ibateguara - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1113 | Ibiapina - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1114 | Ibicaraí - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1115 | Ibicuitinga - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1116 | Ibicuí - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1117 | Ibimirim - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1118 | Ibiraci - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1119 | Ibiraiaras - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1120 | Ibirajuba - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1121 | Ibirubá - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1122 | Ibiá - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1123 | Icapuí - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1124 | Icó - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1125 | Ielmo Marinho - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1126 | Igarapé-Açú - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1127 | Igarassu - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1128 | Igreja Nova - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1129 | Iguaracy - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1130 | Iguaraçu - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1131 | Iguatama - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1132 | Iguatemi - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1133 | Iguatu - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1134 | Iguatu - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1135 | Ilha De Itamaracá - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1136 | Imaculada - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1137 | Imbé - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1138 | Inajá - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1139 | Independência - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1140 | Independência - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1141 | Indianópolis - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1142 | Indiara - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1143 | Indiaroba - SE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1144 | Indiavaí - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1145 | Ingazeira - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1146 | Inhacorá - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1147 | Inhangapi - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1148 | Inhapi - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1149 | Inhaúma - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1150 | Inhumas - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1151 | Inocência - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1152 | Inácio Martins - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1153 | Ipaba - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1154 | Ipameri - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1155 | Ipanema - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1156 | Ipanguaçu - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1157 | Ipaporanga - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1158 | Ipaumirim - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1159 | Ipiranga Do Norte - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1160 | Ipiranga - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1161 | Ipixuna Do Parà - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1162 | Ipixuna - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1163 | Iporá - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1164 | Iporã - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1165 | Ipubi - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1166 | Ipueira - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1167 | Ipuiúna - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1168 | Ipê - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1169 | Iracema - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1170 | Iranduba - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1171 | Irapuã - SP | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1172 | Irauçuba - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1173 | Iraí - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1174 | Irituia - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1175 | Israelândia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1176 | Itabirinha - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1177 | Itacarambi - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1178 | Itacaré - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1179 | Itacoatiara - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1180 | Itacuruba - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1181 | Itacurubi - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1182 | Itaguara - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1183 | Itaguaru - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1184 | Itainópolis - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1185 | Itaitinga - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1186 | Itaituba - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1187 | Itaiçaba - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1188 | Itajá - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1189 | Itamarati De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1190 | Itamarati - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1191 | Itambaracá - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1192 | Itambé Do Mato Dentro - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1193 | Itambé - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1194 | Itanhandu - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1195 | Itanhangá - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1196 | Itanhomi - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1197 | Itapecerica - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1198 | Itapejara D'Oeste - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1199 | Itaperuçu - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1200 | Itapetim - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1201 | Itapeva - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1202 | Itapiranga - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1203 | Itapirapuã - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1204 | Itapissuma - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1205 | Itapiúna - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1206 | Itaporanga - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1207 | Itapuã Do Oeste - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1208 | Itapé - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1209 | Itaqui - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1210 | Itaquitinga - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1211 | Itatiaiuçu - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1212 | Itaueira - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1213 | Itaíba - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1214 | Itaú - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1215 | Itaúba - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1216 | Itiquira - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1217 | Itororó - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1218 | Itupeva - SP | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1219 | Itupiranga - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1220 | Iturama - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1221 | Itú - SP | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1222 | Ivatuba - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1223 | Ivaí - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1224 | Ivolândia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1225 | Ivorá - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1226 | Ivoti - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1227 | Jacareacanga - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1228 | Jacaré Dos Homens - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1229 | Jaciara - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1230 | Jacinto - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1231 | Jacutinga - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1232 | Jacuí - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1233 | Jacuípe - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1234 | Jaguapitã - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1235 | Jaguaraçu - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1236 | Jaguaretama - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1237 | Jaguarão - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1238 | Jandaia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1239 | Jandaíra - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1240 | Janduís - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1241 | Jangada - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1242 | Januária - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1243 | Japaraiba - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1244 | Japaratinga - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1245 | Japi - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1246 | Japonvar - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1247 | Japorã - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1248 | Japurá - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1249 | Jaragua - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1250 | Jaraguari - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1251 | Jaramataia - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1252 | Jardim De Angicos - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1253 | Jardim De Piranhas - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1254 | Jardim Do Seridó - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1255 | Jardim - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1256 | Jardim - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1257 | Jari - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1258 | Jarú - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1259 | Jataúba - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1260 | Jateí - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1261 | Jatobá - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1262 | Jaupaci - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1263 | Jauru - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1264 | Jaçanã - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1265 | Jeceaba - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1266 | Jenipapo De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1267 | Jequitiba - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1268 | Jequitinhonha - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1269 | Jequiá Da Praia - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1270 | Joaquim Gomes - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1271 | Joaquim Nabuco - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1272 | Joca Marques - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1273 | Jordânia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1274 | Josenopolis - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1275 | José Da Penha - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1276 | José Gonçalves De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1277 | Joviânia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1278 | João Alfredo - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1279 | João Câmara - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1280 | João Dias - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1281 | João Monlevade - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1282 | João Pinheiro - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1283 | Juara - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1284 | Juazeirinho - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1285 | Jucati - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1286 | Jucurutu - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1287 | Jucás - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1288 | Junco Do Seridó - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1289 | Jundiá - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1290 | Junqueiro - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1291 | Jupi - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1292 | Juramento - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1293 | Jurema - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1294 | Juripiranga - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1295 | Juruena - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1296 | Juruti - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1297 | Juruá - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1298 | Juscimeira - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1299 | Jussari - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1300 | Jutaí - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1301 | Juti - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1302 | Juína - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1303 | Júlio Borges - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1304 | Ladário - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1305 | Lagamar - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1306 | Lagoa Da Canoa - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1307 | Lagoa Da Prata - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1308 | Lagoa De Itaenga - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1309 | Lagoa De Pedras - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1310 | Lagoa De Velhos - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1311 | Lagoa Do Carro - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1312 | Lagoa Do Ouro - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1313 | Lagoa Do Sitio - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1314 | Lagoa Dos Gatos - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1315 | Lagoa Dos Patos - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1316 | Lagoa Dos Três Cantos - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1317 | Lagoa D´Anta - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1318 | Lagoa Grande - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1319 | Lagoa Nova - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1320 | Lagoa Salgada - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1321 | Lagoa Santa - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1322 | Lagoa Santa - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1323 | Laguna Carapã - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1324 | Lajeado Do Bugre - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1325 | Lajedo - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1326 | Lajes Pintadas - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1327 | Lajes - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1328 | Lambari D´Oeste - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1329 | Lambari - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1330 | Lamim - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1331 | Landri Sales - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1332 | Lapa - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1333 | Laranjal - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1334 | Laranjal - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1335 | Lassance - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1336 | Leme Do Prado - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1337 | Leopoldina - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1338 | Liberato Salzano - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1339 | Lima Duarte - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1340 | Limeira Do Oeste - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1341 | Limoeiro De Anadia - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1342 | Limoeiro Do Norte - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1343 | Limoeiro - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1344 | Loanda - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1345 | Lobato - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1346 | Logradouro - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1347 | Lontra - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1348 | Lucas Do Rio Verde - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1349 | Luciara - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1350 | Lucrécia - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1351 | Luislândia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1352 | Luiziana - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1353 | Lupionópolis - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1354 | Luz - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1355 | Luís Gomes - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1356 | Lábrea - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1357 | Macaparana - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1358 | Macatuba - SP | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1359 | Macau - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1360 | Machacalis - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1361 | Machadinho D´ Oeste - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1362 | Machados - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1363 | Magalhães Barata - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1364 | Major Izidoro - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1365 | Major Sales - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1366 | Malacacheta - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1367 | Mallet - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1368 | Malta - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1369 | Mambai - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1370 | Manacapuru - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1371 | Manaquiri - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1372 | Manari - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1373 | Manaíra - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1374 | Mandaguari - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1375 | Mandirituba - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1376 | Manfrinópolis - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1377 | Manicoré - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1378 | Manoel Viana - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1379 | Maquiné - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1380 | Mar De Espanha - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1381 | Mar Vermelho - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1382 | Mara Rosa - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1383 | Marabá - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1384 | Maracaju - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1385 | Maragogi - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1386 | Maraial - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1387 | Maravilha - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1388 | Maravilhas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1389 | Maraã - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1390 | Marcelino Ramos - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1391 | Marcelino Vieira - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1392 | Marcelândia - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1393 | Marechal Deodoro - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1394 | Maria Da Fé - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1395 | Maribondo - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1396 | Marilena - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1397 | Marituba - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1398 | Marizópolis - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1399 | Marques De Souza - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1400 | Martins - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1401 | Martinópole - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1402 | Mascote - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1403 | Massapê - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1404 | Massaranduba - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1405 | Mata Grande - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1406 | Mata Verde - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1407 | Mataraca - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1408 | Materlândia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1409 | Mathias Lobato - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1410 | Matias Cardoso - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1411 | Matinhas - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1412 | Matinhos - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1413 | Mato Castelhano - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1414 | Mato Rico - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1415 | Mato Verde - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1416 | Matrinchã - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1417 | Matupá - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1418 | Matutina - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1419 | Mauriti - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1420 | Maués - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1421 | Maxaranguape - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1422 | Medeiros - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1423 | Medicilândia - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1424 | Mendes Pimentel - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1425 | Mendes - RJ | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1426 | Mesquita - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1427 | Mesquita - RJ | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1428 | Messias Targino - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1429 | Messias - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1430 | Minador Do Negrão - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1431 | Minas Novas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1432 | Minaçu - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1433 | Mineiros - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1434 | Ministro Andreazza - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1435 | Mirabela - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1436 | Miradouro - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1437 | Miranda - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1438 | Mirandiba - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1439 | Mirante Da Serra - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1440 | Miraselva - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1441 | Mirassol D´Oeste - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1442 | Mococa - SP | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1443 | Moema - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1444 | Moiporá - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1445 | Moju - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1446 | Mojuí Dos Campos - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1447 | Mombaça - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1448 | Monsenhor Gil - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1449 | Montadas - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1450 | Montanhas - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1451 | Monte Alegre Dos Campos - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1452 | Monte Alegre - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1453 | Monte Alegre - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1454 | Monte Carmelo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1455 | Monte Das Gameleiras - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1456 | Monte Formoso - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1457 | Monte Horebe - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1458 | Monte Negro - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1459 | Monteiro - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1460 | Monteirópolis - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1461 | Montes Claros - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1462 | Montezuma - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1463 | Montividiu Do Norte - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1464 | Montividiu - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1465 | Morada Nova - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1466 | Moreilândia - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1467 | Moreno - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1468 | Mormaço - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1469 | Morretes - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1470 | Morrinhos - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1471 | Morro Reuter - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1472 | Mossoró - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1473 | Mossâmedes - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1474 | Mostardas - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1475 | Mozarlandia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1476 | Muaná - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1477 | Mucajai - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1478 | Mundo Novo - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1479 | Muriaé - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1480 | Muribeca - SE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1481 | Murici Dos Portelas - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1482 | Murici - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1483 | Mutunópolis - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1484 | Mãe Do Rio - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1485 | Nanuque - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1486 | Naque - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1487 | Natalândia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1488 | Natércia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1489 | Naviraí - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1490 | Nazareno - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1491 | Nazarezinho - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1492 | Nazaré Da Mata - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1493 | Nepomuceno - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1494 | Nerópolis - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1495 | Nhamundá - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1496 | Ninheira - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1497 | Nobres - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1498 | Normandia - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1499 | Nortelândia - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1500 | Nossa Senhora Das Graças - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1501 | Nossa Senhora Do Livramento - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1502 | Nova Andradina - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1503 | Nova Bandeirantes - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1504 | Nova Belem - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1505 | Nova Brasilândia Do Oeste - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1506 | Nova Brasilândia - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1507 | Nova Canaã Do Norte - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1508 | Nova Cruz - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1509 | Nova Guarita - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1510 | Nova Ipixuna - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1511 | Nova Lacerda - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1512 | Nova Mamoré - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1513 | Nova Marilândia - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1514 | Nova Maringá - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1515 | Nova Monte Verde - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1516 | Nova Mutum - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1517 | Nova Nazaré - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1518 | Nova Olinda Do Norte - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1519 | Nova Olinda - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1520 | Nova Olímpia - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1521 | Nova Ponte - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1522 | Nova Prata Do Iguaçu - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1523 | Nova Resende - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1524 | Nova Russas - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1525 | Nova Santa Helena - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1526 | Nova Santa Rita - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1527 | Nova Timboteua - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1528 | Nova Ubiratã - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1529 | Nova União - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1530 | Nova União - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1531 | Nova Xavantina - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1532 | Novo Airão - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1533 | Novo Aripuanã - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1534 | Novo Cabrais - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1535 | Novo Cruzeiro - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1536 | Novo Horizonte Do Norte - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1537 | Novo Horizonte Do Oeste - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1538 | Novo Lino - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1539 | Novo Machado - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1540 | Novo Mundo - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1541 | Novo Oriente De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1542 | Novo Progresso - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1543 | Novo Repartimento - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1544 | Novo Santo Antônio - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1545 | Novo São Joaquim - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1546 | Novo Tiradentes - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1547 | Nísia Floresta - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1548 | Óbidos - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1549 | Olho D'Água Das Flores - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1550 | Olho D'Água Do Borges - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1551 | Olho D´Agua Do Casado - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1552 | Olinda - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1553 | Olivedos - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1554 | Oliveira Fortes - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1555 | Olivença - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1556 | Onça De Pitangui - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1557 | Oratórios - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1558 | Oriximiná - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1559 | Orobó - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1560 | Orocó - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1561 | Orós - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1562 | Osório - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1563 | Ouricuri - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1564 | Ourilândia Do Norte - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1565 | Ouro Branco - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1566 | Ouro Branco - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1567 | Ouro Fino - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1568 | Ouro Preto Do Oeste - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1569 | Ouro Velho - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1570 | Pacajá - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1571 | Pacaraima - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1572 | Pacoti - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1573 | Pacujá - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1574 | Paineiras - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1575 | Pains - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1576 | Paiçandu - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1577 | Palestina De Goias - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1578 | Palestina De Goás - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1579 | Palestina Do Pará - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1580 | Palestina - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1581 | Palhano - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1582 | Palma - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1583 | Palmares - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1584 | Palmeira Das Missões - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1585 | Palmeira - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1586 | Palmeiras - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1587 | Palmeirina - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1588 | Palmelo - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1589 | Palminópolis - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1590 | Palmital - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1591 | Palmitinho - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1592 | Panamá - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1593 | Panelas - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1594 | Paracatu - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1595 | Paragominas - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1596 | Paramoti - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1597 | Paranaguá - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1598 | Paranatama - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1599 | Paranatinga - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1600 | Paranavaí - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1601 | Paranaíba - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1602 | Paranaíta - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1603 | Paranhos - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1604 | Paraná - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1605 | Parazinho - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1606 | Paraí - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1607 | Paraú - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1608 | Parecis - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1609 | Parelhas - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1610 | Pariconha - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1611 | Parintins - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1612 | Parnamirim - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1613 | Parobé - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1614 | Pará De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1615 | Passabém - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1616 | Passagem - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1617 | Passira - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1618 | Passo Do Sobrado - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1619 | Patis - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1620 | Pato Branco - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1621 | Patos - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1622 | Patrocínio Do Muriaé - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1623 | Patrocínio - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1624 | Patu - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1625 | Paudalho - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1626 | Pauini - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1627 | Paula Cândido - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1628 | Paula Freitas - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1629 | Paulista - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1630 | Paulista - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1631 | Paulo Frontin - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1632 | Paulo Jacinto - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1633 | Pavussú - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1634 | Pedra Azul - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1635 | Pedra Bonita - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1636 | Pedra Branca - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1637 | Pedra Do Indaiá - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1638 | Pedra Dourada - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1639 | Pedra Grande - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1640 | Pedra Preta - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1641 | Pedra Preta - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1642 | Pedra - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1643 | Pedras Altas - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1644 | Pedrinhas - SE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1645 | Pedrinópolis - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1646 | Pedro Avelino - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1647 | Pedro Gomes - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1648 | Pedro Leopoldo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1649 | Pedro Velho - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1650 | Peixe-Boi - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1651 | Peixoto De Azevedo - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1652 | Pejuçara - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1653 | Pelotas - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1654 | Penaforte - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1655 | Pendências - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1656 | Perdigão - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1657 | Perdizes - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1658 | Perdões - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1659 | Perolândia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1660 | Pescador - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1661 | Pesqueira - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1662 | Petrolina - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1663 | Piancó - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1664 | Picuí - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1665 | Piedade De Ponte Nova - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1666 | Pilar - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1667 | Pilões - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1668 | Pimenta Bueno - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1669 | Pimenta - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1670 | Pimenteiras Do Oeste - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1671 | Pimenteiras - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1672 | Pindoba - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1673 | Pindoretama - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1674 | Pinhal De São Bento - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1675 | Pinhal - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1676 | Pinheiral - RJ | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1677 | Pinheiro Machado - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1678 | Pinhão - SE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1679 | Piquet Carneiro - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1680 | Pirajuba - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1681 | Piranga - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1682 | Piranguinho - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1683 | Piranhas - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1684 | Piranhas - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1685 | Pirapetinga - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1686 | Pirapora - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1687 | Pirapó - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1688 | Piraquara - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1689 | Piratini - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1690 | Pirenópolis - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1691 | Pirpirituba - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1692 | Pitangueiras - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1693 | Pitangui - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1694 | Piên - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1695 | Placas - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1696 | Planaltina - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1697 | Planalto Da Serra - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1698 | Planalto - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1699 | Pocinhos - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1700 | Poconé - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1701 | Pombal - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1702 | Pombos - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1703 | Ponta Porã - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1704 | Pontal Do Araguaia - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1705 | Pontalina - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1706 | Ponte Branca - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1707 | Ponte Nova - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1708 | Pontes E Lacerda - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1709 | Porecatu - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1710 | Portalegre - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1711 | Porteirao - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1712 | Porteiras - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1713 | Portelândia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1714 | Porto Alegre Do Norte - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1715 | Porto Amazonas - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1716 | Porto Calvo - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1717 | Porto De Moz - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1718 | Porto De Pedras - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1719 | Porto Dos Gaúchos - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1720 | Porto Esperidião - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1721 | Porto Estrela - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1722 | Porto Lucena - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1723 | Porto Mauá - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1724 | Porto Murtinho - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1725 | Porto Real Do Colégio - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1726 | Porto Rico - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1727 | Porto Velho - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1728 | Posse - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1729 | Potiretama - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1730 | Pouso Alegre - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1731 | Pouso Novo - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1732 | Poxoréu - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1733 | Poço Branco - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1734 | Poço Das Trincheiras - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1735 | Poço Fundo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1736 | Poço Verde - SE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1737 | Poços De Caldas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1738 | Poção - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1739 | Prado Ferreira - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1740 | Prados - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1741 | Prainha - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1742 | Prata Do Piauí - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1743 | Prata - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1744 | Pratinha - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1745 | Pratápolis - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1746 | Presidente Figueiredo - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1747 | Presidente Médici - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1748 | Primavera De Rondônia - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1749 | Primavera Do Leste - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1750 | Primavera - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1751 | Princesa Isabel - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1752 | Pureza - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1753 | Pão De Açúcar - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1754 | Pérola D'Oeste - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1755 | Quaraí - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1756 | Quartel Geral - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1757 | Quatro Barras - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1758 | Quebrangulo - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1759 | Queluzito - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1760 | Querência - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1761 | Quevedos - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1762 | Quipapá - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1763 | Quirinópolis - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1764 | Quitandinha - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1765 | Quiterianópolis - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1766 | Quixaba - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1767 | Quixadá - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1768 | Quixelô - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1769 | Quixeramobim - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1770 | Quixeré - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1771 | Rafael Fernandes - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1772 | Rafael Godeiro - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1773 | Ramilândia - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1774 | Rancho Alegre D' Oeste - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1775 | Realeza - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1776 | Recreio - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1777 | Redenção - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1778 | Renascença - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1779 | Reserva Do Cabaçal - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1780 | Reserva Do Iguaçu - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1781 | Riacho Da Cruz - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1782 | Riacho Das Almas - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1783 | Riacho De Santana - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1784 | Riacho Dos Machados - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1785 | Riachuelo - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1786 | Rialma - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1787 | Ribas Do Rio Pardo - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1788 | Ribeirão Cascalheira - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1789 | Ribeirão Das Neves - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1790 | Ribeirão - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1791 | Ribeirãozinho - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1792 | Rio Azul - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1793 | Rio Branco Do Ivaí - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1794 | Rio Branco Do Sul - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1795 | Rio Branco - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1796 | Rio Crespo - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1797 | Rio Do Fogo - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1798 | Rio Doce - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1799 | Rio Espera - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1800 | Rio Formoso - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1801 | Rio Grande Do Piauí - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1802 | Rio Largo - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1803 | Rio Maria - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1804 | Rio Negro - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1805 | Rio Negro - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1806 | Rio Paranaíba - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1807 | Rio Preto Da Eva - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1808 | Rio Preto - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1809 | Rio Tinto - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1810 | Rio Verde De Mt - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1811 | Rio Vermelho - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1812 | Rochedo - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1813 | Rodeio Bonito - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1814 | Rodeiro - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1815 | Rodolfo Fernandes - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1816 | Rolim De Moura - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1817 | Rolândia - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1818 | Rondolândia - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1819 | Rondon Do Pará - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1820 | Rondonópolis - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1821 | Rorainopolis - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1822 | Rosário Da Limeira - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1823 | Rosário Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1824 | Rosário Oeste - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1825 | Roteiro - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1826 | Rubelita - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1827 | Rubim - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1828 | Rurópolis - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1829 | Ruy Barbosa - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1830 | Saboeiro - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1831 | Sagrada Familia - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1832 | Sairé - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1833 | Salgadinho - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1834 | Salgado Filho - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1835 | Salgado - SE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1836 | Salgueiro - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1837 | Salinópolis - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1838 | Salitre - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1839 | Saloá - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1840 | Salto Do Céu - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1841 | Salto Do Jacuí - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1842 | Salto Do Lontra - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1843 | Salvaterra - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1844 | Sanclerlândia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1845 | Sanharó - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1846 | Santa Amélia - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1847 | Santa Bárbara Do Leste - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1848 | Santa Bárbara Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1849 | Santa Bárbara - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1850 | Santa Carmem - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1851 | Santa Cecília Do Pavão - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1852 | Santa Cecília - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1853 | Santa Cruz Da Baixa Verde - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1854 | Santa Cruz De Goiás - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1855 | Santa Cruz De Monte Castelo - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1856 | Santa Cruz Do Xingu - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1857 | Santa Cruz - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1858 | Santa Efigênia De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1859 | Santa Filomena - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1860 | Santa Fé - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1861 | Santa Helena De Goiás - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1862 | Santa Inês - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1863 | Santa Isabel Do Rio Negro - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1864 | Santa Luzia Do Itanhi - SE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1865 | Santa Luzia Do Norte - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1866 | Santa Luzia Do Oeste - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1867 | Santa Luzia Do Pará - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1868 | Santa Luzia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1869 | Santa Lúcia - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1870 | Santa Margarida Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1871 | Santa Margarida - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1872 | Santa Maria Da Boa Vista - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1873 | Santa Maria Do Oeste - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1874 | Santa Maria Do Salto - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1875 | Santa Maria - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1876 | Santa Quitéria - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1877 | Santa Rita Do Araguaia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1878 | Santa Rita Do Novo Destino - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1879 | Santa Rita Do Trivelato - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1880 | Santa Teresinha - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1881 | Santa Tereza De Goiás - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1882 | Santa Terezinha De Itaipu - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1883 | Santa Terezinha - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1884 | Santa Terezinha - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1885 | Santa Vitória - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1886 | Santana Da Boa Vista - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1887 | Santana Da Vargem - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1888 | Santana De Cataguases - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1889 | Santana Do Cariri - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1890 | Santana Do Deserto - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1891 | Santana Do Ipanema - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1892 | Santana Do Jacaré - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1893 | Santana Do Livramento - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1894 | Santana Do Matos - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1895 | Santana Do Mundaú - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1896 | Santana Do Riacho - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1897 | Santana Do Seridó - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1898 | Santana Dos Montes - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1899 | Santarém Novo - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1900 | Santarém - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1901 | Santiago - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1902 | Santo Afonso - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1903 | Santo Antonio Da Barra - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1904 | Santo Antonio Da Patrulha - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1905 | Santo Antonio Do Aventureiro - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1906 | Santo Antonio Do Itambé - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1907 | Santo Antonio Do Jacinto - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1908 | Santo Antônio De Goiás - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1909 | Santo Antônio De Leverger - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1910 | Santo Antônio Do Içá - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1911 | Santo Antônio Do Leste - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1912 | Santo Antônio Do Monte - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1913 | Santo Antônio Do Retiro - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1914 | Santo Antônio Do Rio Abaixo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1915 | Santo Antônio Do Sudoeste - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1916 | Santo Antônio - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1917 | Santo Augusto - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1918 | Santo Cristo - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1919 | Santo Expedito Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1920 | Santo Inacio Do Piauí - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1921 | Santo Ângelo - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1922 | Sapezal - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1923 | Sapopema - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1924 | Sapucaia Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1925 | Sapucaia - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1926 | Sapucaí Mirim - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1927 | Sapé - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1928 | Sarandi - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1929 | Sarandi - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1930 | Satuba - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1931 | Saudade Do Iguaçu - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1932 | Sebastião Barros - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1933 | Selbach - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1934 | Selviria - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1935 | Sem Peixe - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1936 | Senador Canedo - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1937 | Senador Cortes - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1938 | Senador Elói De Souza - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1939 | Senador Georgino Avelino - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1940 | Senador Jose Porfirio - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1941 | Senador José Bento - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1942 | Senador Modestino Gonçalves - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1943 | Senador Rui Palmeira - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1944 | Senador Salgado Filho - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1945 | Sengés - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1946 | Senhora Dos Remédios - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1947 | Seringueiras - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1948 | Serra Azul De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1949 | Serra Caiada - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1950 | Serra De São Bento - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1951 | Serra Do Mel - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1952 | Serra Grande - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1953 | Serra Negra Do Norte - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1954 | Serra Nova Dourada - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1955 | Serrania - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1956 | Serranópolis - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1957 | Serrinha Dos Pintos - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1958 | Serrinha - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1959 | Serrita - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1960 | Serro - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1961 | Sertanópolis - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1962 | Sertânia - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1963 | Sete Quedas - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1964 | Setubinha - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1965 | Severiano Melo - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1966 | Sidrolândia - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1967 | Silveirânia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1968 | Silves - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1969 | Simplício Mendes - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1970 | Simão Dias - SE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1971 | Simão Pereira - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1972 | Sinop - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1973 | Sirinhaém - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1974 | Sobradinho - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1975 | Socorro Do Piauí - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1976 | Soledade De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1977 | Soledade - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1978 | Solidão - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1979 | Solonópole - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1980 | Sonora - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1981 | Sorriso - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1982 | Soure - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1983 | Sulina - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1984 | Surubim - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1985 | São Benedito Do Sul - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1986 | São Benedito - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1987 | São Bento Abade - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1988 | São Bento Do Norte - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1989 | São Bento Do Trairí - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1990 | São Bento Do Una - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1991 | São Caetano De Odivelas - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1992 | São Caetano - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1993 | São Domingos Do Araguaia - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1994 | São Domingos - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1995 | São Domingos - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1996 | São Felipe Do Oeste - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1997 | São Fernando - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1998 | São Francisco De Sales - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 1999 | São Francisco Do Glória - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2000 | São Francisco Do Guaporé - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2001 | São Francisco Do Oeste - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2002 | São Francisco Do Pará - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2003 | São Francisco - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2004 | São Francisco - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2005 | São Félix De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2006 | São Félix Do Araguaia - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2007 | São Félix Do Xingú - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2008 | São Gabriel Da Cachoeira - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2009 | São Gabriel Do Oeste - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2010 | São Gabriel - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2011 | São Geraldo Do Araguaia - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2012 | São Geraldo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2013 | São Gonçalo Do Abaeté - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2014 | São Gonçalo Do Rio Preto - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2015 | São Gotardo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2016 | São Jerônimo Da Serra - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2017 | São Joaquim Do Monte - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2018 | São Jorge Do Patrocínio - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2019 | São Jose Da Lagoa Tapada - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2020 | São José Da Boa Vista - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2021 | São José Da Coroa Grande - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2022 | São José Da Laje - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2023 | São José Da Tapera - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2024 | São José Das Palmeiras - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2025 | São José De Espinharas - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2026 | São José De Mipibu - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2027 | São José Do Belmonte - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2028 | São José Do Brejo Do Cruz - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2029 | São José Do Campestre - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2030 | São José Do Egito - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2031 | São José Do Goiabal - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2032 | São José Do Inhacorá - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2033 | São José Do Mantimento - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2034 | São José Do Ouro - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2035 | São José Do Povo - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2036 | São José Do Rio Claro - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2037 | São José Do Seridó - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2038 | São José Do Xingu - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2039 | São José Dos Quatro Marcos - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2040 | São João Da Aliança - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2041 | São João Da Baliza - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2042 | São João Da Mata - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2043 | São João Da Paraúna - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2044 | São João Da Ponte - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2045 | São João Da Urtiga - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2046 | São João De Pirabas - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2047 | São João Do Araguaia - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2048 | São João Do Pacuí - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2049 | São João Do Piauí - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2050 | São João Do Polêsine - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2051 | São João Do Rio Do Peixe - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2052 | São João Do Sabugi - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2053 | São João Do Tigre - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2054 | São João Evangelista - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2055 | São João Nepomuceno - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2056 | São João - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2057 | São Leopoldo - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2058 | São Lourenço Da Mata - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2059 | São Lourenço - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2060 | São Luis Do Quitunde - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2061 | São Luiz Do Norte - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2062 | São Luiz - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2063 | São Mamede - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2064 | São Martinho - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2065 | São Miguel De Taipu - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2066 | São Miguel Do Gostoso - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2067 | São Miguel Do Guamá - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2068 | São Miguel Do Guaporé - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2069 | São Miguel Do Passa Quatro - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2070 | São Miguel - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2071 | São Nicolau - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2072 | São Patrício - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2073 | São Paulo De Olivença - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2074 | São Paulo Do Potengi - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2075 | São Pedro Da Cipa - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2076 | São Pedro Do Butiá - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2077 | São Pedro Do Iguaçu - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2078 | São Pedro Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2079 | São Pedro Dos Ferros - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2080 | São Pedro - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2081 | São Rafael - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2082 | São Sebastião De Lagoa De Roça - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2083 | São Sebastião Do Caí - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2084 | São Sebastião Do Paraíso - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2085 | São Sebastião Do Rio Preto - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2086 | São Sebastião Do Uatumã - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2087 | São Sebastião Do Umbuzeiro - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2088 | São Sebastião - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2089 | São Sepé - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2090 | São Simão - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2091 | São Thomé Das Letras - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2092 | São Tomás De Aquino - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2093 | São Tomé - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2094 | São Valentim Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2095 | São Valério Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2096 | São Vicente Férrer - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2097 | São Vicente - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2098 | Sítio Novo - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2099 | Tabaporã - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2100 | Tabatinga - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2101 | Tabira - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2102 | Tabuleiro Do Norte - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2103 | Tacaimbó - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2104 | Tacaratu - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2105 | Taiobeiras - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2106 | Taipú - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2107 | Tamandaré - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2108 | Tangará Da Serra - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2109 | Tangará - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2110 | Tanque D´Arca - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2111 | Tapauá - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2112 | Tapera - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2113 | Tapira - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2114 | Tapira - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2115 | Tapurah - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2116 | Taquara - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2117 | Taquarana - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2118 | Taquari - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2119 | Taquaritinga Do Norte - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2120 | Taquarituba - SP | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2121 | Taquarucu Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2122 | Taquarussu - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2123 | Tarumirim - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2124 | Tauá - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2125 | Tavares - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2126 | Tavares - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2127 | Tefé - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2128 | Teixeira Soares - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2129 | Teixeiras - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2130 | Teixeirópolis - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2131 | Tenente Ananias - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2132 | Tenente Laurentino Cruz - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2133 | Teotonio Vilela - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2134 | Terenos - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2135 | Teresina - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2136 | Terezinha - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2137 | Terra Boa - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2138 | Terra De Areia - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2139 | Terra Nova Do Norte - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2140 | Terra Nova - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2141 | Terra Roxa - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2142 | Tesouro - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2143 | Teófilo Otoni - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2144 | Theobroma - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2145 | Tibau Do Sul - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2146 | Tibau - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2147 | Tijucas Do Sul - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2148 | Timbaúba Dos Batistas - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2149 | Timbaúba - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2150 | Tio Hugo - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2151 | Tiradentes - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2152 | Tobias Barreto - SE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2153 | Tomazina - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2154 | Tombos - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2155 | Tomé-Açu - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2156 | Tonantins - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2157 | Toritama - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2158 | Torixoréu - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2159 | Toropi - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2160 | Touros - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2161 | Tracuateua - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2162 | Tracunhaém - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2163 | Trairão - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2164 | Tramandaí - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2165 | Travesseiro - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2166 | Tres Lagoas - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2167 | Trindade Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2168 | Trindade - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2169 | Trindade - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2170 | Triunfo Potiguar - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2171 | Triunfo - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2172 | Triunfo - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2173 | Trombas - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2174 | Três Arroios - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2175 | Três Barras Do Paraná - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2176 | Três Cachoeiras - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2177 | Três Corações - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2178 | Três Coroas - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2179 | Três Marias - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2180 | Três Pontas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2181 | Tucumã - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2182 | Tucuruí - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2183 | Tunas Do Paraná - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2184 | Tupaciguara - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2185 | Tupanatinga - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2186 | Tupanciretã - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2187 | Tupandi - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2188 | Tuparendi - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2189 | Tuparetama - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2190 | Turmalina - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2191 | Turvelândia - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2192 | Turvo - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2193 | Turvolândia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2194 | Uarini - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2195 | Ubajara - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2196 | Ubaporanga - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2197 | Ubatã - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2198 | Ubaí - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2199 | Uiramuta - RR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2200 | Uirapuru - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2201 | Uirauna - PB | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2202 | Umari - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2203 | Umarizal - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2204 | Umburatiba - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2205 | União Da Vitória - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2206 | União De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2207 | União Do Sul - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2208 | Upanema - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2209 | Uruana De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2210 | Uruaçu - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2211 | Urucará - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2212 | Urucuia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2213 | Urucurituba - AM | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2214 | Uruoca - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2215 | Urupá - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2216 | Uruçuca - BA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2217 | Vale De São Domingos - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2218 | Vale Do Anari - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2219 | Vale Do Paraíso - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2220 | Vale Verde - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2221 | Valença - RJ | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2222 | Vargem Alegre - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2223 | Vargem Grande Do Rio Pardo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2224 | Varjão De Minas - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2225 | Varjão - GO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2226 | Varzelândia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2227 | Vassouras - RJ | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2228 | Vazante - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2229 | Venha Ver - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2230 | Venturosa - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2231 | Venâncio Aires - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2232 | Vera Cruz - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2233 | Vera - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2234 | Veranópolis - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2235 | Verdejante - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2236 | Verdelândia - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2237 | Vereadores De Cachoeira Do Sul - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2238 | Vertente Do Lério - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2239 | Verê - PR | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2240 | Veríssimo - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2241 | Vespasiano - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2242 | Vicentina - MS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2243 | Victor Graeff - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2244 | Vicência - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2245 | Vila Bela Da Santíssima Trindade - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2246 | Vila Flor - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2247 | Vila Nova Do Piauí - PI | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2248 | Vila Rica - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2249 | Vilhena - RO | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2250 | Virgem Da Lapa - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2251 | Visconde Do Rio Branco - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2252 | Viseu - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2253 | Vitória De Santo Antão - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2254 | Viçosa Do Ceará - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2255 | Viçosa - AL | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2256 | Viçosa - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2257 | Viçosa - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2258 | Volta Grande - MG | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2259 | Várzea Alegre - CE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2260 | Várzea Grande - MT | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2261 | Várzea - RN | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2262 | Xangri-Lá - RS | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2263 | Xexéu - PE | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2264 | Xinguara - PA | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/195) |
+| 2265 | Presidente Prudente | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/233) |
 | XXX | Foz do Iguaçu | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/27) |
 | XXX | Araguaina | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/3) |
 | XXX | Jaú | || [PR](https://github.com/okfn-brasil/diario-oficial/pull/197)|

--- a/processing/data_collection/gazette/spiders/al_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/al_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class AlAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "al_associacao_municipios"
+    TERRITORY_ID = "2700000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/ama"

--- a/processing/data_collection/gazette/spiders/am_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/am_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class AmAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "am_associacao_municipios"
+    TERRITORY_ID = "1300000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/aam"

--- a/processing/data_collection/gazette/spiders/ba_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/ba_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class BaAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "ba_associacao_municipios"
+    TERRITORY_ID = "2900000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/amurc"

--- a/processing/data_collection/gazette/spiders/base.py
+++ b/processing/data_collection/gazette/spiders/base.py
@@ -1,7 +1,10 @@
+import json
 import re
-from datetime import datetime
+from datetime import date, datetime
 
 import dateparser
+from dateutil.rrule import DAILY, rrule
+from fake_useragent import UserAgent
 import scrapy
 from gazette.items import Gazette
 from scrapy.exceptions import NotConfigured
@@ -25,6 +28,87 @@ class BaseGazetteSpider(scrapy.Spider):
                 raise
         else:
             self.logger.info("Collecting all gazettes available")
+
+
+class SigpubGazetteSpider(BaseGazetteSpider):
+    """www.diariomunicipal.com.br (Sigpub) base spider
+
+    Documents obtained by this kind of spider are text-PDFs with many cities in it.
+    That's because the websites are usually made for associations of cities.
+    
+    TODO:
+        - All variations have a "possible" start date of 01/01/2009, but that may cause
+        many unnecessary requests to be made if they actually start making available
+        documents later. Some investigation for the start date of each website needs to
+        be made in this case.
+
+    Observations:
+        - These websites have an "Advanced Search", but they are protected by ReCaptcha.
+    """
+
+    custom_settings = {"USER_AGENT": UserAgent().random}
+    start_date = date(2009, 1, 1)
+
+    def start_requests(self):
+        """Requests start page where the calendar widget is available."""
+        yield scrapy.Request(self.CALENDAR_URL, callback=self.parse_calendar)
+
+    def parse_calendar(self, response):
+        """Makes requests for each date to see if a document is available."""
+        default_form_fields = {
+            "calendar[_token]": response.xpath(
+                "//input[@id='calendar__token']/@value"
+            ).get()
+        }
+        for date, date_form_fields in self.available_dates_form_fields():
+            formdata = {**default_form_fields, **date_form_fields}
+
+            yield scrapy.FormRequest(
+                url=response.urljoin("materia/calendario"),
+                formdata=formdata,
+                meta={"date": date, "edition_type": "regular"},
+                callback=self.parse_gazette_info,
+            )
+            yield scrapy.FormRequest(
+                url=response.urljoin("materia/calendario/extra"),
+                formdata=formdata,
+                meta={"date": date, "edition_type": "extra"},
+                callback=self.parse_gazette_info,
+            )
+
+    def parse_gazette_info(self, response):
+        """Parses document availability endpoint and gets document URL if available."""
+        body = json.loads(response.text)
+        meta = response.meta
+
+        if "error" in body:
+            self.logger.debug(
+                f"{meta['edition_type'].capitalize()} Gazette not available for {meta['date'].date()}"
+            )
+            return
+
+        for edition in body["edicao"]:
+            url = f"{body['url_arquivos']}{edition['link_diario']}.pdf"
+            yield Gazette(
+                date=meta["date"].date(),
+                file_urls=[url],
+                territory_id=self.TERRITORY_ID,
+                power="executive_legislative",
+                is_extra_edition=(meta["edition_type"] == "extra"),
+                scraped_at=datetime.utcnow(),
+                edition_number=edition.get("numero_edicao", ""),
+            )
+
+    def available_dates_form_fields(self):
+        """Generates dates and corresponding form fields for availability endpoint."""
+        available_dates = rrule(freq=DAILY, dtstart=self.start_date, until=date.today())
+        for query_date in available_dates:
+            form_fields = {
+                "calendar[day]": str(query_date.day),
+                "calendar[month]": str(query_date.month),
+                "calendar[year]": str(query_date.year),
+            }
+            yield query_date, form_fields
 
 
 class FecamGazetteSpider(BaseGazetteSpider):

--- a/processing/data_collection/gazette/spiders/ce_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/ce_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class CeAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "ce_associacao_municipios"
+    TERRITORY_ID = "2300000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/aprece"

--- a/processing/data_collection/gazette/spiders/go_associacao_municipios_agm.py
+++ b/processing/data_collection/gazette/spiders/go_associacao_municipios_agm.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class GoAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "go_associacao_municipios_agm"
+    TERRITORY_ID = "5200000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/agm"

--- a/processing/data_collection/gazette/spiders/go_associacao_municipios_fgm.py
+++ b/processing/data_collection/gazette/spiders/go_associacao_municipios_fgm.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class GoAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "go_associacao_municipios_fgm"
+    TERRITORY_ID = "5200000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/fgm"

--- a/processing/data_collection/gazette/spiders/mg_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/mg_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class MgAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "mg_associacao_municipios"
+    TERRITORY_ID = "3100000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/amm-mg"

--- a/processing/data_collection/gazette/spiders/ms_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/ms_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class MsAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "ms_associacao_municipios"
+    TERRITORY_ID = "5000000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/ms"

--- a/processing/data_collection/gazette/spiders/mt_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/mt_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class MtAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "mt_associacao_municipios"
+    TERRITORY_ID = "5100000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/amm-mt"

--- a/processing/data_collection/gazette/spiders/pa_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/pa_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class PaAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "pa_associacao_municipios"
+    TERRITORY_ID = "1500000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/famep"

--- a/processing/data_collection/gazette/spiders/pb_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/pb_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class PbAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "pb_associacao_municipios"
+    TERRITORY_ID = "2500000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/famup"

--- a/processing/data_collection/gazette/spiders/pe_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/pe_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class PeAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "pe_associacao_municipios"
+    TERRITORY_ID = "2600000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/amupe"

--- a/processing/data_collection/gazette/spiders/pi_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/pi_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class PiAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "pi_associacao_municipios"
+    TERRITORY_ID = "2200000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/appm"

--- a/processing/data_collection/gazette/spiders/pr_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/pr_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class PrAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "pr_associacao_municipios"
+    TERRITORY_ID = "4100000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/amp"

--- a/processing/data_collection/gazette/spiders/rj_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/rj_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class RjAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "rj_associacao_municipios"
+    TERRITORY_ID = "3300000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/aemerj"

--- a/processing/data_collection/gazette/spiders/rn_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/rn_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class RnAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "rn_associacao_municipios"
+    TERRITORY_ID = "2400000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/femurn"

--- a/processing/data_collection/gazette/spiders/ro_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/ro_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class RoAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "ro_associacao_municipios"
+    TERRITORY_ID = "1100000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/arom"

--- a/processing/data_collection/gazette/spiders/rr_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/rr_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class RrAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "rr_associacao_municipios"
+    TERRITORY_ID = "1400000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/amr"

--- a/processing/data_collection/gazette/spiders/rs_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/rs_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class RsAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "rs_associacao_municipios"
+    TERRITORY_ID = "4300000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/famurs"

--- a/processing/data_collection/gazette/spiders/se_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/se_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class SeAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "se_associacao_municipios"
+    TERRITORY_ID = "2800000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/sergipe"

--- a/processing/data_collection/gazette/spiders/sp_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/sp_associacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class SpAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+    name = "sp_associacao_municipios"
+    TERRITORY_ID = "3500000"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/apm"

--- a/processing/data_collection/gazette/spiders/sp_macatuba.py
+++ b/processing/data_collection/gazette/spiders/sp_macatuba.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base import SigpubGazetteSpider
+
+
+class SpMacatubaSpider(SigpubGazetteSpider):
+    name = "sp_macatuba"
+    TERRITORY_ID = "3528007"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/macatuba"

--- a/processing/data_collection/gazette/spiders/sp_monte_alto.py
+++ b/processing/data_collection/gazette/spiders/sp_monte_alto.py
@@ -1,3 +1,4 @@
+from gazette.spiders.base import SigpubGazetteSpider
 from gazette.spiders.instar_base import BaseInstarSpider
 
 
@@ -6,3 +7,9 @@ class SpMonteAltoSpider(BaseInstarSpider):
     name = "sp_monte_alto"
     allowed_domains = ["montealto.instaridc.com.br"]
     start_urls = ["http://montealto.instaridc.com.br/portal/diario-oficial"]
+
+
+class SpMonteAltoSigpubSpider(SigpubGazetteSpider):
+    name = "sp_monte_alto_sigpub"
+    TERRITORY_ID = "3531308"
+    CALENDAR_URL = "http://www.diariomunicipal.com.br/pmmasp"

--- a/processing/requirements.in
+++ b/processing/requirements.in
@@ -1,6 +1,7 @@
 black==19.10b0
 boto3
 dateparser
+fake-useragent
 itemadapter
 psycopg2-binary
 python-dateutil

--- a/processing/requirements.txt
+++ b/processing/requirements.txt
@@ -18,6 +18,7 @@ constantly==15.1.0        # via twisted
 cryptography==3.1.1       # via pyopenssl, scrapy, service-identity
 cssselect==1.1.0          # via parsel, scrapy
 dateparser==0.7.6         # via -r requirements.in
+fake-useragent==0.1.11    # via -r requirements.in
 hyperlink==20.0.1         # via twisted
 idna==2.10                # via hyperlink, requests
 incremental==17.5.0       # via twisted


### PR DESCRIPTION
AMUPE (Associação de Municípios de Pernambuco) has some siblings :) The base is the same and it has coverage in almost every state (as you can see [here](http://www.diariomunicipal.com.br/)). Some states have most of their cities in it, some only have a bit more than a couple. But it is something already.

Right now, I implemented all states of the Northeast Region. I'll keep updating it in the next days. And 
document whatever we feel necessary at the end.

I reeeally didn't want to update CITIES.md to include these cities. Do you have a script for that since you added Fecam, @jvanz :smile:?

And `TERRITORY_ID` is kind of a problem. Because the Gazettes are for every city in the association. I thought about allowing a list of ids and adding multiple entries in the database for every id in the list. But I'm not sure about this. What do you think?
