### PR TITLE
Florianópolis-SC - Limit requests according to start date argument provided

### DIFF
--- a/processing/data_collection/gazette/spiders/sc_florianopolis.py
+++ b/processing/data_collection/gazette/spiders/sc_florianopolis.py
@@ -2,7 +2,7 @@ import re
 from datetime import date, datetime
 
 from dateparser import parse
-from dateutil.relativedelta import relativedelta
+from dateutil.rrule import MONTHLY, rrule
 from scrapy import FormRequest
 
 from gazette.items import Gazette
@@ -11,20 +11,23 @@ from gazette.spiders.base import BaseGazetteSpider
 
 class ScFlorianopolisSpider(BaseGazetteSpider):
     name = "sc_florianopolis"
-    URL = "http://www.pmf.sc.gov.br/governo/index.php?pagina=govdiariooficial"
     TERRITORY_ID = "4205407"
-    AVAILABLE_FROM = date(2015, 1, 1)  # actually from June/2009
+
+    start_date = date(2009, 6, 1)
 
     def start_requests(self):
-        target = date.today()
-        while target >= self.AVAILABLE_FROM:
-            year, month = str(target.year), str(target.month)
-            data = dict(ano=year, mes=month, passo="1", enviar="")
-            yield FormRequest(url=self.URL, formdata=data, callback=self.parse)
-            if hasattr(self, "start_date") and target <= self.start_date:
-                break
+        end_date = date.today()
 
-            target = target - relativedelta(months=1)
+        periods_of_interest = [
+            (date.year, date.month)
+            for date in rrule(freq=MONTHLY, dtstart=self.start_date, until=end_date)
+        ]
+        for year, month in periods_of_interest:
+            data = dict(ano=str(year), mes=str(month), passo="1", enviar="")
+            yield FormRequest(
+                "http://www.pmf.sc.gov.br/governo/index.php?pagina=govdiariooficial",
+                formdata=data,
+            )
 
     def parse(self, response):
         for link in response.css("ul.listagem li a"):
@@ -33,8 +36,6 @@ class ScFlorianopolisSpider(BaseGazetteSpider):
                 continue
 
             gazette_date = self.get_date(link)
-            if hasattr(self, "start_date") and gazette_date < self.start_date:
-                continue
 
             yield Gazette(
                 date=gazette_date,


### PR DESCRIPTION
This PR improves how requests are made according to the start date desired, avoiding the spider to send requests that won't get gazettes from dates we are not interested. (Based on discussion in #247).