### PR TITLE
Add List command

### DIFF
--- a/processing/data_collection/gazette/__main__.py
+++ b/processing/data_collection/gazette/__main__.py
@@ -1,0 +1,26 @@
+from collections import defaultdict
+import re
+from pathlib import Path
+
+
+def main():
+    root = Path(__file__).parent
+    spiders = root / "spiders"
+    pattern = r"([a-z]{2})_([a-z_]+)\.py"
+
+    results = defaultdict(list)
+
+    for f in spiders.glob("*.py"):
+        name = f.name
+        matches = re.findall(pattern, name)
+
+        if matches:
+            state, city = matches[0]
+            city = city.replace("_", " ").title()
+            results[state].append(city)
+
+    print(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/processing/data_collection/gazette/__main__.py
+++ b/processing/data_collection/gazette/__main__.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from os import stat
 import re
 from pathlib import Path
 
@@ -6,7 +7,7 @@ from pathlib import Path
 def main():
     root = Path(__file__).parent
     spiders = root / "spiders"
-    pattern = r"([a-z]{2})_([a-z_]+)\.py"
+    pattern = r"^([a-z]{2})_([a-z_]+)\.py$"
 
     results = defaultdict(list)
 
@@ -16,10 +17,15 @@ def main():
 
         if matches:
             state, city = matches[0]
+            state = state.upper()
             city = city.replace("_", " ").title()
             results[state].append(city)
 
-    print(results)
+    for state in sorted(results.keys()):
+        print(f"Cidades de {state}")
+        for city in sorted(results[state]):
+            print(f"\t{city}")
+        print("*-" * 20, "*", sep="")
 
 
 if __name__ == "__main__":

--- a/processing/data_collection/gazette/__main__.py
+++ b/processing/data_collection/gazette/__main__.py
@@ -4,7 +4,14 @@ import re
 from pathlib import Path
 
 
-def main():
+def list_spiders(path="spiders"):
+    """
+    Lists all the spiders available and breaks their names
+    in state and city.
+
+    Returns a dictionary containing the state's initials
+    and a list of its cities.
+    """
     root = Path(__file__).parent
     spiders = root / "spiders"
     pattern = r"^([a-z]{2})_([a-z_]+)\.py$"
@@ -21,11 +28,29 @@ def main():
             city = city.replace("_", " ").title()
             results[state].append(city)
 
-    for state in sorted(results.keys()):
+    return results
+
+
+def print_spiders_list(spider_list):
+    """
+    Given a dictionary as returned by `lists_spiders`,
+    prints them in a user-friendly format.
+
+    Currently, it will order the keys alphabetically
+    and print each city on a separate line, also
+    alphabetically. At the end of each key, it
+    prints a separator.
+    """
+    for state in sorted(spider_list.keys()):
         print(f"Cidades de {state}")
-        for city in sorted(results[state]):
+        for city in sorted(spider_list[state]):
             print(f"\t{city}")
         print("*-" * 20, "*", sep="")
+
+
+def main():
+    results = list_spiders()
+    print_spiders_list(results)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is related to #205 and it adds a CLI to Gazette that lists all the available spiders. It accepts an optional list of states' initials and filters by them if they are provided. The output is grouped by the state's initials, in alphabetical order and the cities inside the group are also sorted.

I'm not very proficient with Python's `argparse` so I might have not done things in an optimal way, if anyone can take a closer look at argument handling, please do!

The expected behavior is:
![Peek 15-08-2020 17-49](https://user-images.githubusercontent.com/247856/90321419-bf9dee00-df1f-11ea-8331-80cf16e585f2.gif)

Please notice that I'm inside the `processing/data_collection` folder. Maybe it would be nice to have a way to externalize this command to the project's root

