### PR TITLE
Duplicate key when running make setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-setup:
+setup: destroy
 	cp .env.example .env
 	docker-compose pull
 	docker-compose build
@@ -9,6 +9,10 @@ setup:
 		pip install pre-commit; \
 	fi
 	pre-commit install
+
+destroy:
+	echo "Removing all containers...."
+	docker-compose down --rmi all --volumes --remove-orphans
 
 seed:
 	docker-compose up -d postgres


### PR DESCRIPTION
One of the step ran by the "make setup" is to populate the territories
table with the content of the "territories.cvs" files. However, if the
database is already populates by some previous failed "make setup" run,
The command fails. To fix that, before start the process of build
container images and start the process, a docker-compose call is done to
remove all the container images and volume used by the services. Thus,
the "make setup" will always rebuild everything fine.

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>