### PR TITLE
Add pb_joao_pessoa spider

### DIFF
--- a/CITIES.md
+++ b/CITIES.md
@@ -6,7 +6,6 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 :white_check_mark: Done
 :soon: In progress
 
-<<<<<<< HEAD
 | # | Cidade | Crawler | Issue | PR |
 |:-:|--------|:-------:|:------:|:------:|
 | 1 | São Paulo | | [issue](https://github.com/okfn-brasil/diario-oficial/issues/7) | |
@@ -31,7 +30,7 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 | 20 | Campo Grande | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/35) |
 | 21 | Teresina | :white_check_mark: | [issue](https://github.com/okfn-brasil/diario-oficial/issues/188)| [PR](https://github.com/okfn-brasil/diario-oficial/pull/216) |
 | 22 | São Bernardo do Campo | | | |
-| 23 | João Pessoa | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/72) |
+| 23 | João Pessoa | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/querido-diario/pull/72), [PR](https://github.com/okfn-brasil/querido-diario/pull/270) |
 | 24 | Nova Iguaçu | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/120) |
 | 25 | Santo André | | | |
 | 26 | São José dos Campos | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/71) |

--- a/CITIES.md
+++ b/CITIES.md
@@ -6,6 +6,7 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 :white_check_mark: Done
 :soon: In progress
 
+<<<<<<< HEAD
 | # | Cidade | Crawler | Issue | PR |
 |:-:|--------|:-------:|:------:|:------:|
 | 1 | São Paulo | | [issue](https://github.com/okfn-brasil/diario-oficial/issues/7) | |
@@ -30,7 +31,7 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 | 20 | Campo Grande | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/35) |
 | 21 | Teresina | :white_check_mark: | [issue](https://github.com/okfn-brasil/diario-oficial/issues/188)| [PR](https://github.com/okfn-brasil/diario-oficial/pull/216) |
 | 22 | São Bernardo do Campo | | | |
-| 23 | João Pessoa | :soon: | | |
+| 23 | João Pessoa | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/72) |
 | 24 | Nova Iguaçu | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/120) |
 | 25 | Santo André | | | |
 | 26 | São José dos Campos | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/71) |

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -7,7 +7,7 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class PbJoaoPessoaSpider(BaseGazetteSpider):
-    MUNICIPALITY_ID = '2507507'
+    TERRITORY_ID = '2507507'
 
     EXTRA_EDITION_CSS = 'td:first-child'
     GAZETTE_ROW_CSS = '.table-semanarios table tbody tr'
@@ -24,7 +24,7 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
         """
         @url http://www.joaopessoa.pb.gov.br/semanariooficial/
         @returns requests 1
-        @scrapes date file_urls is_extra_edition municipality_id power scraped_at
+        @scrapes date file_urls is_extra_edition territory_id power scraped_at
         """
 
         for element in response.css(self.GAZETTE_ROW_CSS):
@@ -37,7 +37,7 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra_edition,
-                territory_id=self.MUNICIPALITY_ID,
+                territory_id=self.TERRITORY_ID,
                 power='executive_legislature',
                 scraped_at=datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -7,18 +7,18 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class PbJoaoPessoaSpider(BaseGazetteSpider):
-    TERRITORY_ID = '2507507'
+    TERRITORY_ID = "2507507"
 
-    EXTRA_EDITION_CSS = 'td:first-child'
-    GAZETTE_ROW_CSS = '.table-semanarios table tbody tr'
-    GAZETTE_URL_CSS = 'td:last-child a::attr(href)'
-    NEXT_PAGE_CSS = '.pagination a.next::attr(href)'
-    DATE_CSS = 'td:nth-last-child(2)::text'
-    DATE_REGEX = r'[0-9]{2}/[0-9]{2}/[0-9]{4}'
+    EXTRA_EDITION_CSS = "td:first-child"
+    GAZETTE_ROW_CSS = ".table-semanarios table tbody tr"
+    GAZETTE_URL_CSS = "td:last-child a::attr(href)"
+    NEXT_PAGE_CSS = ".pagination a.next::attr(href)"
+    DATE_CSS = "td:nth-last-child(2)::text"
+    DATE_REGEX = r"[0-9]{2}/[0-9]{2}/[0-9]{4}"
 
-    allowed_domains = ['www.joaopessoa.pb.gov.br']
-    name = 'pb_joao_pessoa'
-    start_urls = ['http://www.joaopessoa.pb.gov.br/semanariooficial/']
+    allowed_domains = ["www.joaopessoa.pb.gov.br"]
+    name = "pb_joao_pessoa"
+    start_urls = ["http://www.joaopessoa.pb.gov.br/semanariooficial/"]
 
     def parse(self, response):
         """
@@ -30,15 +30,15 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
         for element in response.css(self.GAZETTE_ROW_CSS):
             url = element.css(self.GAZETTE_URL_CSS).extract_first()
             date = element.css(self.DATE_CSS).re(self.DATE_REGEX).pop()
-            date = dateparser.parse(date, languages=['pt']).date()
-            is_extra_edition = 'Especial' in element.css(self.EXTRA_EDITION_CSS).extract_first()
+            date = dateparser.parse(date, languages=["pt"]).date()
+            is_extra = "Especial" in element.css(self.EXTRA_EDITION_CSS).extract_first()
 
             yield Gazette(
                 date=date,
                 file_urls=[url],
-                is_extra_edition=is_extra_edition,
+                is_extra_edition=is_extra,
                 territory_id=self.TERRITORY_ID,
-                power='executive_legislature',
+                power="executive_legislature",
                 scraped_at=datetime.utcnow(),
             )
 

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -24,7 +24,7 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
 
         Normal gazettes are displayed in a weekly basis, so, the date which is taken
         into account for this type of gazette is the last in the publication period
-        (i.e. "29/08/2020" from "23/08/2020 à 29/08/2020").
+        (i.e. "29/08/2020" from "23/08/2020 to 29/08/2020").
 
         Special gazzetes are daily, but that same logic applies here and it works
         correctly.

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -1,6 +1,7 @@
+from datetime import datetime
+
 import dateparser
 
-from datetime import datetime
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -15,13 +15,12 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
     DATE_CSS = "td:nth-last-child(2)::text"
     DATE_REGEX = r"[0-9]{2}/[0-9]{2}/[0-9]{4}"
 
-    allowed_domains = ["www.joaopessoa.pb.gov.br"]
     name = "pb_joao_pessoa"
-    start_urls = ["http://www.joaopessoa.pb.gov.br/semanariooficial/"]
+    start_urls = ["http://antigo.joaopessoa.pb.gov.br/semanariooficial/"]
 
     def parse(self, response):
         """
-        @url http://www.joaopessoa.pb.gov.br/semanariooficial/
+        @url http://antigo.joaopessoa.pb.gov.br/semanariooficial/
         @returns items 10
         @returns requests 1
         @scrapes date file_urls is_extra_edition territory_id power scraped_at

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -19,11 +19,14 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
     start_urls = ["http://antigo.joaopessoa.pb.gov.br/semanariooficial/"]
 
     def parse(self, response):
-        """
-        @url http://antigo.joaopessoa.pb.gov.br/semanariooficial/
-        @returns items 10
-        @returns requests 1
-        @scrapes date file_urls is_extra_edition territory_id power scraped_at
+        """Parses gazettes page and requests next page.
+
+        Normal gazettes are displayed in a weekly basis, so, the date which is taken
+        into account for this type of gazette is the last in the publication period
+        (i.e. "29/08/2020" from "23/08/2020 à 29/08/2020").
+
+        Special gazzetes are daily, but that same logic applies here and it works
+        correctly.
         """
 
         for element in response.css(self.GAZETTE_ROW_CSS):

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -3,9 +3,10 @@ import dateparser
 from datetime import datetime
 from scrapy import Request, Spider
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class PbJoaoPessoaSpider(Spider):
+class PbJoaoPessoaSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '2507507'
 
     EXTRA_EDITION_CSS = 'td:first-child'

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -1,7 +1,6 @@
 import dateparser
 
 from datetime import datetime
-from scrapy import Request, Spider
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
@@ -23,6 +22,7 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
     def parse(self, response):
         """
         @url http://www.joaopessoa.pb.gov.br/semanariooficial/
+        @returns items 10
         @returns requests 1
         @scrapes date file_urls is_extra_edition territory_id power scraped_at
         """
@@ -43,4 +43,4 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
             )
 
         for url in response.css(self.NEXT_PAGE_CSS).extract():
-            yield Request(url)
+            yield response.follow(url)

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -1,0 +1,45 @@
+import dateparser
+
+from datetime import datetime
+from scrapy import Request, Spider
+from gazette.items import Gazette
+
+
+class PbJoaoPessoaSpider(Spider):
+    MUNICIPALITY_ID = '2507507'
+
+    EXTRA_EDITION_CSS = 'td:first-child'
+    GAZETTE_ROW_CSS = '.table-semanarios table tbody tr'
+    GAZETTE_URL_CSS = 'td:last-child a::attr(href)'
+    NEXT_PAGE_CSS = '.pagination a.next::attr(href)'
+    DATE_CSS = 'td:nth-last-child(2)::text'
+    DATE_REGEX = r'[0-9]{2}/[0-9]{2}/[0-9]{4}'
+
+    allowed_domains = ['www.joaopessoa.pb.gov.br']
+    name = 'pb_joao_pessoa'
+    start_urls = ['http://www.joaopessoa.pb.gov.br/semanariooficial/']
+
+    def parse(self, response):
+        """
+        @url http://www.joaopessoa.pb.gov.br/semanariooficial/
+        @returns requests 1
+        @scrapes date file_urls is_extra_edition municipality_id power scraped_at
+        """
+
+        for element in response.css(self.GAZETTE_ROW_CSS):
+            url = element.css(self.GAZETTE_URL_CSS).extract_first()
+            date = element.css(self.DATE_CSS).re(self.DATE_REGEX).pop()
+            date = dateparser.parse(date, languages=['pt']).date()
+            is_extra_edition = 'Especial' in element.css(self.EXTRA_EDITION_CSS).extract_first()
+
+            yield Gazette(
+                date=date,
+                file_urls=[url],
+                is_extra_edition=is_extra_edition,
+                territory_id=self.MUNICIPALITY_ID,
+                power='executive_legislature',
+                scraped_at=datetime.utcnow(),
+            )
+
+        for url in response.css(self.NEXT_PAGE_CSS).extract():
+            yield Request(url)


### PR DESCRIPTION
This finishes the spider for João Pessoa. Just a rebase and a URL change was needed.

I changed the docstring since spider contracts are not used.

Also, I think the "Special Editions" being extracted as "Extra Editions" are not correct, but I'd prefer if someone else could clarify that. I believe that special editions are editions that have a publication date outside of the normal schedule. And extra editions are editions that are published in the same date as another "already published" edition.

This is motivated by #221 .

Closes #186 .