### PR TITLE
Fix power field to the values expected by spidermon

### DIFF
--- a/processing/data_collection/gazette/spiders/al_maceio.py
+++ b/processing/data_collection/gazette/spiders/al_maceio.py
@@ -51,5 +51,5 @@ class AlMaceioSpider(BaseGazetteSpider):
             date=date,
             file_urls=[url],
             is_extra_edition=is_extra_edition,
-            power="executive_legislature",
+            power="executive_legislative",
         )

--- a/processing/data_collection/gazette/spiders/ba_vitoria_da_conquista.py
+++ b/processing/data_collection/gazette/spiders/ba_vitoria_da_conquista.py
@@ -34,5 +34,5 @@ class BaVitoriaDaConquistaSpider(BaseGazetteSpider):
                 date=parsing_date,
                 file_urls=[url],
                 is_extra_edition=False,
-                power="executive_legislature",
+                power="executive_legislative",
             )

--- a/processing/data_collection/gazette/spiders/base.py
+++ b/processing/data_collection/gazette/spiders/base.py
@@ -185,4 +185,5 @@ class FecamGazetteSpider(BaseGazetteSpider):
         return Gazette(
             date=dateparser.parse(document[1], languages=("pt",)).date(),
             file_urls=(document[0],),
+            power="executive",
         )

--- a/processing/data_collection/gazette/spiders/go_aparecida_de_goiania.py
+++ b/processing/data_collection/gazette/spiders/go_aparecida_de_goiania.py
@@ -19,7 +19,7 @@ class GoAparecidaDeGoianiaSpider(BaseGazetteSpider):
         records = json.loads(response.text)["records"]
         for record in records:
             url = download_url.format(record["numero"])
-            power = "executive_legislature"
+            power = "executive_legislative"
             date = parse(record["publicado"], languages=["en"]).date()
 
             yield Gazette(

--- a/processing/data_collection/gazette/spiders/go_goiania.py
+++ b/processing/data_collection/gazette/spiders/go_goiania.py
@@ -34,7 +34,7 @@ class GoGoianiaSpider(BaseGazetteSpider):
 
             url = response.urljoin(url)
             # Apparently, Goiânia doesn't have a separate gazette for executive and legislative
-            power = "executive_legislature"
+            power = "executive_legislative"
             link_text = link.css("::text").extract_first()
             if link_text is None:
                 continue

--- a/processing/data_collection/gazette/spiders/instar_base.py
+++ b/processing/data_collection/gazette/spiders/instar_base.py
@@ -30,5 +30,5 @@ class BaseInstarSpider(BaseGazetteSpider):
                 date=parse(date, languages=["pt"]).date(),
                 file_urls=[response.urljoin(href)],
                 is_extra_edition=is_extra_edition,
-                power="executive_legislature",
+                power="executive_legislative",
             )

--- a/processing/data_collection/gazette/spiders/mg_contagem.py
+++ b/processing/data_collection/gazette/spiders/mg_contagem.py
@@ -36,7 +36,7 @@ class MgContagemSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra_edition,
-                power="executive_legislature",
+                power="executive_legislative",
             )
 
         number_of_pages = int(

--- a/processing/data_collection/gazette/spiders/mg_uberaba.py
+++ b/processing/data_collection/gazette/spiders/mg_uberaba.py
@@ -50,7 +50,7 @@ class MgUberaba(BaseGazetteSpider):
                 date=date,
                 file_urls=[self.mount_url(filename, date.year)],
                 is_extra_edition=False,
-                power="executive_legislature",
+                power="executive_legislative",
             )
 
     def extract_date(self, filename):

--- a/processing/data_collection/gazette/spiders/ms_campo_grande.py
+++ b/processing/data_collection/gazette/spiders/ms_campo_grande.py
@@ -42,5 +42,5 @@ class MsCampoGrandeSpider(BaseGazetteSpider):
                 date=gazette_date,
                 file_urls=[gazette_url],
                 is_extra_edition=is_extra_edition,
-                power="executive_legislature",
+                power="executive_legislative",
             )

--- a/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
+++ b/processing/data_collection/gazette/spiders/pb_joao_pessoa.py
@@ -37,7 +37,7 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra,
-                power="executive_legislature",
+                power="executive_legislative",
             )
 
         for url in response.css(self.NEXT_PAGE_CSS).extract():

--- a/processing/data_collection/gazette/spiders/pr_cascavel.py
+++ b/processing/data_collection/gazette/spiders/pr_cascavel.py
@@ -18,7 +18,7 @@ class PrCascavelSpider(BaseGazetteSpider):
             date = parse(date, languages=["pt"]).date()
             for link in row.xpath(".//td[3]//a"):
                 link_text = link.xpath(".//text()").extract_first()
-                power = "executive" if "Executivo" in link_text else "legislature"
+                power = "executive" if "Executivo" in link_text else "legislative"
                 url = response.urljoin(link.xpath("./@href").extract_first(""))
                 yield Gazette(
                     date=date, file_urls=[url], is_extra_edition=False, power=power,

--- a/processing/data_collection/gazette/spiders/pr_curitiba.py
+++ b/processing/data_collection/gazette/spiders/pr_curitiba.py
@@ -101,7 +101,7 @@ class PrCuritibaSpider(BaseGazetteSpider):
                         f"https://legisladocexterno.curitiba.pr.gov.br/DiarioSuplementoConsultaExterna_Download.aspx?Id={gazette_id}"
                     ],
                     is_extra_edition=True,
-                    power="executive_legislature",
+                    power="executive_legislative",
                 )
 
     def parse_regular_edition(self, response):
@@ -114,5 +114,5 @@ class PrCuritibaSpider(BaseGazetteSpider):
                 f"https://legisladocexterno.curitiba.pr.gov.br/DiarioConsultaExterna_Download.aspx?Id={gazette_id}"
             ],
             is_extra_edition=False,
-            power="executive_legislature",
+            power="executive_legislative",
         )

--- a/processing/data_collection/gazette/spiders/pr_foz_do_iguacu.py
+++ b/processing/data_collection/gazette/spiders/pr_foz_do_iguacu.py
@@ -37,7 +37,7 @@ class PrFozDoIguacuSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[f"{self.BASE_URL}{url}"],
                 is_extra_edition=is_extra_edition,
-                power="executive_legislature",
+                power="executive_legislative",
             )
 
     @staticmethod

--- a/processing/data_collection/gazette/spiders/pr_londrina.py
+++ b/processing/data_collection/gazette/spiders/pr_londrina.py
@@ -31,7 +31,7 @@ class PrLondrina(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra,
-                power="executive_legislature",
+                power="executive_legislative",
             )
 
         for page in range(2, len(response.css(".button.othersOptPage")) + 1):

--- a/processing/data_collection/gazette/spiders/pr_maringa.py
+++ b/processing/data_collection/gazette/spiders/pr_maringa.py
@@ -41,5 +41,5 @@ class PrMaringaSpider(BaseGazetteSpider):
                     f"http://venus.maringa.pr.gov.br/arquivos/orgao_oficial/arquivos/oom%20{gazette_id}.pdf"
                 ],
                 is_extra_edition=any(caracter.isalpha() for caracter in gazette_id),
-                power="executive_legislature",
+                power="executive_legislative",
             )

--- a/processing/data_collection/gazette/spiders/pr_ponta_grossa.py
+++ b/processing/data_collection/gazette/spiders/pr_ponta_grossa.py
@@ -32,7 +32,7 @@ class PrPontaGrossaSpider(BaseGazetteSpider):
                     date=gazette_date,
                     file_urls=[pdf_info["url"]],
                     is_extra_edition=pdf_info["is_extra_edition"],
-                    power="executive_legislature",
+                    power="executive_legislative",
                 )
 
     @staticmethod

--- a/processing/data_collection/gazette/spiders/ro_porto_velho.py
+++ b/processing/data_collection/gazette/spiders/ro_porto_velho.py
@@ -40,5 +40,5 @@ class RoPortoVelho(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra_edition,
-                power="executive_legislature",
+                power="executive_legislative",
             )

--- a/processing/data_collection/gazette/spiders/rr_boa_vista.py
+++ b/processing/data_collection/gazette/spiders/rr_boa_vista.py
@@ -29,7 +29,7 @@ class RrBoaVistaSpider(BaseGazetteSpider):
             url = div.xpath("./a/@href").extract_first()
             url = response.urljoin(url)
 
-            power = "executive_legislature"
+            power = "executive_legislative"
             yield Gazette(
                 date=date, file_urls=[url], is_extra_edition=False, power=power,
             )

--- a/processing/data_collection/gazette/spiders/rs_caxias_do_sul.py
+++ b/processing/data_collection/gazette/spiders/rs_caxias_do_sul.py
@@ -48,7 +48,7 @@ class RsCaxiasDoSulSpider(BaseGazetteSpider):
         date = parse(cells[1].extract(), languages=["pt"]).date()
         is_extra_edition = cells[2].extract() != "Normal"
         return Gazette(
-            date=date, is_extra_edition=is_extra_edition, power="executive_legislature",
+            date=date, is_extra_edition=is_extra_edition, power="executive_legislative",
         )
 
     def parse_pdf_page(self, response):

--- a/processing/data_collection/gazette/spiders/rs_porto_alegre.py
+++ b/processing/data_collection/gazette/spiders/rs_porto_alegre.py
@@ -35,7 +35,7 @@ class RsPortoAlegreSpider(BaseGazetteSpider):
                 continue
 
             url = response.urljoin(url)
-            power = "executive" if "executivo" in url.lower() else "legislature"
+            power = "executive" if "executivo" in url.lower() else "legislative"
             date = link.css("::text").extract_first()
             is_extra_edition = "extra" in date.lower()
             date = parse(date.split("-")[0], languages=["pt"]).date()

--- a/processing/data_collection/gazette/spiders/sc_florianopolis.py
+++ b/processing/data_collection/gazette/spiders/sc_florianopolis.py
@@ -44,7 +44,7 @@ class ScFlorianopolisSpider(BaseGazetteSpider):
                 edition_number=gazette_edition_number,
                 file_urls=(url,),
                 is_extra_edition=self.is_extra(link),
-                power="executive_legislature",
+                power="executive_legislative",
             )
 
     @staticmethod

--- a/processing/data_collection/gazette/spiders/sc_joinville.py
+++ b/processing/data_collection/gazette/spiders/sc_joinville.py
@@ -35,7 +35,7 @@ class ScJoinvilleSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra_edition,
-                power="executive_legislature",
+                power="executive_legislative",
             )
 
         for url in response.css(self.NEXT_PAGE_CSS).extract():

--- a/processing/data_collection/gazette/spiders/sp_campinas.py
+++ b/processing/data_collection/gazette/spiders/sp_campinas.py
@@ -41,7 +41,7 @@ class SpCampinasSpider(BaseGazetteSpider):
             date = parse(f"{day} {month_year}", languages=["pt"]).date()
             url = f"{self.sp_campinas_url}{url}"
             is_extra_edition = False
-            power = "executive_legislature"
+            power = "executive_legislative"
             items.append(
                 Gazette(
                     date=date,

--- a/processing/data_collection/gazette/spiders/sp_guaruja.py
+++ b/processing/data_collection/gazette/spiders/sp_guaruja.py
@@ -30,5 +30,5 @@ class SpGuaruja(BaseGazetteSpider):
                     date=date,
                     file_urls=[url],
                     is_extra_edition=is_extra_edition,
-                    power="executive_legislature",
+                    power="executive_legislative",
                 )

--- a/processing/data_collection/gazette/spiders/sp_itu.py
+++ b/processing/data_collection/gazette/spiders/sp_itu.py
@@ -36,7 +36,7 @@ class SpItuSpider(BaseGazetteSpider):
                 file_urls=[url],
                 edition_number=edition_number,
                 is_extra_edition=is_extra_edition,
-                power="executive_legislature",
+                power="executive_legislative",
             )
 
     def extract_date(self, element):

--- a/processing/data_collection/gazette/spiders/sp_santos.py
+++ b/processing/data_collection/gazette/spiders/sp_santos.py
@@ -25,7 +25,7 @@ class SpSantosSpider(BaseGazetteSpider):
                     date=parsing_date,
                     file_urls=[url],
                     is_extra_edition=False,
-                    power="executive_legislature",
+                    power="executive_legislative",
                 )
 
             parsing_date = parsing_date - dt.timedelta(days=1)

--- a/processing/data_collection/gazette/spiders/sp_sao_jose_dos_campos.py
+++ b/processing/data_collection/gazette/spiders/sp_sao_jose_dos_campos.py
@@ -35,7 +35,7 @@ class SpSaoJoseDosCamposSpider(BaseGazetteSpider):
                 date=date,
                 file_urls=[url],
                 is_extra_edition=is_extra,
-                power="executive_legislature",
+                power="executive_legislative",
             )
 
         for element in response.css(self.NEXT_PAGE_LINK_CSS):


### PR DESCRIPTION
After the spidermon configuration some spider stop working due a invalid
value for the power item field. This commit replace all these invalid
values for the value allowed by the spidermon schema

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>