### PR TITLE
Doc: Improved Troubleshooting section on README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,21 @@ execute the follow command and do logout and login:
 ```console
 $ sudo usermod -aG docker $USER
 ```
+
+### ImportError: cannot import name 'main'
+
+A error like this can occour when you run `pip3 install -r requirements.txt`,
+which is a step from build (`make setup`). This means you must have
+inadvertently upgraded your system pip (probably through something like
+`sudo pip install pip --upgrade`)
+
+To recover the pip3 binary you'll need to run (on Debian-based systems. On
+non-Debian system, replace `apt` by the specific package manager):
+
+```console
+$ sudo python3 -m pip uninstall pip && sudo apt install python3-pip --reinstall
+```
+
 ### "Permission denied" error when files are downloaded
 
 This problem most probably occurs due to a mismatch between your system's user id and the container's user id and there is a volume in place connecting both file systems (that's the default case here).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Table of Contents
   * [Tips and tricks](#tips-and-tricks)
   * [Troubleshooting](#troubleshooting)
      * [Non-specific errors when building or running](#non-specific-errors-when-building-or-running)
-     * [ImportError: cannot import name 'main'](importerror-cannot-import-name-main)
+     * [ImportError: cannot import name 'main'](#importerror-cannot-import-name-main)
      * ["Permission denied" error when gazette files are downloaded](#permission-denied-error-when-gazette-files-are-downloaded)
   * [Contributing](#contributing)
   * [Acknowledgments](#acknowledgments)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ $ make setup
 $ docker-compose up
 ```
 
+If you get some error here, see the section [Troubleshooting](#troubleshooting)
+below.
+
 ### Run Gazette Crawler
 
 The gazettes spiders are written using Scrapy framework and must be executed with crawl command: `scrapy crawl <spider filename>`.
@@ -74,6 +77,13 @@ SPIDER=sc_florianopolis make run_spider
 
 ## Troubleshooting
 
+### Non-specific errors when building or running
+Several error is because your user don't is from docker group. To resolve this,
+execute the follow command and do logout and login:
+
+```console
+$ sudo usermod -aG docker $USER
+```
 ### "Permission denied" error when files are downloaded
 
 This problem most probably occurs due to a mismatch between your system's user id and the container's user id and there is a volume in place connecting both file systems (that's the default case here).
@@ -87,6 +97,7 @@ $ id -u
 Copy the output, replace the value of the environment variable `LOCAL_USER_ID` in the generated `.env` file with the copied value and execute `docker-compose build`. With the image rebuilt you are ready to go.
 
 To save yourself this effort in the future, you can replace the value of `LOCAL_USER_ID` in `.env.example` too and `.env` will already be generated with the correct value for it when `make setup` is executed.
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Table of Contents
      * [Run Gazette Crawler](#run-gazette-crawler)
   * [Tips and tricks](#tips-and-tricks)
   * [Troubleshooting](#troubleshooting)
-     * ["Permission denied" error when files are downloaded](#permission-denied-error-when-files-are-downloaded)
+     * [Non-specific errors when building or running](#non-specific-errors-when-building-or-running)
+     * [ImportError: cannot import name 'main'](importerror-cannot-import-name-main)
+     * ["Permission denied" error when gazette files are downloaded](#permission-denied-error-when-gazette-files-are-downloaded)
   * [Contributing](#contributing)
   * [Acknowledgments](#acknowledgments)
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ SPIDER=sc_florianopolis make run_spider
 ## Troubleshooting
 
 ### Non-specific errors when building or running
-Several error is because your user don't is from docker group. To resolve this,
+Several error is because your user is not in the docker group. To resolve this,
 execute the follow command and do logout and login:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ non-Debian system, replace `apt` by the specific package manager):
 $ sudo python3 -m pip uninstall pip && sudo apt install python3-pip --reinstall
 ```
 
-### "Permission denied" error when files are downloaded
+### "Permission denied" error when gazette files are downloaded
 
 This problem most probably occurs due to a mismatch between your system's user id and the container's user id and there is a volume in place connecting both file systems (that's the default case here).
 


### PR DESCRIPTION
This PR improved Troubleshooting section on README by:

- Added instruction to add user to docker group to resolv non-specific errors
- Added instruction to restore pip if need
- Removed a ambiguity in a subsection title