### PR TITLE
Add spider for Belem - Pará

### DIFF
--- a/CITIES.md
+++ b/CITIES.md
@@ -19,7 +19,7 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 | 9 | Recife | :white_check_mark: | [issue](https://github.com/okfn-brasil/diario-oficial/issues/187) | [PR](https://github.com/okfn-brasil/diario-oficial/pull/170) |
 | 10 | Porto Alegre | :white_check_mark: | | |
 | 11 | Goiânia | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/6) |
-| 12 | Belém | | | |
+| 12 | Belém | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/212) |
 | 13 | Guarulhos | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/4) |
 | 14 | Campinas | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/2) |
 | 15 | São Luís | :soon: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/22) |

--- a/processing/data_collection/gazette/spiders/pa_belem.py
+++ b/processing/data_collection/gazette/spiders/pa_belem.py
@@ -13,6 +13,11 @@ class PaBelemSpider(BaseGazetteSpider):
     TERRITORY_ID = "1501402"
     name = "pa_belem"
     allowed_domains = ["sistemas.belem.pa.gov.br"]
+    custom_settings = {
+        "DEFAULT_REQUEST_HEADERS": {
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8,application/octet-stream"
+        }
+    }
 
     BASE_URL = "https://sistemas.belem.pa.gov.br/diario-consulta-api/diarios"
 

--- a/processing/data_collection/gazette/spiders/pa_belem.py
+++ b/processing/data_collection/gazette/spiders/pa_belem.py
@@ -1,0 +1,56 @@
+import json
+from datetime import datetime
+
+import requests
+import scrapy
+from dateparser import parse
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class PaBelemSpider(BaseGazetteSpider):
+    TERRITORY_ID = "1501402"
+    name = "pa_belem"
+    allowed_domains = ["sistemas.belem.pa.gov.br"]
+
+    BASE_URL = "https://sistemas.belem.pa.gov.br/diario-consulta-api/diarios"
+
+    def start_requests(self):
+        """
+        Requests the gazette to get the total of documents and use it as a query param
+
+        @url https://sistemas.belem.pa.gov.br/diario-consulta-api/diarios
+        @returns requests 1
+        """
+
+        gazettes_data = requests.get(self.BASE_URL).json()
+        number_of_documents = gazettes_data["response"]["numFound"]
+
+        url = f"{self.BASE_URL}?start=0&rows={number_of_documents}"
+
+        yield scrapy.Request(url=url, callback=self.parse)
+
+    def parse(self, response):
+        """
+        @url https://sistemas.belem.pa.gov.br/diario-consulta-api/diarios?start=0&rows={x]
+        @returns requests 1
+        @scrapes date file_urls is_extra_edition territory_id power scraped_at
+        """
+
+        data = json.loads(response.body)["response"]
+
+        for gazette_data in data["docs"]:
+            date = parse(gazette_data["data_publicacao"]).date()
+            gazette_id = gazette_data["id"]
+
+            url = f"{self.BASE_URL}/{gazette_id}"
+
+            yield Gazette(
+                date=date,
+                file_urls=[url],
+                is_extra_edition=bool(None),
+                territory_id=self.TERRITORY_ID,
+                power="executive",
+                scraped_at=datetime.utcnow(),
+            )


### PR DESCRIPTION
### Description

Add spider for Belem - Pará. Issue #182 .

I've tried to run the spider built on [PR 87](https://github.com/okfn-brasil/diario-oficial/pull/87) but it didn't work and based on the spider code I assumed that the website changed since it was built (2 years ago)

Despite that, this PR is still a WIP because I couldn't find a way to download the PDF files.

#### Problem description

On this spider [I am using a different URL](https://sistemas.belem.pa.gov.br/diario-consulta-api/diarios) (the API one) but you can [check in here](http://sistemas.belem.pa.gov.br/diario/painel) that we can't get any pdf `href` based on the website DOM. So, as we can download the file just by clicking on the button I guess that the only possible solution that we have is to install selenium, right? Do you see any other possible solution?

As I couldn't resolve it by scraping the DOM - because of Javascript - and I wanted to check if there is any other option than downloading selenium I've decided to try to use the API url and see if I can hack a way out to download the gazette pdfs, but unfortunately I couldn't.

If I try to download the file specifying the Accept headers key, like here: `curl -X GET https://sistemas.belem.pa.gov.br/diario-consulta-api/diarios/13959 -H 'Accept: application/octet-stream'` the file is downloaded, but if I don't specify it - that's what happens when we [`yield` the `Gazette`](https://github.com/okfn-brasil/diario-oficial/compare/main...rodolfolottin:pa_belem_spider?expand=1#diff-9682884629ccc69202e9125a3119036cR49-R56) the downloaded content is just a pure JSON.

What do you think? Do you see any other solution than installing selenium?
