### PR TITLE
Add spider for Teresina/PI

### DIFF
--- a/CITIES.md
+++ b/CITIES.md
@@ -28,7 +28,7 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 | 18 | Duque de Caxias | | | |
 | 19 | Natal | :white_check_mark: | [issue](https://github.com/okfn-brasil/diario-oficial/issues/189) | [PR](https://github.com/okfn-brasil/diario-oficial/pull/192) |
 | 20 | Campo Grande | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/35) |
-| 21 | Teresina | :soon: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/53) |
+| 21 | Teresina | :white_check_mark: | [issue](https://github.com/okfn-brasil/diario-oficial/issues/188)| [PR](https://github.com/okfn-brasil/diario-oficial/pull/216) |
 | 22 | São Bernardo do Campo | | | |
 | 23 | João Pessoa | :soon: | | |
 | 24 | Nova Iguaçu | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/120) |

--- a/processing/data_collection/gazette/spiders/pi_teresina.py
+++ b/processing/data_collection/gazette/spiders/pi_teresina.py
@@ -1,3 +1,4 @@
+import math
 from datetime import datetime
 from urllib.parse import urlencode
 
@@ -17,11 +18,12 @@ class PiTeresina(BaseGazetteSpider):
 
     def parse(self, response):
         total_items = int(response.css(".texto span b::text").get())
-        total_pages = self.calculate_number_of_pages(total_items, 10)
+        ITEMS_PER_PAGE = 10
+        total_pages = math.ceil(total_items / ITEMS_PER_PAGE)
 
         for i in range(1, total_pages + 1):
             params = {"pagina": i}
-            url = "{}?{}".format(self.BASE_URL, urlencode(params))
+            url = f"{self.BASE_URL}?{urlencode(params)}"
             yield scrapy.Request(url=url, callback=self.parse_page)
 
     def parse_page(self, response):
@@ -39,10 +41,3 @@ class PiTeresina(BaseGazetteSpider):
                 power="executive_legislative",
                 scraped_at=datetime.utcnow(),
             )
-
-    def calculate_number_of_pages(self, total_items, items_per_page=10):
-        if total_items % items_per_page == 0:
-            number_of_pages = total_items // items_per_page
-        else:
-            number_of_pages = (total_items // items_per_page) + 1
-        return number_of_pages

--- a/processing/data_collection/gazette/spiders/pi_teresina.py
+++ b/processing/data_collection/gazette/spiders/pi_teresina.py
@@ -1,0 +1,46 @@
+import scrapy
+import dateparser
+
+from datetime import datetime
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class PiTeresina(BaseGazetteSpider):
+    TERRITORY_ID = "2211001"
+    name = "pi_teresina"
+    start_urls = ["http://dom.pmt.pi.gov.br/lista_diario.php"]
+
+    def parse(self, response):
+        total_items = int(response.css("#meio > div.texto > span > b::text").get())
+        total_pages = self.calculate_number_of_pages(total_items, 10)
+
+        pages_urls = [
+            "http://dom.pmt.pi.gov.br/lista_diario.php?pagina={}".format(i)
+            for i in range(1, total_pages + 1)
+        ]
+        for url in pages_urls:
+            yield scrapy.Request(url=url, callback=self.parse_page)
+
+    def parse_page(self, response):
+        for entry in response.css("tbody > tr"):
+            file_url = entry.css("a::attr(href)").get()
+
+            date_text = entry.css("td:nth-child(2)::text").get()
+            date = dateparser.parse(date_text, languages=["pt"]).date()
+
+            yield Gazette(
+                date=date,
+                file_urls=[file_url],
+                territory_id=self.TERRITORY_ID,
+                power="executive_legislative",
+                scraped_at=datetime.utcnow(),
+            )
+
+    def calculate_number_of_pages(self, total_items, items_per_page=10):
+        if total_items % items_per_page == 0:
+            number_of_pages = total_items // items_per_page
+        else:
+            number_of_pages = (total_items // items_per_page) + 1
+        return number_of_pages

--- a/processing/data_collection/gazette/spiders/pi_teresina.py
+++ b/processing/data_collection/gazette/spiders/pi_teresina.py
@@ -2,6 +2,7 @@ import scrapy
 import dateparser
 
 from datetime import datetime
+from urllib.parse import urlencode
 
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
@@ -9,30 +10,31 @@ from gazette.spiders.base import BaseGazetteSpider
 
 class PiTeresina(BaseGazetteSpider):
     TERRITORY_ID = "2211001"
+    BASE_URL = "http://dom.pmt.pi.gov.br/lista_diario.php"
     name = "pi_teresina"
-    start_urls = ["http://dom.pmt.pi.gov.br/lista_diario.php"]
+    allowed_domains = ["dom.pmt.pi.gov.br"]
+    start_urls = [BASE_URL]
 
     def parse(self, response):
-        total_items = int(response.css("#meio > div.texto > span > b::text").get())
+        total_items = int(response.css(".texto span b::text").get())
         total_pages = self.calculate_number_of_pages(total_items, 10)
 
-        pages_urls = [
-            "http://dom.pmt.pi.gov.br/lista_diario.php?pagina={}".format(i)
-            for i in range(1, total_pages + 1)
-        ]
-        for url in pages_urls:
+        for i in range(1, total_pages + 1):
+            params = {"pagina": i}
+            url = "{}?{}".format(self.BASE_URL, urlencode(params))
             yield scrapy.Request(url=url, callback=self.parse_page)
 
     def parse_page(self, response):
-        for entry in response.css("tbody > tr"):
-            file_url = entry.css("a::attr(href)").get()
+        for entry in response.css("tbody tr"):
+            # retrieves gazette files and attachments
+            file_urls = entry.css("td a::attr(href)").getall()
 
             date_text = entry.css("td:nth-child(2)::text").get()
             date = dateparser.parse(date_text, languages=["pt"]).date()
 
             yield Gazette(
                 date=date,
-                file_urls=[file_url],
+                file_urls=file_urls,
                 territory_id=self.TERRITORY_ID,
                 power="executive_legislative",
                 scraped_at=datetime.utcnow(),

--- a/processing/data_collection/gazette/spiders/pi_teresina.py
+++ b/processing/data_collection/gazette/spiders/pi_teresina.py
@@ -1,8 +1,8 @@
-import scrapy
-import dateparser
-
 from datetime import datetime
 from urllib.parse import urlencode
+
+import dateparser
+import scrapy
 
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider


### PR DESCRIPTION
Add spider for Teresina/PI [gazette](http://dom.pmt.pi.gov.br/lista_diario.php). 
The [PR #53](https://github.com/okfn-brasil/querido-diario/pull/53) is out of date and no longer works. This PR is updated with the changes that occurred on the website.

The Teresina gazette website shows the total number of diaries available and this was explored in the development of the spider
![Captura de tela de 2020-08-23 17-03-09](https://user-images.githubusercontent.com/12171286/90987613-a53cc380-e562-11ea-81e9-15ed073f5866.png)

In some editions there are also attachments. All of them are recovered by the spider
![Captura de tela de 2020-08-23 17-04-39](https://user-images.githubusercontent.com/12171286/90987628-cb626380-e562-11ea-9977-be18b83b849d.png)


Suggestions for improvement are welcome