### PR TITLE
Add edition number field

### DIFF
--- a/processing/data_collection/gazette/items.py
+++ b/processing/data_collection/gazette/items.py
@@ -4,6 +4,7 @@ import scrapy
 class Gazette(scrapy.Item):
     source_text = scrapy.Field()
     date = scrapy.Field()
+    edition_number = scrapy.Field()
     file_checksum = scrapy.Field()
     file_path = scrapy.Field()
     file_url = scrapy.Field()

--- a/processing/data_collection/gazette/spiders/sc_florianopolis.py
+++ b/processing/data_collection/gazette/spiders/sc_florianopolis.py
@@ -36,8 +36,11 @@ class ScFlorianopolisSpider(BaseGazetteSpider):
             if hasattr(self, "start_date") and gazette_date < self.start_date:
                 continue
 
+            gazette_edition_number = link.css("::attr(title)").re_first(r"Edição (\d+)")
+
             yield Gazette(
                 date=gazette_date,
+                edition_number=gazette_edition_number,
                 file_urls=(url,),
                 is_extra_edition=self.is_extra(link),
                 territory_id=self.TERRITORY_ID,

--- a/processing/database/models.py
+++ b/processing/database/models.py
@@ -38,6 +38,7 @@ class Gazette(DeclarativeBase):
     id = Column(Integer, primary_key=True)
     source_text = Column(Text)
     date = Column(Date)
+    edition_number = Column(String)
     is_extra_edition = Column(Boolean)
     is_parsed = Column(Boolean, default=False)
     power = Column(String)


### PR DESCRIPTION
Practically all cities provides the edition number of gazettes and we weren't collecting it.
As usually this is something easy to collect and it seems useful to be able to find a gazette with another property, we should start collecting it. 
I updated just one spider for testing, but we will need to update all spiders to include this field.