### PR TITLE
Stats collector

### DIFF
--- a/data_collection/gazette/extensions.py
+++ b/data_collection/gazette/extensions.py
@@ -1,0 +1,51 @@
+import json
+import os
+
+from scrapy import signals
+from sqlalchemy import JSON, Column, DateTime, Integer, String, create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DeclarativeBase = declarative_base()
+
+
+class JobStats(DeclarativeBase):
+    __tablename__ = "job_stats"
+    id = Column(Integer, primary_key=True)
+    spider = Column(String)
+    start_time = Column(DateTime)
+    job_id = Column(String)
+    job_stats = Column(JSON)
+
+
+class StatsPersist:
+    def __init__(self, crawler, database_url):
+        self._stats = crawler.stats
+        self._database_url = database_url
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        database_url = crawler.settings.get("QUERIDODIARIO_DATABASE_URL")
+
+        o = cls(crawler, database_url)
+        crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
+        crawler.signals.connect(o.spider_closed, signal=signals.spider_closed)
+        return o
+
+    def spider_opened(self, spider):
+        engine = create_engine(self._database_url)
+        DeclarativeBase.metadata.create_all(engine)
+        self.Session = sessionmaker(bind=engine)
+
+    def spider_closed(self, spider, reason):
+        stats = self._stats.get_stats()
+        serializable_stats = json.loads(json.dumps(stats, default=str))
+        job_stats = JobStats(
+            spider=spider.name,
+            start_time=stats["start_time"],
+            job_id=os.environ.get("SHUB_JOBKEY", ""),
+            job_stats=serializable_stats,
+        )
+        session = self.Session()
+        session.add(job_stats)
+        session.commit()

--- a/data_collection/gazette/settings.py
+++ b/data_collection/gazette/settings.py
@@ -36,6 +36,7 @@ SPIDERMON_TELEGRAM_RECIPIENTS = ["<RECIPIENT>"]
 
 QUERIDODIARIO_DATABASE_URL = "sqlite:///querido-diario.db"
 QUERIDODIARIO_MAX_REQUESTS_ITEMS_RATIO = 5
+QUERIDODIARIO_MAX_DAYS_WITHOUT_GAZETTES = 5
 
 # These settings are needed only when storing downloaded files
 # in a S3 bucket

--- a/data_collection/gazette/settings.py
+++ b/data_collection/gazette/settings.py
@@ -18,6 +18,7 @@ FILES_STORE = "data"
 
 EXTENSIONS = {
     "spidermon.contrib.scrapy.extensions.Spidermon": 500,
+    "gazette.extensions.StatsPersist": 600,
 }
 SPIDERMON_ENABLED = True
 SPIDERMON_VALIDATION_SCHEMAS = [


### PR DESCRIPTION
This PR adds:
- A extension that stores job stats (the ones that appears in the end of spider execution) in a database table;
- A monitor that will check if we didn't scrape items in certain (configurable) amount of days.

The purpose of this monitor is to allow us to be warned when a spider stopped providing gazettes to us that can happen if the website changes or if something that we included in the project breaks something related to the spider that fails.

I choose 5 days as default because we may have long holidays that will make the cities not publish gazettes. This can be configured in the project or per-spider.