### PR TITLE
TERRITORY_ID should be a string

### DIFF
--- a/processing/data_collection/gazette/spiders/mt_cuiaba.py
+++ b/processing/data_collection/gazette/spiders/mt_cuiaba.py
@@ -14,7 +14,7 @@ BASE_URL = "http://gazetamunicipal.cuiaba.mt.gov.br/api/api/editions"
 
 
 class MtCuiabaSpider(BaseGazetteSpider):
-    TERRITORY_ID = 5103403
+    TERRITORY_ID = "5103403"
     name = "mt_cuiaba"
     allowed_domains = ["gazetamunicipal.cuiaba.mt.gov.br"]
     start_urls = ["http://gazetamunicipal.cuiaba.mt.gov.br/"]


### PR DESCRIPTION
All other files use it as string and to avoid errors it's best to use
the same pattern everywhere.