### PR TITLE
Fix selector to retrieve PDF URL for gazette

### DIFF
--- a/data_collection/gazette/spiders/ba_salvador.py
+++ b/data_collection/gazette/spiders/ba_salvador.py
@@ -47,7 +47,9 @@ class BaSalvadorSpider(BaseGazetteSpider):
 
     def parse_gazette(self, response, gazette_date):
         gazette_date = datetime.datetime.strptime(gazette_date, "%Y-%m-%d").date()
-        pdf_url = response.css("#PDFId embed::attr(src)").get()
+        pdf_url = response.css("#PDFId object::attr(data)").get()
+        if pdf_url is None:
+            self.logger.error(f"Unable to retrieve PDF URL for {gazette_date}.")
 
         yield Gazette(
             date=gazette_date,


### PR DESCRIPTION
The changed how the PDF URL is displayed.
After this PR is merged, we should run a full scrape for this city, so we can get gazettes that we missed in the last weeks.