### PR TITLE
Increase amount of time to wait a download finish before timing out

### DIFF
--- a/data_collection/gazette/settings.py
+++ b/data_collection/gazette/settings.py
@@ -12,6 +12,8 @@ ITEM_PIPELINES = {
     "gazette.pipelines.SQLDatabasePipeline": 500,
 }
 
+DOWNLOAD_TIMEOUT = 360
+
 FILES_STORE = "data"
 
 EXTENSIONS = {


### PR DESCRIPTION
Some gazette files are bigger enough that the default 180s value is not enough for completing the download. This will prevent that we stop getting these big gazettes.