### PR TITLE
Alternative Date Filtering proposal

### DIFF
--- a/processing/data_collection/gazette/pipelines.py
+++ b/processing/data_collection/gazette/pipelines.py
@@ -5,21 +5,12 @@ import os
 import subprocess
 
 from itemadapter import ItemAdapter
-from scrapy.exceptions import DropItem
 from scrapy.http import Request
 from scrapy.pipelines.files import FilesPipeline
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 from gazette.settings import FILES_STORE
-
-
-class GazetteDateFilteringPipeline:
-    def process_item(self, item, spider):
-        if hasattr(spider, "start_date"):
-            if spider.start_date > item.get("date"):
-                raise DropItem("Droping all items before {}".format(spider.start_date))
-        return item
 
 
 class ExtractTextPipeline:

--- a/processing/data_collection/gazette/settings.py
+++ b/processing/data_collection/gazette/settings.py
@@ -3,9 +3,11 @@ SPIDER_MODULES = ["gazette.spiders"]
 NEWSPIDER_MODULE = "gazette.spiders"
 ROBOTSTXT_OBEY = False
 ITEM_PIPELINES = {
-    "gazette.pipelines.GazetteDateFilteringPipeline": 50,
     "scrapy.pipelines.files.FilesPipeline": 100,
     "gazette.pipelines.ExtractTextPipeline": 200,
+}
+SPIDER_MIDDLEWARES = {
+    "gazette.middlewares.GazetteDateFilteringSpiderMiddleware": 0,
 }
 FILES_STORE = "/mnt/data/"
 QUERIDODIARIO_EXTRACT_TEXT_FROM_FILE = True

--- a/processing/data_collection/gazette/spiders/base.py
+++ b/processing/data_collection/gazette/spiders/base.py
@@ -9,13 +9,18 @@ from gazette.items import Gazette
 
 
 class BaseGazetteSpider(scrapy.Spider):
-    def __init__(self, start_date=None, *args, **kwargs):
+    def __init__(self, start_date=None, end_date=None, *args, **kwargs):
         super(BaseGazetteSpider, self).__init__(*args, **kwargs)
 
         if start_date is not None:
-            parsed_data = dateparser.parse(start_date)
+            parsed_data = dateparser.parse(start_date, settings={"DATE_ORDER": "DMY"})
             if parsed_data is not None:
                 self.start_date = parsed_data.date()
+
+        if end_date is not None:
+            parsed_data = dateparser.parse(end_date, settings={"DATE_ORDER": "DMY"})
+            if parsed_data is not None:
+                self.end_date = parsed_data.date()
 
 
 class FecamGazetteSpider(BaseGazetteSpider):

--- a/processing/data_collection/gazette/spiders/pe_recife.py
+++ b/processing/data_collection/gazette/spiders/pe_recife.py
@@ -51,7 +51,7 @@ class PeRecifeSpider(BaseGazetteSpider):
         for date in dates:
             yield scrapy.Request(
                 url=self.EDITIONS_IN_DATE_URL.format(full_date=date.strftime("%Y%m%d")),
-                meta={"date": date},
+                meta={"gazette_date": date.date()},
                 callback=self.parse_editions_in_date,
             )
 
@@ -60,7 +60,7 @@ class PeRecifeSpider(BaseGazetteSpider):
         Parses available editions to request only Recife's gazette documents.
         """
         recife_editions = self._find_recife_editions(response.text)
-        date = response.meta["date"]
+        date = response.meta["gazette_date"]
 
         for edition in recife_editions:
             url = self.GAZETTE_URL.format(


### PR DESCRIPTION
This is motivated by #247 and #172 .

This middleware can filter requests based on the `meta` field `gazette_date` and incorporates the functionality of `GazetteDateFilteringPipeline`. So it can filter items too.

The `end_date` attribute was added to enable a more specific date range for the crawl. I guess this should benefit #172.

`pe_recife` and `pr_curitiba` were refactored just for demonstration purposes. If we were to merge, they could become other PRs.

If we were to merge, documentation should be added too, to indicate this practice for contributors.

By the way, `pr_curitiba` has an issue, #260 was opened for it.