### PR TITLE
Add Spider for Bento Gonçalves

### DIFF
--- a/CITIES.md
+++ b/CITIES.md
@@ -2277,4 +2277,4 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 | XXX | Araguaina | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/3) |
 | XXX | Jaú | || [PR](https://github.com/okfn-brasil/diario-oficial/pull/197)|
 | XXX | Itu | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/303) |
-| XXX | Bento Gonçalves | | [issue](https://github.com/okfn-brasil/querido-diario/issues/322) | |
+| XXX | Bento Gonçalves - RS | | [issue](https://github.com/okfn-brasil/querido-diario/issues/322) | |

--- a/CITIES.md
+++ b/CITIES.md
@@ -2277,3 +2277,4 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 | XXX | Araguaina | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/3) |
 | XXX | Jaú | || [PR](https://github.com/okfn-brasil/diario-oficial/pull/197)|
 | XXX | Itu | :white_check_mark: | | [PR](https://github.com/okfn-brasil/querido-diario/pull/303) |
+| XXX | Bento Gonçalves | | [issue](https://github.com/okfn-brasil/querido-diario/issues/322) | |

--- a/processing/data_collection/gazette/spiders/rs_bento_goncalves.py
+++ b/processing/data_collection/gazette/spiders/rs_bento_goncalves.py
@@ -22,7 +22,7 @@ class RsBentoGoncalvesSpider(BaseGazetteSpider):
         pages = response.xpath(pagesURLSelector).getall()
 
         for page in pages:
-            url = 'http://www.' + self.allowed_domains[0] + '/' + page
+            url = 'http://www.{}/{}'.format(self.allowed_domains[0], page)
             yield scrapy.Request(url, self.parse_gazettes)
 
     def parse_gazettes(self, response):
@@ -44,7 +44,7 @@ class RsBentoGoncalvesSpider(BaseGazetteSpider):
 
                 yield Gazette(
                     date=date,
-                    file_urls=['http://www.' + self.allowed_domains[0] + '/' + gazetteLinks[i]],
+                    file_urls=['http://www.{}/{}'.format(self.allowed_domains[0], gazetteLinks[i])],
                     is_extra_edition=self.isExtraEdition(gazetteTitles[i]),
                     territory_id=self.TERRITORY_ID,
                     power="executive",

--- a/processing/data_collection/gazette/spiders/rs_bento_goncalves.py
+++ b/processing/data_collection/gazette/spiders/rs_bento_goncalves.py
@@ -1,0 +1,74 @@
+from dateparser import parse
+import datetime as dt
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RsBentoGoncalvesSpider(BaseGazetteSpider):
+    TERRITORY_ID = "4302105"
+    name = "rs_bento_goncalves"
+    allowed_domains = ["bentogoncalves.rs.gov.br"]
+    start_urls = ["http://www.bentogoncalves.rs.gov.br/diario-oficial"]
+    start_date = dt.date(2014, 9, 19)
+
+    def parse(self, response):
+        for gazette in self.parse_gazettes(response):
+            yield gazette
+
+        pagesURLSelector = '//*[@id="conteudo"]/div[2]/ul/div[2]/div/a/@href'
+        pages = response.xpath(pagesURLSelector).getall()
+
+        for page in pages:
+            url = "http://www." + self.allowed_domains[0] + "/" + page
+            yield scrapy.Request(url, self.parse_gazettes)
+
+    def parse_gazettes(self, response):
+        gazetteLinksSelector = '//*[@id="conteudo"]/div[2]/ul/li/p/a/@href'
+        gazetteTitleSelector = '//*[@id="conteudo"]/div[2]/ul/li/p/a/strong/text()'
+
+        gazetteLinks = list(
+            map(self.linkToGazette, response.xpath(gazetteLinksSelector).getall())
+        )
+        gazetteTitles = response.xpath(gazetteTitleSelector).getall()
+        gazetteDates = list(map(self.gazetteDate, gazetteTitles))
+        gazetteIsExtraEdition = list(map(self.isExtraEdition, gazetteTitles))
+
+        for date, link, isExtraEdition in zip(
+            gazetteDates, gazetteLinks, gazetteIsExtraEdition
+        ):
+            if link and date:
+                yield Gazette(
+                    date=date,
+                    file_urls=[link],
+                    is_extra_edition=isExtraEdition,
+                    territory_id=self.TERRITORY_ID,
+                    power="executive",
+                    scraped_at=dt.datetime.utcnow(),
+                )
+
+    def linkToGazette(self, elem):
+        if ".pdf" in elem:
+            return "http://www." + self.allowed_domains[0] + "/" + elem
+
+    def gazetteDate(self, elem):
+        splitedElem = elem.split("/")
+        try:
+            return dt.date(
+                int(splitedElem[2][:4]),
+                int(splitedElem[1][:2]),
+                int(splitedElem[0][-2:]),
+            )
+        except:
+            print("No date found.")
+            return None
+
+    def isExtraEdition(self, elem):
+        extraStrings = ["extra", "suplementar", "complementar"]
+        elemLower = elem.lower()
+        for extraString in extraStrings:
+            if extraString in elemLower:
+                return True
+        return False

--- a/processing/data_collection/gazette/spiders/rs_bento_goncalves.py
+++ b/processing/data_collection/gazette/spiders/rs_bento_goncalves.py
@@ -1,6 +1,6 @@
-from dateparser import parse
 import datetime as dt
 
+from dateparser import parse
 import scrapy
 
 from gazette.items import Gazette


### PR DESCRIPTION
This PR resolves the #322 

I added the Bento Gonçalves city in the CITIES.md since didn't appear there.

The spider crawl the main page of [http://www.bentogoncalves.rs.gov.br/diario-oficial](http://www.bentogoncalves.rs.gov.br/diario-oficial), the official 
link to Bento Gonçalves gazette.

After iterates through the site pagination in order to get all gazettes.

Some observations are that there are three map functions:

1. Parse to the PDF document url, but return None if there is no link PDF. 
I made that because the gazetteLinkSelector was getting some other tag links too.
2. Parse the date from the title of the Gazette, but return None if there is no date.
3. Parse if the Gazette is an extra edition.