### PR TITLE
Inserted Guidelines to maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,6 @@ This section is a space for project maintainers, since as code review and reposi
 ### Responsibilities of a Querido Diario maintainer:
 
 - Respect the [code of conduct](https://github.com/okfn-brasil/querido-diario/blob/main/CODE_OF_CONDUCT.md) and ensure that anyone who may have suffered harassment has a help channel.
-- Manage the labels to avoid rework and conflict communication. ([CPython project](https://github.com/python/cpython/pulls) as a reference)
-    - *awaiting review*
-    - *awaiting changes*
-    - *awaiting merge*
 - Always justify a suggestion according to the practices already adopted in the project, legibility and simplicity. It is essential for a civil project to have a structure as easy as possible for beginners.
+- The maintainers should **run all the spiders before merging it**.
+- If a Pull Request have many commits and their messages are not clear, use the *Squash and merge* option. It is not necessary to do squash when the commits discipline is good, as an example: [Pull Request](https://github.com/okfn-brasil/querido-diario/pull/252/commits).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,3 +52,16 @@ $ black .
 ```
 
 It is important to note that the CI will fail if you commit Python code that is not in accordance with Black code style.
+
+## Guidelines to maintainers
+
+This section is a space for project maintainers, since as code review and repository organization are part of the contribution process, all code review guidelines are of public interest to anyone in the community.
+
+### Responsibilities of a Querido Diario maintainer:
+
+- Respect the [code of conduct](https://github.com/okfn-brasil/querido-diario/blob/main/CODE_OF_CONDUCT.md) and ensure that anyone who may have suffered harassment has a help channel.
+- Manage the labels to avoid rework and conflict communication. ([CPython project](https://github.com/python/cpython/pulls) as a reference)
+    - *awaiting review*
+    - *awaiting changes*
+    - *awaiting merge*
+- Always justify a suggestion according to the practices already adopted in the project, legibility and simplicity. It is essential for a civil project to have a structure as easy as possible for beginners.


### PR DESCRIPTION
I could open an issue to discuss this, but I have adopted a philosophy of starting a discussion with a proposal.

I created this chapter to propose an organization for the project maintainers. The idea is that it is not legislation with multiple responsibilities, but a guide that facilitates communication and reduces rework.

I do this when we invite @giuliocc to compose our team of maintainers. :1st_place_medal:  Thus, we are growing and creating a working model to prevent distress to people as generous as Querido Diario maintainers.

"There is a criteria I call change latency, which is the round-trip time from identifying a problem to testing a solution. The faster the better. If maintainers cannot respond to pull requests as rapidly as people expect, they're not doing their job (or they need more hands)." (Peter Hintjens)
https://hintjens.gitbooks.io/social-architecture/content/chapter4.html

I would like opinions: @jvanz @rennerocha