### PR TITLE
Remove fake-useragent library

### DIFF
--- a/data_collection/gazette/spiders/base/sigpub.py
+++ b/data_collection/gazette/spiders/base/sigpub.py
@@ -3,7 +3,6 @@ from datetime import date
 
 import scrapy
 from dateutil.rrule import DAILY, rrule
-from fake_useragent import UserAgent
 
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
@@ -25,7 +24,6 @@ class SigpubGazetteSpider(BaseGazetteSpider):
         - These websites have an "Advanced Search", but they are protected by ReCaptcha.
     """
 
-    custom_settings = {"USER_AGENT": UserAgent().random}
     start_date = date(2009, 1, 1)
 
     def start_requests(self):

--- a/data_collection/requirements.in
+++ b/data_collection/requirements.in
@@ -3,7 +3,6 @@ black
 boto3
 chompjs
 dateparser
-fake-useragent
 flake8
 isort
 itemadapter

--- a/data_collection/requirements.txt
+++ b/data_collection/requirements.txt
@@ -24,7 +24,6 @@ cssselect==1.1.0          # via parsel, scrapy
 dateparser==0.7.6         # via -r requirements.in
 distlib==0.3.1            # via virtualenv
 docutils==0.15.2          # via awscli
-fake-useragent==0.1.11    # via -r requirements.in
 filelock==3.0.12          # via virtualenv
 flake8==3.8.4             # via -r requirements.in
 hyperlink==20.0.1         # via twisted
@@ -46,7 +45,7 @@ mypy-extensions==0.4.3    # via black
 nodeenv==1.5.0            # via pre-commit
 parsel==1.6.0             # via itemloaders, scrapy
 pathspec==0.8.0           # via black
-pip-tools==5.3.1          # via -r requirements.in
+pip-tools==5.4.0          # via -r requirements.in
 pre-commit==2.8.2         # via -r requirements.in
 protego==0.1.16           # via scrapy
 psycopg2-binary==2.8.6    # via -r requirements.in


### PR DESCRIPTION
This library is not required as the unique spider that uses it still works without using random custom user-agents.