### PR TITLE
Deploy to scrapinghub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+    paths: 
+      - 'data_collection/gazette/spiders/'
+
+jobs:
+  deploy_to_scrapinghub:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - name: Install shub
+      run: |
+        python -m pip install --upgrade pip
+        pip install shub
+    - name: Deploy to ScrapingHub
+      env:
+        SHUB_APIKEY: ${{ secrets.SHUB_APIKEY }}
+      run: |
+        cd data_collection/
+        shub deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,11 @@
-name: Deploy
+name: Deploy to Scrapy Cloud
 
 on:
   push:
     branches: [main]
-    paths: 
-      - 'data_collection/gazette/spiders/'
 
 jobs:
-  deploy_to_scrapinghub:
+  deploy_to_scrapy_cloud:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -16,7 +14,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install shub
-    - name: Deploy to ScrapingHub
+    - name: Deploy to Scrapy Cloud
       env:
         SHUB_APIKEY: ${{ secrets.SHUB_APIKEY }}
       run: |


### PR DESCRIPTION
This PR enables automated deployment to ScrapingHub after a push to `main` and changes on the spider's folder. It depends on configuring the secret `SHUB_APIKEY` on this repo. I couldn't find any mention of this environment variable [in the docs](https://shub.readthedocs.io/en/stable/search.html?q=SHUB_APIKEY&check_keywords=yes&area=default) but it seems to work [according to the code](https://github.com/scrapinghub/shub/blob/3ef47b018bf4f10c2045d6385a1beb6ad2e5a638/shub/config.py#L502). :shipit: 