### PR TITLE
Fix ExtractTextPipeline and SQLDatabasePipeline

### DIFF
--- a/processing/data_collection/gazette/pipelines.py
+++ b/processing/data_collection/gazette/pipelines.py
@@ -50,6 +50,9 @@ class ExtractTextPipeline:
         if not extract_text_from_file:
             return item
 
+        if "files" not in item or not item["files"]:
+            return item
+
         if self.is_doc(item["files"][0]["path"]):
             item["source_text"] = self.doc_source_text(item)
         elif self.is_pdf(item["files"][0]["path"]):
@@ -155,9 +158,10 @@ class SQLDatabasePipeline:
 
         session = self.Session()
 
-        item_file = item["files"][0]
-        item["file_path"] = item_file["path"]
-        item["file_url"] = item_file["url"]
+        if "files" in item and item["files"]:
+            item_file = item["files"][0]
+            item["file_path"] = item_file["path"]
+            item["file_url"] = item_file["url"]
         item["file_checksum"] = item_file["checksum"]
         item.pop("files")
         item.pop("file_urls")


### PR DESCRIPTION
This is a simple fix for #256. Reopening after #257 

> Thanks for your PR @phrfpeixoto ! But I`ll not accept it. We are in the process of moving off the data manipulation code from this repository. So, this code will be obsolete within days. Sorry... =/
>
> If you interesting in check the future commits on that. Keep eyes on this repo: https://github.com/okfn-brasil/querido-diario-data-processing

I see your point, but I really don't think this is a massive change in the code, and having it accepted would not pose any challenge in this "migration" to a new repository.

On the other hand it could improve development process on spiders in here. This is a change that I often have to do whenever I need to run a new spider and avoid downloading files.

Furthermore, the pipeline does have a bug. If you use any way to avoid downloading files, it will break. The only way to avoid it is to disable the pipeline: Either supressing the files_url on the scraped items, or disabling the FILES_STORE directory

SPIDER="ap_macapa -s FILES_STORE='' -a start_date=2020-09-01 -a end_date=2020-09-30 -o /mnt/data/items.json" make run_spider

This still breaks. It would have to be:

SPIDER="ap_macapa -s QUERIDODIARIO_EXTRACT_TEXT_FROM_FILE=0 -s FILES_STORE='' -a start_date=2020-09-01 -a end_date=2020-09-30 -o /mnt/data/items.json" make run_spider

Doesn't seem right to me having to disable the pipeline to work-around a bug that can be fixed with 2 lines of code.