### PR TITLE
Default value for the processed column

### DIFF
--- a/processing/data_collection/gazette/database/models.py
+++ b/processing/data_collection/gazette/database/models.py
@@ -43,7 +43,7 @@ class Gazette(DeclarativeBase):
     created_at = Column(DateTime, default=dt.datetime.utcnow)
     territory = relationship("Territory", back_populates="gazettes")
     territory_id = Column(String, ForeignKey("territories.id"))
-    processed = Column(Boolean)
+    processed = Column(Boolean, default=False)
     __table_args__ = (UniqueConstraint("territory_id", "date", "file_checksum"),)
 
 


### PR DESCRIPTION
The default value for the processed column in the database should be
false. Thus, all the files will be processed by the processing pipeline

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>