### PR TITLE
Add spider for São Paulo/SP

### DIFF
--- a/CITIES.md
+++ b/CITIES.md
@@ -8,7 +8,7 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 
 | # | Cidade | Crawler | Issue | PR |
 |:-:|--------|:-------:|:------:|:------:|
-| 1 | São Paulo | | [issue](https://github.com/okfn-brasil/diario-oficial/issues/7) | |
+| 1 | São Paulo | :white_check_mark: | [issue](https://github.com/okfn-brasil/diario-oficial/issues/380) | [PR](https://github.com/okfn-brasil/querido-diario/pull/381) |
 | 2 | Rio de Janeiro | :white_check_mark: | [issue](https://github.com/okfn-brasil/diario-oficial/issues/15) | [PR](https://github.com/okfn-brasil/diario-oficial/pull/29) |
 | 3 | Brasília | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/querido_diario/pull/57), [PR](https://github.com/okfn-brasil/querido-diario/pull/271) |
 | 4 | Salvador | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/47) |

--- a/data_collection/gazette/spiders/sp_sao_paulo.py
+++ b/data_collection/gazette/spiders/sp_sao_paulo.py
@@ -1,8 +1,9 @@
 import locale
 import re
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 
 import scrapy
+from dateutil.rrule import DAILY, rrule
 
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
@@ -20,12 +21,9 @@ class SpSaoPauloSpider(BaseGazetteSpider):
     def start_requests(self):
         # Need to have the month's name in portuguese for the pdf url
         locale.setlocale(locale.LC_TIME, "pt_BR.UTF-8")
-        today = date.today()
-        day = self.start_date
-        while day < today:
+        for day in rrule(freq=DAILY, dtstart=self.start_date, until=date.today()):
             url = f"{self.BASE_URL}/nav_v6/header.asp?txtData={day.strftime('%d/%m/%Y')}&cad=1"
-            yield scrapy.Request(url, cb_kwargs=dict(day=day))
-            day = day + timedelta(days=1)
+            yield scrapy.Request(url, cb_kwargs=dict(day=day.date()))
 
     def get_max_page(self, response):
         page_txt = response.css("span.form-text::text").get()

--- a/data_collection/gazette/spiders/sp_sao_paulo.py
+++ b/data_collection/gazette/spiders/sp_sao_paulo.py
@@ -1,0 +1,54 @@
+import locale
+import re
+from datetime import date, datetime, timedelta
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+RE_max_page_num = re.compile(r"\d+ de (\d+)")
+
+
+class SpSaoPauloSpider(BaseGazetteSpider):
+    TERRITORY_ID = "3550308"
+    BASE_URL = "http://diariooficial.imprensaoficial.com.br"
+    allowed_domains = ["diariooficial.imprensaoficial.com.br"]
+    name = "sp_sao_paulo"
+    start_date = date(2017, 6, 1)
+
+    def start_requests(self):
+        # Need to have the month's name in portuguese for the pdf url
+        locale.setlocale(locale.LC_TIME, "pt_BR.UTF-8")
+        today = date.today()
+        day = self.start_date
+        while day < today:
+            url = f"{self.BASE_URL}/nav_v6/header.asp?txtData={day.strftime('%d/%m/%Y')}&cad=1"
+            yield scrapy.Request(url, cb_kwargs=dict(day=day))
+            day = day + timedelta(days=1)
+
+    def get_max_page(self, response):
+        page_txt = response.css("span.form-text::text").get()
+
+        try:
+            max_page = int(RE_max_page_num.search(page_txt).group(1))
+        except:
+            max_page = None
+
+        return max_page
+
+    def parse(self, response, day):
+        max_page = self.get_max_page(response)
+        if not max_page:
+            return
+        day_url = f"{self.BASE_URL}/doflash/prototipo/{day.strftime('%Y')}/{day.strftime('%B')}/{day.strftime('%d')}/cidade/pdf"
+        urls = [f"{day_url}/pg_{page:04}.pdf" for page in range(1, max_page + 1)]
+
+        yield Gazette(
+            date=day,
+            file_urls=urls,
+            is_extra_edition=False,
+            territory_id=self.TERRITORY_ID,
+            power="executive",
+            scraped_at=datetime.utcnow(),
+        )

--- a/data_collection/gazette/spiders/sp_sao_paulo.py
+++ b/data_collection/gazette/spiders/sp_sao_paulo.py
@@ -7,7 +7,7 @@ import scrapy
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
-RE_max_page_num = re.compile(r"\d+ de (\d+)")
+RE_MAX_PAGE_NUM = re.compile(r"\d+ de (\d+)")
 
 
 class SpSaoPauloSpider(BaseGazetteSpider):
@@ -31,7 +31,7 @@ class SpSaoPauloSpider(BaseGazetteSpider):
         page_txt = response.css("span.form-text::text").get()
 
         try:
-            max_page = int(RE_max_page_num.search(page_txt).group(1))
+            max_page = int(RE_MAX_PAGE_NUM.search(page_txt).group(1))
         except:
             max_page = None
 

--- a/data_collection/gazette/spiders/sp_sao_paulo.py
+++ b/data_collection/gazette/spiders/sp_sao_paulo.py
@@ -30,7 +30,7 @@ class SpSaoPauloSpider(BaseGazetteSpider):
 
         try:
             max_page = int(RE_MAX_PAGE_NUM.search(page_txt).group(1))
-        except:
+        except TypeError:
             max_page = None
 
         return max_page


### PR DESCRIPTION
Fixes #380.

Some caveats:

* I used the url scheme shown [here](https://github.com/okfn-brasil/querido-diario/issues/7#issuecomment-385122215) which directly gives the pdf, rather than serving a pdfViewer with no easy way to query the pdf file (at least I have no idea how to do it). Unfortunately, with this scheme the farthest back one can go is to July 1st, 2017.

* As already pointed in that same issue, this gazette serves each page as a separate PDF. I handled this by just getting the maximum page and returning the list of urls for each gazette (each one for a single page). But there a couple problems:
    * Since the pdf for each page is saved using a hash as its name, I think this might make it more difficult to later join the pages in the correct order. So it might be interesting to prepend the index number to the hash, like `1_<hash>.pdf`, etc. Or perhaps even simpler, have this information in the database if it isn't already.
    * Besides that, since each page requires a separate request, I need to do about 80 requests for each gazette, yielding a low requests ratio, hence the following error:
```
FAIL: Requests/Items Ratio/Ratio of requests over items scraped count
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nfraprado/cur/querido_diario/querido-diario/data_collection/gazette/monitors.py", line 24, in test_requests_items_ratio
    self.assertLess(
AssertionError: 101.57142857142857 not less than 5 : 10157.14% is greater than the allowed 500%
                ratio of requests over items scraped.
```

This is my first time contributing to the project as well as using scrapy (besides the tutorial), so any feedback would be greatly appreciated :) 