### PR TITLE
Remove scrapy-deltafetch middleware

### DIFF
--- a/processing/data_collection/gazette/settings.py
+++ b/processing/data_collection/gazette/settings.py
@@ -7,8 +7,4 @@ ITEM_PIPELINES = {
     "scrapy.pipelines.files.FilesPipeline": 100,
     "gazette.pipelines.ExtractTextPipeline": 200,
 }
-SPIDER_MIDDLEWARES = {"scrapy_deltafetch.DeltaFetch": 100}
 FILES_STORE = "/mnt/data/"
-# skip already crawled item
-DELTAFETCH_ENABLED = True
-DELTAFETCH_DIR = "/mnt/data/deltafetch"

--- a/processing/requirements.in
+++ b/processing/requirements.in
@@ -8,5 +8,4 @@ python-decouple
 python-magic
 requests
 scrapy
-scrapy-deltafetch
 SQLAlchemy

--- a/processing/requirements.txt
+++ b/processing/requirements.txt
@@ -10,7 +10,6 @@ automat==20.2.0           # via twisted
 black==19.10b0            # via -r requirements.in
 boto3==1.15.6             # via -r requirements.in
 botocore==1.18.6          # via boto3, s3transfer
-bsddb3==6.2.7             # via scrapy-deltafetch
 certifi==2020.6.20        # via requests
 cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
@@ -44,8 +43,7 @@ queuelib==1.5.0           # via scrapy
 regex==2020.9.27          # via black, dateparser
 requests==2.24.0          # via -r requirements.in
 s3transfer==0.3.3         # via boto3
-scrapy-deltafetch==1.2.1  # via -r requirements.in
-scrapy==2.3.0             # via -r requirements.in, scrapy-deltafetch
+scrapy==2.3.0             # via -r requirements.in
 service-identity==18.1.0  # via scrapy
 six==1.15.0               # via automat, cryptography, parsel, protego, pyopenssl, python-dateutil, w3lib
 sqlalchemy==1.3.19        # via -r requirements.in


### PR DESCRIPTION
This middleware was introduced to avoid spiders to request data that was already requested before, reducing the amount of requests made. However, it is not certain that it will reach this goal considering that some requests may be the same but the content returned different. A better solution to reduce the number of requests may be necessary, but we will only know for sure when we start running all the spiders daily.

More about this: #219