### PR TITLE
Add setting to enable/disable extracting text from gazette files

### DIFF
--- a/processing/data_collection/gazette/pipelines.py
+++ b/processing/data_collection/gazette/pipelines.py
@@ -28,6 +28,12 @@ class ExtractTextPipeline:
     """
 
     def process_item(self, item, spider):
+        extract_text_from_file = spider.settings.getbool(
+            "QUERIDODIARIO_EXTRACT_TEXT_FROM_FILE", True
+        )
+        if not extract_text_from_file:
+            return item
+
         if self.is_doc(item["files"][0]["path"]):
             item["source_text"] = self.doc_source_text(item)
         elif self.is_pdf(item["files"][0]["path"]):

--- a/processing/data_collection/gazette/settings.py
+++ b/processing/data_collection/gazette/settings.py
@@ -12,3 +12,5 @@ FILES_STORE = "/mnt/data/"
 # skip already crawled item
 DELTAFETCH_ENABLED = True
 DELTAFETCH_DIR = "/mnt/data/deltafetch"
+
+QUERIDODIARIO_EXTRACT_TEXT_FROM_FILE = True


### PR DESCRIPTION
This settings allows to run spiders without the step that extracts content of PDF files. Useful for developing and debugging.