### PR TITLE
Validate format of start_date argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ The following example is the command to run the gazette crawler for Florianópol
 $ docker-compose run --rm processing bash -c "cd data_collection && scrapy crawl sc_florianopolis"
 ```
 
+You can limit the gazettes you want to download passing `start_date` as argument with `YYYY-MM-DD` format. The
+following command will download only gazettes which date is greater than 01/Sep/2020:
+
+```console
+$ docker-compose run --rm processing bash -c "cd data_collection && scrapy crawl sc_florianopolis -a start_date=2020-09-01"
+```
+
 ## Tips and tricks
 
 There is a make target allowing you run the scrapy shell inside the container used by the crawler:

--- a/processing/data_collection/gazette/spiders/base.py
+++ b/processing/data_collection/gazette/spiders/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import re
 from datetime import datetime
 
@@ -13,9 +12,16 @@ class BaseGazetteSpider(scrapy.Spider):
         super(BaseGazetteSpider, self).__init__(*args, **kwargs)
 
         if start_date is not None:
-            parsed_data = dateparser.parse(start_date)
-            if parsed_data is not None:
-                self.start_date = parsed_data.date()
+            try:
+                self.start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
+                self.logger.info(f"Collecting gazettes after {self.start_date}")
+            except ValueError:
+                self.logger.exception(
+                    f"Unable to parse {start_date}. Use %Y-%m-d date format."
+                )
+                raise
+        else:
+            self.logger.info("Collecting all gazettes available")
 
 
 class FecamGazetteSpider(BaseGazetteSpider):


### PR DESCRIPTION
Having a fixed pattern for this argument seems better when we start
scheduling hundreds of spiders daily. It also removes the dependency on
dateparser (that can have performance issues depending the format you
are trying to parse).