### PR TITLE
Add spider argument: end_date

### DIFF
--- a/data_collection/gazette/spiders/base/__init__.py
+++ b/data_collection/gazette/spiders/base/__init__.py
@@ -5,7 +5,7 @@ from scrapy.exceptions import NotConfigured
 
 
 class BaseGazetteSpider(scrapy.Spider):
-    def __init__(self, start_date=None, *args, **kwargs):
+    def __init__(self, start_date=None, end_date=None, *args, **kwargs):
         super(BaseGazetteSpider, self).__init__(*args, **kwargs)
 
         if not hasattr(self, "TERRITORY_ID"):
@@ -14,11 +14,23 @@ class BaseGazetteSpider(scrapy.Spider):
         if start_date is not None:
             try:
                 self.start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
-                self.logger.info(f"Collecting gazettes after {self.start_date}")
+                self.logger.info(f"Collecting gazettes from {self.start_date}")
             except ValueError:
                 self.logger.exception(
                     f"Unable to parse {start_date}. Use %Y-%m-d date format."
                 )
                 raise
         else:
-            self.logger.info("Collecting all gazettes available")
+            self.logger.info("Collecting all gazettes available from the beginning")
+
+        if end_date is not None:
+            try:
+                self.end_date = datetime.strptime(end_date, "%Y-%m-%d").date()
+                self.logger.info(f"Collecting gazettes until {self.end_date}")
+            except ValueError:
+                self.logger.exception(
+                    f"Unable to parse {end_date}. Use %Y-%m-d date format."
+                )
+                raise
+        else:
+            self.logger.info("Collecting all gazettes available until today")


### PR DESCRIPTION
I found it useful to have the end_date argument for testing purposes. So you can narrow the dates that your spider works on. 

Example of use:
`scrapy crawl sp_sao_bernardo_do_campo -a start_date=2016-06-01 -a end_date=2017-08-01`