### PR TITLE
Removes from the spiders the autogenerated gazette fields

### DIFF
--- a/processing/data_collection/gazette/spiders/al_maceio.py
+++ b/processing/data_collection/gazette/spiders/al_maceio.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import scrapy
 from dateparser import parse
 

--- a/processing/data_collection/gazette/spiders/al_maceio.py
+++ b/processing/data_collection/gazette/spiders/al_maceio.py
@@ -53,7 +53,5 @@ class AlMaceioSpider(BaseGazetteSpider):
             date=date,
             file_urls=[url],
             is_extra_edition=is_extra_edition,
-            territory_id=self.TERRITORY_ID,
             power="executive_legislature",
-            scraped_at=datetime.utcnow(),
         )

--- a/processing/data_collection/gazette/spiders/am_manaus.py
+++ b/processing/data_collection/gazette/spiders/am_manaus.py
@@ -66,10 +66,5 @@ class AmManausSpider(BaseGazetteSpider):
 
     def build_gazzete(self, date, url, power, is_extra_edition=False):
         return Gazette(
-            date=date,
-            file_urls=[url],
-            is_extra_edition=is_extra_edition,
-            territory_id=self.TERRITORY_ID,
-            power=power,
-            scraped_at=datetime.utcnow(),
+            date=date, file_urls=[url], is_extra_edition=is_extra_edition, power=power,
         )

--- a/processing/data_collection/gazette/spiders/am_manaus.py
+++ b/processing/data_collection/gazette/spiders/am_manaus.py
@@ -1,6 +1,5 @@
 import dateparser
 
-from datetime import datetime
 from scrapy import Request
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider

--- a/processing/data_collection/gazette/spiders/ap_macapa.py
+++ b/processing/data_collection/gazette/spiders/ap_macapa.py
@@ -66,7 +66,5 @@ class ApMacapaSpider(BaseGazetteSpider):
                 date=gazette_date,
                 file_urls=[file_url],
                 is_extra_edition=(index > 0),
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislative",
-                scraped_at=dt.datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/ba_feira_de_santana.py
+++ b/processing/data_collection/gazette/spiders/ba_feira_de_santana.py
@@ -29,9 +29,7 @@ class BaFeiraDeSantanaSpider(BaseGazetteSpider):
             gazette = Gazette(
                 date=parse(date, languages=["pt"]).date(),
                 is_extra_edition=False,
-                territory_id=self.TERRITORY_ID,
                 power=power,
-                scraped_at=dt.datetime.utcnow(),
             )
 
             gazette_details_page = f"abrir.asp?edi={edition}&p={power_id}"

--- a/processing/data_collection/gazette/spiders/ba_feira_de_santana.py
+++ b/processing/data_collection/gazette/spiders/ba_feira_de_santana.py
@@ -1,5 +1,4 @@
 from dateparser import parse
-import datetime as dt
 import scrapy
 from scrapy.http import Request
 

--- a/processing/data_collection/gazette/spiders/ba_salvador.py
+++ b/processing/data_collection/gazette/spiders/ba_salvador.py
@@ -65,11 +65,7 @@ class BaSalvadorSpider(BaseGazetteSpider):
         pdf_url = response.css("#PDFId embed::attr(src)").extract_first()
 
         yield Gazette(
-            date=parsed_date.date(),
-            file_urls=[pdf_url],
-            territory_id=self.TERRITORY_ID,
-            power=self.power,
-            scraped_at=datetime.datetime.utcnow(),
+            date=parsed_date.date(), file_urls=[pdf_url], power=self.power,
         )
 
 

--- a/processing/data_collection/gazette/spiders/ba_vitoria_da_conquista.py
+++ b/processing/data_collection/gazette/spiders/ba_vitoria_da_conquista.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date
 from dateparser import parse
 
 import scrapy

--- a/processing/data_collection/gazette/spiders/ba_vitoria_da_conquista.py
+++ b/processing/data_collection/gazette/spiders/ba_vitoria_da_conquista.py
@@ -34,7 +34,5 @@ class BaVitoriaDaConquistaSpider(BaseGazetteSpider):
                 date=parsing_date,
                 file_urls=[url],
                 is_extra_edition=False,
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
-                scraped_at=datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/base.py
+++ b/processing/data_collection/gazette/spiders/base.py
@@ -35,7 +35,7 @@ class SigpubGazetteSpider(BaseGazetteSpider):
 
     Documents obtained by this kind of spider are text-PDFs with many cities in it.
     That's because the websites are usually made for associations of cities.
-    
+
     TODO:
         - All variations have a "possible" start date of 01/01/2009, but that may cause
         many unnecessary requests to be made if they actually start making available
@@ -92,10 +92,8 @@ class SigpubGazetteSpider(BaseGazetteSpider):
             yield Gazette(
                 date=meta["date"].date(),
                 file_urls=[url],
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislative",
                 is_extra_edition=(meta["edition_type"] == "extra"),
-                scraped_at=datetime.utcnow(),
                 edition_number=edition.get("numero_edicao", ""),
             )
 
@@ -187,6 +185,4 @@ class FecamGazetteSpider(BaseGazetteSpider):
         return Gazette(
             date=dateparser.parse(document[1], languages=("pt",)).date(),
             file_urls=(document[0],),
-            territory_id=self.TERRITORY_ID,
-            scraped_at=datetime.utcnow(),
         )

--- a/processing/data_collection/gazette/spiders/ce_fortaleza.py
+++ b/processing/data_collection/gazette/spiders/ce_fortaleza.py
@@ -39,9 +39,7 @@ class CeFortalezaSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=extra_edition,
-                territory_id=self.TERRITORY_ID,
                 power="executive",
-                scraped_at=datetime.utcnow(),
             )
 
         for page_number in response.css(self.NEXT_PAGE_CSS).re("#(\d)+"):

--- a/processing/data_collection/gazette/spiders/df_brasilia.py
+++ b/processing/data_collection/gazette/spiders/df_brasilia.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import re
 
 import dateparser

--- a/processing/data_collection/gazette/spiders/df_brasilia.py
+++ b/processing/data_collection/gazette/spiders/df_brasilia.py
@@ -78,7 +78,5 @@ class DfBrasiliaSpider(BaseGazetteSpider):
             date=date,
             file_urls=file_urls,
             is_extra_edition=is_extra_edition,
-            territory_id=self.TERRITORY_ID,
-            scraped_at=datetime.utcnow(),
             power="executive_legislative",
         )

--- a/processing/data_collection/gazette/spiders/es_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/es_associacao_municipios.py
@@ -1,5 +1,4 @@
 from dateparser import parse
-import datetime as dt
 
 import scrapy
 

--- a/processing/data_collection/gazette/spiders/es_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/es_associacao_municipios.py
@@ -19,12 +19,7 @@ class EsAssociacaoMunicipiosSpider(BaseGazetteSpider):
             date = gazette_node.css("td::text")[1].extract()
             date = parse(date, languages=["pt"]).date()
             yield Gazette(
-                date=date,
-                file_urls=[url],
-                is_extra_edition=False,
-                territory_id=self.TERRITORY_ID,
-                power="executive",
-                scraped_at=dt.datetime.utcnow(),
+                date=date, file_urls=[url], is_extra_edition=False, power="executive",
             )
 
         css_path = ".pagination .next:not(.disabled) a::attr(href)"

--- a/processing/data_collection/gazette/spiders/go_aparecida_de_goiania.py
+++ b/processing/data_collection/gazette/spiders/go_aparecida_de_goiania.py
@@ -1,4 +1,3 @@
-import datetime as dt
 import json
 
 import scrapy

--- a/processing/data_collection/gazette/spiders/go_aparecida_de_goiania.py
+++ b/processing/data_collection/gazette/spiders/go_aparecida_de_goiania.py
@@ -24,10 +24,5 @@ class GoAparecidaDeGoianiaSpider(BaseGazetteSpider):
             date = parse(record["publicado"], languages=["en"]).date()
 
             yield Gazette(
-                date=date,
-                file_urls=[url],
-                is_extra_edition=False,
-                territory_id=self.TERRITORY_ID,
-                power=power,
-                scraped_at=dt.datetime.utcnow(),
+                date=date, file_urls=[url], is_extra_edition=False, power=power,
             )

--- a/processing/data_collection/gazette/spiders/go_goiania.py
+++ b/processing/data_collection/gazette/spiders/go_goiania.py
@@ -50,9 +50,7 @@ class GoGoianiaSpider(BaseGazetteSpider):
                     date=date,
                     file_urls=[url],
                     is_extra_edition=is_extra_edition,
-                    territory_id=self.TERRITORY_ID,
                     power=power,
-                    scraped_at=dt.datetime.utcnow(),
                 )
             )
         return items

--- a/processing/data_collection/gazette/spiders/instar_base.py
+++ b/processing/data_collection/gazette/spiders/instar_base.py
@@ -32,7 +32,5 @@ class BaseInstarSpider(BaseGazetteSpider):
                 date=parse(date, languages=["pt"]).date(),
                 file_urls=[response.urljoin(href)],
                 is_extra_edition=is_extra_edition,
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
-                scraped_at=dt.datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/instar_base.py
+++ b/processing/data_collection/gazette/spiders/instar_base.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 from dateparser import parse
 from scrapy import Request
 

--- a/processing/data_collection/gazette/spiders/mg_contagem.py
+++ b/processing/data_collection/gazette/spiders/mg_contagem.py
@@ -15,7 +15,7 @@ class MgContagemSpider(BaseGazetteSpider):
         """
         @url http://www.contagem.mg.gov.br/?se=doc&pagina=2
         @returns items 15 15
-        @scrapes date file_urls is_extra_edition territory_id power scraped_at
+        @scrapes date file_urls is_extra_edition power
         """
         anchor_elements = response.css(".texto11pt a")
 
@@ -38,9 +38,7 @@ class MgContagemSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra_edition,
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
-                scraped_at=dt.datetime.utcnow(),
             )
 
         number_of_pages = int(

--- a/processing/data_collection/gazette/spiders/mg_contagem.py
+++ b/processing/data_collection/gazette/spiders/mg_contagem.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 import dateparser
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider

--- a/processing/data_collection/gazette/spiders/mg_uberaba.py
+++ b/processing/data_collection/gazette/spiders/mg_uberaba.py
@@ -50,9 +50,7 @@ class MgUberaba(BaseGazetteSpider):
                 date=date,
                 file_urls=[self.mount_url(filename, date.year)],
                 is_extra_edition=False,
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
-                scraped_at=dt.datetime.utcnow(),
             )
 
     def extract_date(self, filename):

--- a/processing/data_collection/gazette/spiders/ms_campo_grande.py
+++ b/processing/data_collection/gazette/spiders/ms_campo_grande.py
@@ -42,7 +42,5 @@ class MsCampoGrandeSpider(BaseGazetteSpider):
                 date=gazette_date,
                 file_urls=[gazette_url],
                 is_extra_edition=is_extra_edition,
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
-                scraped_at=datetime.datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/mt_cuiaba.py
+++ b/processing/data_collection/gazette/spiders/mt_cuiaba.py
@@ -45,7 +45,5 @@ class MtCuiabaSpider(BaseGazetteSpider):
                 date=parse(edition_date, languages=["pt"]),
                 file_urls=[edition_url],
                 is_extra_edition=edition["suplement"],
-                territory_id=self.TERRITORY_ID,
                 power="executive",
-                scraped_at=datetime.datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/pa_belem.py
+++ b/processing/data_collection/gazette/spiders/pa_belem.py
@@ -1,5 +1,4 @@
 import json
-from datetime import datetime
 
 import requests
 import scrapy

--- a/processing/data_collection/gazette/spiders/pa_belem.py
+++ b/processing/data_collection/gazette/spiders/pa_belem.py
@@ -40,7 +40,7 @@ class PaBelemSpider(BaseGazetteSpider):
         """
         @url https://sistemas.belem.pa.gov.br/diario-consulta-api/diarios?start=0&rows={x]
         @returns requests 1
-        @scrapes date file_urls is_extra_edition territory_id power scraped_at
+        @scrapes date file_urls is_extra_edition power
         """
 
         data = json.loads(response.body)["response"]
@@ -55,7 +55,5 @@ class PaBelemSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=bool(None),
-                territory_id=self.TERRITORY_ID,
                 power="executive",
-                scraped_at=datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 import dateparser
-
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
@@ -40,9 +39,7 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra,
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
-                scraped_at=datetime.utcnow(),
             )
 
         for url in response.css(self.NEXT_PAGE_CSS).extract():

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import dateparser
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider

--- a/processing/data_collection/gazette/spiders/pe_recife.py
+++ b/processing/data_collection/gazette/spiders/pe_recife.py
@@ -73,9 +73,7 @@ class PeRecifeSpider(BaseGazetteSpider):
             yield Gazette(
                 date=date,
                 file_urls=[url],
-                territory_id=self.TERRITORY_ID,
                 is_extra_edition=self._is_extra(edition),
-                scraped_at=dt.datetime.utcnow(),
                 power="executive_legislative",
             )
 

--- a/processing/data_collection/gazette/spiders/pi_teresina.py
+++ b/processing/data_collection/gazette/spiders/pi_teresina.py
@@ -1,5 +1,4 @@
 import math
-from datetime import datetime
 from urllib.parse import urlencode
 
 import dateparser

--- a/processing/data_collection/gazette/spiders/pi_teresina.py
+++ b/processing/data_collection/gazette/spiders/pi_teresina.py
@@ -35,9 +35,5 @@ class PiTeresina(BaseGazetteSpider):
             date = dateparser.parse(date_text, languages=["pt"]).date()
 
             yield Gazette(
-                date=date,
-                file_urls=file_urls,
-                territory_id=self.TERRITORY_ID,
-                power="executive_legislative",
-                scraped_at=datetime.utcnow(),
+                date=date, file_urls=file_urls, power="executive_legislative",
             )

--- a/processing/data_collection/gazette/spiders/pr_cascavel.py
+++ b/processing/data_collection/gazette/spiders/pr_cascavel.py
@@ -22,12 +22,7 @@ class PrCascavelSpider(BaseGazetteSpider):
                 power = "executive" if "Executivo" in link_text else "legislature"
                 url = response.urljoin(link.xpath("./@href").extract_first(""))
                 yield Gazette(
-                    date=date,
-                    file_urls=[url],
-                    is_extra_edition=False,
-                    territory_id=self.TERRITORY_ID,
-                    power=power,
-                    scraped_at=dt.datetime.utcnow(),
+                    date=date, file_urls=[url], is_extra_edition=False, power=power,
                 )
         next_page_xpath = '//a[@title="Próxima página"]/@href'
         next_page_url = response.xpath(next_page_xpath).extract_first()

--- a/processing/data_collection/gazette/spiders/pr_cascavel.py
+++ b/processing/data_collection/gazette/spiders/pr_cascavel.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from dateparser import parse
-import datetime as dt
 
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider

--- a/processing/data_collection/gazette/spiders/pr_curitiba.py
+++ b/processing/data_collection/gazette/spiders/pr_curitiba.py
@@ -53,7 +53,10 @@ class PrCuritibaSpider(BaseGazetteSpider):
                     "ctl00_cphMasterPrincipal_TabContalegacyDealPooliner1_ClientState": '{{"ActiveTabIndex":{},"TabState":[true,true,true,true,true,true,true,true,true,true,true,true]}}',
                 }
                 yield scrapy.FormRequest.from_response(
-                    response, formdata=formdata, meta={"month": month}, callback=self.parse_month,
+                    response,
+                    formdata=formdata,
+                    meta={"month": month},
+                    callback=self.parse_month,
                 )
 
     def parse_month(self, response):
@@ -81,7 +84,9 @@ class PrCuritibaSpider(BaseGazetteSpider):
             pdf_date = row.css("td:nth-child(2) span ::text").extract_first()
             gazette_id = row.css("td:nth-child(3) a ::attr(data-teste)").extract_first()
             parsed_date = parse(f"{pdf_date}", languages=["pt"]).date()
-            eventtarget = row.css("td:nth-child(3) a ::attr(href)").re_first("'(.*lnkVisualizar)'")
+            eventtarget = row.css("td:nth-child(3) a ::attr(href)").re_first(
+                "'(.*lnkVisualizar)'"
+            )
             if gazette_id == "0":
                 yield scrapy.FormRequest.from_response(
                     response,

--- a/processing/data_collection/gazette/spiders/pr_curitiba.py
+++ b/processing/data_collection/gazette/spiders/pr_curitiba.py
@@ -10,9 +10,8 @@ keys dynamically as they are hidden inputs in the page.
 
 from datetime import date
 
-from dateparser import parse
 import scrapy
-
+from dateparser import parse
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
@@ -54,10 +53,7 @@ class PrCuritibaSpider(BaseGazetteSpider):
                     "ctl00_cphMasterPrincipal_TabContalegacyDealPooliner1_ClientState": '{{"ActiveTabIndex":{},"TabState":[true,true,true,true,true,true,true,true,true,true,true,true]}}',
                 }
                 yield scrapy.FormRequest.from_response(
-                    response,
-                    formdata=formdata,
-                    meta={"month": month},
-                    callback=self.parse_month,
+                    response, formdata=formdata, meta={"month": month}, callback=self.parse_month,
                 )
 
     def parse_month(self, response):
@@ -85,9 +81,7 @@ class PrCuritibaSpider(BaseGazetteSpider):
             pdf_date = row.css("td:nth-child(2) span ::text").extract_first()
             gazette_id = row.css("td:nth-child(3) a ::attr(data-teste)").extract_first()
             parsed_date = parse(f"{pdf_date}", languages=["pt"]).date()
-            eventtarget = row.css("td:nth-child(3) a ::attr(href)").re_first(
-                "'(.*lnkVisualizar)'"
-            )
+            eventtarget = row.css("td:nth-child(3) a ::attr(href)").re_first("'(.*lnkVisualizar)'")
             if gazette_id == "0":
                 yield scrapy.FormRequest.from_response(
                     response,

--- a/processing/data_collection/gazette/spiders/pr_curitiba.py
+++ b/processing/data_collection/gazette/spiders/pr_curitiba.py
@@ -8,7 +8,7 @@ That's why so many `FormRequest.from_response` are necessary, to catch those for
 keys dynamically as they are hidden inputs in the page.
 """
 
-from datetime import date, datetime
+from datetime import date
 
 from dateparser import parse
 import scrapy
@@ -102,9 +102,7 @@ class PrCuritibaSpider(BaseGazetteSpider):
                         f"https://legisladocexterno.curitiba.pr.gov.br/DiarioSuplementoConsultaExterna_Download.aspx?Id={gazette_id}"
                     ],
                     is_extra_edition=True,
-                    territory_id=self.TERRITORY_ID,
-                    power="executive_legislative",
-                    scraped_at=datetime.utcnow(),
+                    power="executive_legislature",
                 )
 
     def parse_regular_edition(self, response):
@@ -117,7 +115,5 @@ class PrCuritibaSpider(BaseGazetteSpider):
                 f"https://legisladocexterno.curitiba.pr.gov.br/DiarioConsultaExterna_Download.aspx?Id={gazette_id}"
             ],
             is_extra_edition=False,
-            territory_id=self.TERRITORY_ID,
-            power="executive_legislative",
-            scraped_at=datetime.utcnow(),
+            power="executive_legislature",
         )

--- a/processing/data_collection/gazette/spiders/pr_foz_do_iguacu.py
+++ b/processing/data_collection/gazette/spiders/pr_foz_do_iguacu.py
@@ -37,9 +37,7 @@ class PrFozDoIguacuSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[f"{self.BASE_URL}{url}"],
                 is_extra_edition=is_extra_edition,
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
-                scraped_at=dt.datetime.utcnow(),
             )
 
     @staticmethod

--- a/processing/data_collection/gazette/spiders/pr_londrina.py
+++ b/processing/data_collection/gazette/spiders/pr_londrina.py
@@ -33,9 +33,7 @@ class PrLondrina(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra,
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
-                scraped_at=dt.datetime.utcnow(),
             )
 
         for page in range(2, len(response.css(".button.othersOptPage")) + 1):

--- a/processing/data_collection/gazette/spiders/pr_londrina.py
+++ b/processing/data_collection/gazette/spiders/pr_londrina.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 from dateparser import parse
 from scrapy import FormRequest
 

--- a/processing/data_collection/gazette/spiders/pr_maringa.py
+++ b/processing/data_collection/gazette/spiders/pr_maringa.py
@@ -41,7 +41,5 @@ class PrMaringaSpider(BaseGazetteSpider):
                     f"http://venus.maringa.pr.gov.br/arquivos/orgao_oficial/arquivos/oom%20{gazette_id}.pdf"
                 ],
                 is_extra_edition=any(caracter.isalpha() for caracter in gazette_id),
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
-                scraped_at=datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/pr_maringa.py
+++ b/processing/data_collection/gazette/spiders/pr_maringa.py
@@ -1,5 +1,5 @@
 from dateparser import parse
-from datetime import date, datetime
+from datetime import date
 import re
 
 import scrapy

--- a/processing/data_collection/gazette/spiders/pr_ponta_grossa.py
+++ b/processing/data_collection/gazette/spiders/pr_ponta_grossa.py
@@ -32,9 +32,7 @@ class PrPontaGrossaSpider(BaseGazetteSpider):
                     date=gazette_date,
                     file_urls=[pdf_info["url"]],
                     is_extra_edition=pdf_info["is_extra_edition"],
-                    territory_id=self.TERRITORY_ID,
                     power="executive_legislature",
-                    scraped_at=datetime.utcnow(),
                 )
 
     @staticmethod

--- a/processing/data_collection/gazette/spiders/pr_ponta_grossa.py
+++ b/processing/data_collection/gazette/spiders/pr_ponta_grossa.py
@@ -1,5 +1,5 @@
 from dateparser import parse
-from datetime import date, datetime
+from datetime import date
 import re
 
 import scrapy

--- a/processing/data_collection/gazette/spiders/rj_campos_goytacazes.py
+++ b/processing/data_collection/gazette/spiders/rj_campos_goytacazes.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import re
 
 import dateparser

--- a/processing/data_collection/gazette/spiders/rj_campos_goytacazes.py
+++ b/processing/data_collection/gazette/spiders/rj_campos_goytacazes.py
@@ -23,7 +23,7 @@ class RjCampoGoytacazesSpider(BaseGazetteSpider):
         @url https://www.campos.rj.gov.br/diario-oficial.php?PGpagina=1&PGporPagina=15
         @returns requests 1
         @returns items 15 15
-        @scrapes date file_urls is_extra_edition municipality_id power scraped_at
+        @scrapes date file_urls is_extra_edition power
         """
 
         for element in response.css("ul.ul-licitacoes li"):
@@ -52,9 +52,7 @@ class RjCampoGoytacazesSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[path_to_gazette],
                 is_extra_edition=is_extra_edition,
-                territory_id=self.TERRITORY_ID,
                 power="executive",
-                scraped_at=datetime.utcnow(),
             )
 
         next_url = (

--- a/processing/data_collection/gazette/spiders/rj_nova_iguacu.py
+++ b/processing/data_collection/gazette/spiders/rj_nova_iguacu.py
@@ -24,7 +24,7 @@ class RjNovaIguacu(BaseGazetteSpider):
         """
         @url http://www.novaiguacu.rj.gov.br/diario-oficial/?data=2018-05-16
         @returns items 1 1
-        @scrapes date file_urls is_extra_edition territory_id power scraped_at
+        @scrapes date file_urls is_extra_edition power
         """
         link = response.css("div.caption h4 a")
         if not link:
@@ -33,10 +33,5 @@ class RjNovaIguacu(BaseGazetteSpider):
         date = link.re_first(r"\d{1,2}/\d{1,2}/\d{2}(?:\d{2})?")
         date = parse(date, languages=["pt"]).date()
         yield Gazette(
-            date=date,
-            file_urls=[url],
-            is_extra_edition=False,
-            territory_id=self.TERRITORY_ID,
-            power="executive",
-            scraped_at=dt.datetime.utcnow(),
+            date=date, file_urls=[url], is_extra_edition=False, power="executive",
         )

--- a/processing/data_collection/gazette/spiders/rj_rio_de_janeiro.py
+++ b/processing/data_collection/gazette/spiders/rj_rio_de_janeiro.py
@@ -2,7 +2,6 @@ import datetime
 
 import scrapy
 from dateutil.rrule import DAILY, rrule
-
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
@@ -39,7 +38,5 @@ class RjRioDeJaneiroSpider(BaseGazetteSpider):
                 date=gazette_date,
                 file_urls=[gazette_url],
                 is_extra_edition=is_extra_edition,
-                territory_id=self.TERRITORY_ID,
                 power="executive",
-                scraped_at=datetime.datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/rn_natal.py
+++ b/processing/data_collection/gazette/spiders/rn_natal.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date
 
 import dateparser
 from dateutil.rrule import rrule, MONTHLY

--- a/processing/data_collection/gazette/spiders/rn_natal.py
+++ b/processing/data_collection/gazette/spiders/rn_natal.py
@@ -41,7 +41,5 @@ class RnNatalSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[file_url],
                 is_extra_edition=extra_edition,
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislative",
-                scraped_at=datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/ro_porto_velho.py
+++ b/processing/data_collection/gazette/spiders/ro_porto_velho.py
@@ -40,7 +40,5 @@ class RoPortoVelho(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra_edition,
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
-                scraped_at=dt.datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/rr_boa_vista.py
+++ b/processing/data_collection/gazette/spiders/rr_boa_vista.py
@@ -33,10 +33,5 @@ class RrBoaVistaSpider(BaseGazetteSpider):
 
             power = "executive_legislature"
             yield Gazette(
-                date=date,
-                file_urls=[url],
-                is_extra_edition=False,
-                territory_id=self.TERRITORY_ID,
-                power=power,
-                scraped_at=dt.datetime.utcnow(),
+                date=date, file_urls=[url], is_extra_edition=False, power=power,
             )

--- a/processing/data_collection/gazette/spiders/rr_boa_vista.py
+++ b/processing/data_collection/gazette/spiders/rr_boa_vista.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 import scrapy
 import w3lib.url
 from dateparser import parse

--- a/processing/data_collection/gazette/spiders/rs_caxias_do_sul.py
+++ b/processing/data_collection/gazette/spiders/rs_caxias_do_sul.py
@@ -48,11 +48,7 @@ class RsCaxiasDoSulSpider(BaseGazetteSpider):
         date = parse(cells[1].extract(), languages=["pt"]).date()
         is_extra_edition = cells[2].extract() != "Normal"
         return Gazette(
-            date=date,
-            is_extra_edition=is_extra_edition,
-            territory_id=self.TERRITORY_ID,
-            power="executive_legislature",
-            scraped_at=dt.datetime.utcnow(),
+            date=date, is_extra_edition=is_extra_edition, power="executive_legislature",
         )
 
     def parse_pdf_page(self, response):

--- a/processing/data_collection/gazette/spiders/rs_gravatai.py
+++ b/processing/data_collection/gazette/spiders/rs_gravatai.py
@@ -1,5 +1,4 @@
 from dateparser import parse
-from datetime import datetime
 
 from scrapy import Request
 

--- a/processing/data_collection/gazette/spiders/rs_gravatai.py
+++ b/processing/data_collection/gazette/spiders/rs_gravatai.py
@@ -34,7 +34,7 @@ class RsGravataiSpider(BaseGazetteSpider):
         """
         @url https://gravatai.atende.net/?pg=diariooficial&pagina=1
         @returns items 1
-        @scrapes date file_urls is_extra_edition territory_id power scraped_at
+        @scrapes date file_urls is_extra_edition power
         """
 
         for element in response.css(".nova_listagem > .linha"):
@@ -58,7 +58,5 @@ class RsGravataiSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra_edition,
-                territory_id=self.TERRITORY_ID,
                 power="executive",
-                scraped_at=datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/rs_porto_alegre.py
+++ b/processing/data_collection/gazette/spiders/rs_porto_alegre.py
@@ -44,9 +44,7 @@ class RsPortoAlegreSpider(BaseGazetteSpider):
                     date=date,
                     file_urls=[url],
                     is_extra_edition=is_extra_edition,
-                    territory_id=self.TERRITORY_ID,
                     power=power,
-                    scraped_at=dt.datetime.utcnow(),
                 )
             )
         return items

--- a/processing/data_collection/gazette/spiders/sc_florianopolis.py
+++ b/processing/data_collection/gazette/spiders/sc_florianopolis.py
@@ -43,9 +43,7 @@ class ScFlorianopolisSpider(BaseGazetteSpider):
                 edition_number=gazette_edition_number,
                 file_urls=(url,),
                 is_extra_edition=self.is_extra(link),
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
-                scraped_at=datetime.utcnow(),
             )
 
     @staticmethod

--- a/processing/data_collection/gazette/spiders/sc_florianopolis.py
+++ b/processing/data_collection/gazette/spiders/sc_florianopolis.py
@@ -1,5 +1,5 @@
 import re
-from datetime import date, datetime
+from datetime import date
 
 from dateparser import parse
 from dateutil.relativedelta import relativedelta

--- a/processing/data_collection/gazette/spiders/sc_joinville.py
+++ b/processing/data_collection/gazette/spiders/sc_joinville.py
@@ -1,6 +1,5 @@
 import dateparser
 
-from datetime import datetime
 from scrapy import Request, Spider
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider

--- a/processing/data_collection/gazette/spiders/sc_joinville.py
+++ b/processing/data_collection/gazette/spiders/sc_joinville.py
@@ -24,7 +24,7 @@ class ScJoinvilleSpider(BaseGazetteSpider):
         """
         @url http://www.joinville.sc.gov.br/jornal/index/page/1
         @returns requests 1
-        @scrapes date file_urls is_extra_edition territory_id power scraped_at
+        @scrapes date file_urls is_extra_edition power
         """
 
         for element in response.css(self.GAZETTE_ELEMENT_CSS):
@@ -36,9 +36,7 @@ class ScJoinvilleSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra_edition,
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
-                scraped_at=datetime.utcnow(),
             )
 
         for url in response.css(self.NEXT_PAGE_CSS).extract():

--- a/processing/data_collection/gazette/spiders/sp_bauru.py
+++ b/processing/data_collection/gazette/spiders/sp_bauru.py
@@ -2,7 +2,6 @@
 from scrapy import Request
 from gazette.spiders.base import BaseGazetteSpider
 from gazette.items import Gazette
-from datetime import datetime
 import dateparser
 
 

--- a/processing/data_collection/gazette/spiders/sp_bauru.py
+++ b/processing/data_collection/gazette/spiders/sp_bauru.py
@@ -49,7 +49,5 @@ class SpBauruSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition="especial" in url.lower(),
-                territory_id=self.TERRITORY_ID,
-                scraped_at=datetime.utcnow(),
                 power="executive",
             )

--- a/processing/data_collection/gazette/spiders/sp_campinas.py
+++ b/processing/data_collection/gazette/spiders/sp_campinas.py
@@ -47,9 +47,7 @@ class SpCampinasSpider(BaseGazetteSpider):
                     date=date,
                     file_urls=[url],
                     is_extra_edition=is_extra_edition,
-                    territory_id=self.TERRITORY_ID,
                     power=power,
-                    scraped_at=dt.datetime.utcnow(),
                 )
             )
         return items

--- a/processing/data_collection/gazette/spiders/sp_fernandopolis.py
+++ b/processing/data_collection/gazette/spiders/sp_fernandopolis.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import scrapy
 from dateparser import parse
 from gazette.items import Gazette

--- a/processing/data_collection/gazette/spiders/sp_fernandopolis.py
+++ b/processing/data_collection/gazette/spiders/sp_fernandopolis.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 
-from dateparser import parse
 import scrapy
-
+from dateparser import parse
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
@@ -26,7 +25,5 @@ class SpFernandopolis(BaseGazetteSpider):
                 date=date,
                 file_urls=[link],
                 is_extra_edition=is_extra_edition,
-                municipality_id=self.TERRITORY_ID,
                 power="executive",
-                scraped_at=datetime.utcnow(),
             )

--- a/processing/data_collection/gazette/spiders/sp_franca.py
+++ b/processing/data_collection/gazette/spiders/sp_franca.py
@@ -39,12 +39,7 @@ class SpFrancaSpider(BaseGazetteSpider):
 
         items.append(
             Gazette(
-                date=date,
-                file_urls=[url],
-                is_extra_edition=False,
-                territory_id=self.TERRITORY_ID,
-                scraped_at=dt.datetime.utcnow(),
-                power="executive",
+                date=date, file_urls=[url], is_extra_edition=False, power="executive",
             )
         )
 

--- a/processing/data_collection/gazette/spiders/sp_guaruja.py
+++ b/processing/data_collection/gazette/spiders/sp_guaruja.py
@@ -31,7 +31,5 @@ class SpGuaruja(BaseGazetteSpider):
                     date=date,
                     file_urls=[url],
                     is_extra_edition=is_extra_edition,
-                    territory_id=self.TERRITORY_ID,
                     power="executive_legislature",
-                    scraped_at=datetime.utcnow(),
                 )

--- a/processing/data_collection/gazette/spiders/sp_guaruja.py
+++ b/processing/data_collection/gazette/spiders/sp_guaruja.py
@@ -1,5 +1,4 @@
 from dateparser import parse
-from datetime import datetime
 
 import scrapy
 

--- a/processing/data_collection/gazette/spiders/sp_guarulhos.py
+++ b/processing/data_collection/gazette/spiders/sp_guarulhos.py
@@ -36,9 +36,7 @@ class SpGuarulhosSpider(BaseGazetteSpider):
                     date=date,
                     file_urls=url,
                     is_extra_edition=is_extra_edition,
-                    territory_id=self.TERRITORY_ID,
                     power=power,
-                    scraped_at=dt.datetime.utcnow(),
                 )
             )
         return items

--- a/processing/data_collection/gazette/spiders/sp_jau.py
+++ b/processing/data_collection/gazette/spiders/sp_jau.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from scrapy import Spider
 from gazette.items import Gazette
-from datetime import datetime
 import dateparser
 
 

--- a/processing/data_collection/gazette/spiders/sp_jau.py
+++ b/processing/data_collection/gazette/spiders/sp_jau.py
@@ -27,7 +27,5 @@ class SpJauSpider(Spider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition="extra" in gazette_title,
-                territory_id=self.TERRITORY_ID,
-                scraped_at=datetime.utcnow(),
                 power="executive",
             )

--- a/processing/data_collection/gazette/spiders/sp_jundiai.py
+++ b/processing/data_collection/gazette/spiders/sp_jundiai.py
@@ -38,7 +38,5 @@ class SpJundiaiSpider(BaseGazetteSpider):
             date=gazette_date,
             file_urls=file_urls,
             is_extra_edition=is_extra_edition,
-            territory_id=self.TERRITORY_ID,
             power=power,
-            scraped_at=dt.datetime.utcnow(),
         )

--- a/processing/data_collection/gazette/spiders/sp_jundiai.py
+++ b/processing/data_collection/gazette/spiders/sp_jundiai.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from dateparser import parse
-import datetime as dt
 
 import scrapy
 

--- a/processing/data_collection/gazette/spiders/sp_presidente_prudente.py
+++ b/processing/data_collection/gazette/spiders/sp_presidente_prudente.py
@@ -1,5 +1,4 @@
 import re
-from datetime import datetime
 
 from scrapy import Request
 

--- a/processing/data_collection/gazette/spiders/sp_presidente_prudente.py
+++ b/processing/data_collection/gazette/spiders/sp_presidente_prudente.py
@@ -40,8 +40,6 @@ class SpPresidentePrudenteSpider(BaseGazetteSpider):
             date=doc_date,
             file_urls=(doc_url,),
             is_extra_edition=False,
-            territory_id=self.TERRITORY_ID,
-            scraped_at=datetime.utcnow(),
             power="executive",
         )
 

--- a/processing/data_collection/gazette/spiders/sp_santos.py
+++ b/processing/data_collection/gazette/spiders/sp_santos.py
@@ -25,9 +25,7 @@ class SpSantosSpider(BaseGazetteSpider):
                     date=parsing_date,
                     file_urls=[url],
                     is_extra_edition=False,
-                    territory_id=self.TERRITORY_ID,
                     power="executive_legislature",
-                    scraped_at=dt.datetime.utcnow(),
                 )
 
             parsing_date = parsing_date - dt.timedelta(days=1)

--- a/processing/data_collection/gazette/spiders/sp_sao_jose_dos_campos.py
+++ b/processing/data_collection/gazette/spiders/sp_sao_jose_dos_campos.py
@@ -36,9 +36,7 @@ class SpSaoJoseDosCamposSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra,
-                territory_id=self.TERRITORY_ID,
                 power="executive_legislature",
-                scraped_at=datetime.utcnow(),
             )
 
         for element in response.css(self.NEXT_PAGE_LINK_CSS):

--- a/processing/data_collection/gazette/spiders/sp_sao_jose_dos_campos.py
+++ b/processing/data_collection/gazette/spiders/sp_sao_jose_dos_campos.py
@@ -1,6 +1,5 @@
 import dateparser
 
-from datetime import datetime
 from scrapy import FormRequest
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider

--- a/processing/data_collection/gazette/spiders/to_araguaina.py
+++ b/processing/data_collection/gazette/spiders/to_araguaina.py
@@ -45,19 +45,14 @@ class ToAraguainaSpider(BaseGazetteSpider):
             yield gazette_object
 
     def create_gazette_object(
-        self, date, file_url, is_extra_edition=False, scraped_at=None, power="executive"
+        self, date, file_url, is_extra_edition=False, power="executive"
     ):
-        if not scraped_at:
-            scraped_at = dt.datetime.utcnow()
-
         file_urls = [file_url]
 
         gazette_object = Gazette(
             date=date,
             file_urls=file_urls,
             is_extra_edition=is_extra_edition,
-            territory_id=self.TERRITORY_ID,
-            scraped_at=scraped_at,
             power=power,
         )
         return gazette_object

--- a/processing/data_collection/gazette/spiders/to_araguaina.py
+++ b/processing/data_collection/gazette/spiders/to_araguaina.py
@@ -1,7 +1,6 @@
 from dateparser import parse
 import requests
 import re
-import datetime as dt
 import scrapy
 
 from gazette.items import Gazette

--- a/processing/data_collection/gazette/spiders/to_palmas.py
+++ b/processing/data_collection/gazette/spiders/to_palmas.py
@@ -53,8 +53,6 @@ class ToPalmasSpider(BaseGazetteSpider):
             item = Gazette(
                 date=dateparser.parse(gazette_date, languages=["pt"]).date(),
                 is_extra_edition=is_extra_edition,
-                territory_id=self.TERRITORY_ID,
-                scraped_at=datetime.datetime.utcnow(),
                 power="executive_legislative",
             )
             yield scrapy.Request(

--- a/processing/data_collection/gazette/spiders/to_palmas.py
+++ b/processing/data_collection/gazette/spiders/to_palmas.py
@@ -55,7 +55,10 @@ class ToPalmasSpider(BaseGazetteSpider):
                 power="executive_legislative",
             )
             yield scrapy.Request(
-                gazette_url, method="HEAD", callback=self.parse_pdf_url, cb_kwargs={"item": item},
+                gazette_url,
+                method="HEAD",
+                callback=self.parse_pdf_url,
+                cb_kwargs={"item": item},
             )
 
         next_pages_urls = response.css(".pagination a::attr(href)").getall()

--- a/processing/data_collection/gazette/spiders/to_palmas.py
+++ b/processing/data_collection/gazette/spiders/to_palmas.py
@@ -3,7 +3,6 @@ from urllib.parse import urlencode
 
 import dateparser
 import scrapy
-
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
@@ -56,10 +55,7 @@ class ToPalmasSpider(BaseGazetteSpider):
                 power="executive_legislative",
             )
             yield scrapy.Request(
-                gazette_url,
-                method="HEAD",
-                callback=self.parse_pdf_url,
-                cb_kwargs={"item": item},
+                gazette_url, method="HEAD", callback=self.parse_pdf_url, cb_kwargs={"item": item},
             )
 
         next_pages_urls = response.css(".pagination a::attr(href)").getall()


### PR DESCRIPTION
Since #253, spiders don't need to set `scraped_at` and `territory_id` at gazettes creation, saving us a few keystrokes. 
So I decided to do some housecleaning and removed them from all spiders :sleepy: 