### PR TITLE
Refactor am_manaus to allow start_date

### DIFF
--- a/data_collection/gazette/spiders/am_manaus.py
+++ b/data_collection/gazette/spiders/am_manaus.py
@@ -1,3 +1,7 @@
+import re
+from datetime import date
+from urllib.parse import unquote
+
 import dateparser
 from scrapy import Request
 
@@ -7,66 +11,83 @@ from gazette.spiders.base import BaseGazetteSpider
 
 class AmManausSpider(BaseGazetteSpider):
     TERRITORY_ID = "1302603"
-
-    EXECUTIVE_URL = "http://dom.manaus.am.gov.br/diario-oficial-de-manaus"
-    EXECUTIVE_NEXT_PAGE_URL = EXECUTIVE_URL + "/atct_topic_view?b_start:int={}&-C="
-    LEGISLATIVE_URL = "http://www.cmm.am.gov.br/diario-oficial"
-
-    EXECUTIVE_DATE_CSS = "td:first-child span::text"
-    EXECUTIVE_GAZETTE_ROW_CSS = "table.listing tbody tr"
-    EXECUTIVE_PDF_HREF_CSS = "td:nth-child(2) a::attr(href)"
-    EXECUTIVE_PDF_TEXT_CSS = "td:nth-child(2) a:last-child::text"
-
-    LEGISLATIVE_DATE_CSS = "td:first-child"
-    LEGISLATIVE_GAZETTE_ROW_CSS = ".table-cmm tr"
-    LEGISLATIVE_NEXT_PAGE_CSS = ".paging a.next::attr(href)"
-    LEGISLATIVE_PDF_HREF_CSS = "td:last-child a::attr(href)"
-    LEGISLATIVE_DATE_REGEX = r"[0-9]{2}/[0-9]{2}/[0-9]{4}"
-
-    EXECUTIVE_LAST_PAGE = 1000
-    EXECUTIVE_STEP = 20
-
-    allowed_domains = ["manaus.am.gov.br", "cmm.am.gov.br"]
     name = "am_manaus"
+    allowed_domains = ["manaus.am.gov.br"]
+    start_date = date(2000, 4, 19)
+
+    NEXT_PAGE_CSS = "span.next a::attr(href)"
+    DATE_CSS = "td:first-child span::text"
+    GAZETTE_ROW_CSS = "table.listing tbody tr"
+    PDF_HREF_CSS = "td:nth-child(2) a::attr(href)"
+    PDF_TEXT_CSS = "td:nth-child(2) a:last-child::text"
 
     def start_requests(self):
-        yield Request(self.EXECUTIVE_URL, self.parse_executive)
-        yield Request(self.LEGISLATIVE_URL, self.parse_legislative)
+        yield Request(
+            url="http://dom.manaus.am.gov.br/diario-oficial-de-manaus",
+            callback=self.parse_gazettes_list,
+        )
 
-    def parse_executive(self, response):
-        for element in response.css(self.EXECUTIVE_GAZETTE_ROW_CSS):
-            url = element.css(self.EXECUTIVE_PDF_HREF_CSS).extract_first()
-            date = element.css(self.EXECUTIVE_DATE_CSS).extract_first()
+    def parse_gazettes_list(self, response):
+        for gazette in response.css(self.GAZETTE_ROW_CSS):
+            url = gazette.css(self.PDF_HREF_CSS).get()
+            date = gazette.css(self.DATE_CSS).get()
             date = dateparser.parse(date, languages=["pt"]).date()
-            pdf_title = element.css(self.EXECUTIVE_PDF_TEXT_CSS).extract_first()
-            is_extra_edition = "Edição Extra" in pdf_title
+            title = gazette.css(self.PDF_TEXT_CSS).get()
+            is_extra_edition = "extra" in title.lower()
+            filename = unquote(url).split("/")[-1]
+            edition = re.search(
+                r"(?:dom\d{4}|dom ?|^)(\d{3,4})", filename.lower()
+            ).group(1)
 
-            yield self.build_gazzete(date, url, "executive", is_extra_edition)
+            yield Gazette(
+                date=date,
+                edition_number=int(edition),
+                file_urls=[url],
+                is_extra_edition=is_extra_edition,
+                power="executive",
+            )
 
-        steps = range(20, self.EXECUTIVE_LAST_PAGE, self.EXECUTIVE_STEP)
-        for step in steps:
-            url = self.EXECUTIVE_NEXT_PAGE_URL.format(step)
-            yield Request(url, self.parse_executive)
+        if self.start_date < date:
+            yield from self.paginate(response)
 
-    def parse_legislative(self, response):
-        for element in response.css(self.LEGISLATIVE_GAZETTE_ROW_CSS):
-            if not element.css("td"):
+    def paginate(self, response):
+        next_page_href = response.css(self.NEXT_PAGE_CSS).get()
+        if next_page_href:
+            yield response.follow(url=next_page_href, callback=self.parse_gazettes_list)
+
+
+class AmManausLegislativeSpider(BaseGazetteSpider):
+    TERRITORY_ID = "1302603"
+    name = "am_manaus_legislative"
+    allowed_domains = ["cmm.am.gov.br"]
+    start_date = date(2013, 7, 26)
+
+    DATE_CSS = "td:first-child"
+    GAZETTE_ROW_CSS = ".table-cmm tr"
+    NEXT_PAGE_CSS = ".paging a.next::attr(href)"
+    PDF_HREF_CSS = "td:last-child a::attr(href)"
+    DATE_REGEX = r"[0-9]{2}/[0-9]{2}/[0-9]{4}"
+
+    def start_requests(self):
+        yield Request(
+            "http://www.cmm.am.gov.br/diario-oficial", self.parse_gazettes_list
+        )
+
+    def parse_gazettes_list(self, response):
+        for gazette in response.css(self.GAZETTE_ROW_CSS):
+            if not gazette.css("td"):
                 continue
 
-            url = element.css(self.LEGISLATIVE_PDF_HREF_CSS).extract_first()
-            date = element.css(self.LEGISLATIVE_DATE_CSS)
-            date = date.re(self.LEGISLATIVE_DATE_REGEX).pop()
+            url = gazette.css(self.PDF_HREF_CSS).extract_first()
+            date = gazette.css(self.DATE_CSS)
+            date = date.re(self.DATE_REGEX).pop()
             date = dateparser.parse(date, languages=["pt"]).date()
 
-            yield self.build_gazzete(date, url, "legislative")
+            yield Gazette(
+                date=date,
+                file_urls=[url],
+                power="legislative",
+            )
 
-        for url in response.css(self.LEGISLATIVE_NEXT_PAGE_CSS).extract():
-            yield Request(url, self.parse_legislative)
-
-    def build_gazzete(self, date, url, power, is_extra_edition=False):
-        return Gazette(
-            date=date,
-            file_urls=[url],
-            is_extra_edition=is_extra_edition,
-            power=power,
-        )
+        for url in response.css(self.NEXT_PAGE_CSS).extract():
+            yield Request(url, self.parse_gazettes_list)


### PR DESCRIPTION
Since there were two spiders inside one (executive and legislative)
a split was made. This simplifies things for the start_date
implementation but also for any other attribute that was specific
to only one of those spiders.

To make less requests in production (only last day's gazette), the
pagination was changed to step-by-step.

P.S. the am_manaus_legislative spider was not working and this
commit does not fix it.