### PR TITLE
Misleading error message when write in the database fails.

### DIFF
--- a/data_collection/gazette/pipelines.py
+++ b/data_collection/gazette/pipelines.py
@@ -74,11 +74,12 @@ class SQLDatabasePipeline:
             session.add(gazette)
             try:
                 session.commit()
-            except IntegrityError:
+            except IntegrityError as e:
                 spider.logger.warning(
-                    f"Gazette already exists in database. "
+                    f"Something wrong has happened when adding the gazette in the database."
                     f"Date: {gazette_item['date']}. "
-                    f"File Checksum: {gazette_item['file_checksum']}"
+                    f"File Checksum: {gazette_item['file_checksum']}.",
+                    exc_info=e,
                 )
                 session.rollback()
             except Exception:


### PR DESCRIPTION
The integrity error raised by SQLAlchemy is launched not only when the
item is already in the database. For instance, it can also be launched
when the territories table is missing some territory ID. Thus, this
commit updates the error message and add the exception in the log
message. Thus, the users will be able to detect which kind of error
they are facing.

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>