### PR TITLE
Remove unused municipality_id field

### DIFF
--- a/processing/data_collection/gazette/items.py
+++ b/processing/data_collection/gazette/items.py
@@ -13,6 +13,3 @@ class Gazette(scrapy.Item):
     scraped_at = scrapy.Field()
     file_urls = scrapy.Field()
     files = scrapy.Field()
-    # TEMP: Can be removed once this attribute stop being used.
-    #       Check PostgreSQLPipeline for more info.
-    municipality_id = scrapy.Field()

--- a/processing/data_collection/gazette/spiders/ba_salvador.py
+++ b/processing/data_collection/gazette/spiders/ba_salvador.py
@@ -12,7 +12,7 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class BaSalvadorSpider(BaseGazetteSpider):
-    MUNICIPALITY_ID = "2927408"
+    TERRITORY_ID = "2927408"
     name = "ba_salvador"
     allowed_domains = ["salvador.ba.gov.br"]
     power = "executive"
@@ -67,7 +67,7 @@ class BaSalvadorSpider(BaseGazetteSpider):
         yield Gazette(
             date=parsed_date.date(),
             file_urls=[pdf_url],
-            municipality_id=self.MUNICIPALITY_ID,
+            territory_id=self.TERRITORY_ID,
             power=self.power,
             scraped_at=datetime.datetime.utcnow(),
         )

--- a/processing/data_collection/gazette/spiders/ms_campo_grande.py
+++ b/processing/data_collection/gazette/spiders/ms_campo_grande.py
@@ -8,7 +8,7 @@ from gazette.items import Gazette
 
 
 class MsCampoGrandeSpider(scrapy.Spider):
-    MUNICIPALITY_ID = "5002704"
+    TERRITORY_ID = "5002704"
     name = "ms_campo_grande"
     allowed_domains = ["portal.capital.ms.gov.br"]
 
@@ -41,7 +41,7 @@ class MsCampoGrandeSpider(scrapy.Spider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra_edition,
-                municipality_id=self.MUNICIPALITY_ID,
+                territory_id=self.TERRITORY_ID,
                 power=power,
                 scraped_at=dt.datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/sp_guaruja.py
+++ b/processing/data_collection/gazette/spiders/sp_guaruja.py
@@ -8,7 +8,7 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class SpGuaruja(BaseGazetteSpider):
-    MUNICIPALITY_ID = "3518701"
+    TERRITORY_ID = "3518701"
     name = "sp_guaruja"
     allowed_domains = ["guaruja.sp.gov.br"]
     start_urls = ["http://www.guaruja.sp.gov.br/index.php/diario-oficial/"]
@@ -31,7 +31,7 @@ class SpGuaruja(BaseGazetteSpider):
                     date=date,
                     file_urls=[url],
                     is_extra_edition=is_extra_edition,
-                    municipality_id=self.MUNICIPALITY_ID,
+                    territory_id=self.TERRITORY_ID,
                     power="executive_legislature",
                     scraped_at=datetime.utcnow(),
                 )


### PR DESCRIPTION
This field was replaced by territory_id. Just a few old spiders were still using it, so it can be removed now.