### PR TITLE
Add Queue export pipelines for AMQP, Kafka, SQS and Kinesis

### DIFF
--- a/data_collection/gazette/settings.py
+++ b/data_collection/gazette/settings.py
@@ -10,6 +10,10 @@ ITEM_PIPELINES = {
     "gazette.pipelines.QueridoDiarioFilesPipeline": 300,
     "spidermon.contrib.scrapy.pipelines.ItemValidationPipeline": 400,
     "gazette.pipelines.SQLDatabasePipeline": 500,
+    "gazette.pipelines.AmqpExporterPipeline": 500,
+    "gazette.pipelines.KafkaExporterPipeline": 500,
+    "gazette.pipelines.SQSExporterPipeline": 500,
+    "gazette.pipelines.KinesisExporterPipeline": 500,
 }
 
 DOWNLOAD_TIMEOUT = 360
@@ -39,10 +43,28 @@ QUERIDODIARIO_DATABASE_URL = "sqlite:///querido-diario.db"
 QUERIDODIARIO_MAX_REQUESTS_ITEMS_RATIO = 5
 QUERIDODIARIO_MAX_DAYS_WITHOUT_GAZETTES = 5
 
-# These settings are needed only when storing downloaded files
-# in a S3 bucket
+# These settings are used when storing downloaded files
+# in a S3 bucket and to integrate with other AWS services
 AWS_ACCESS_KEY_ID = ""
 AWS_SECRET_ACCESS_KEY = ""
-AWS_ENDPOINT_URL = ""
 AWS_REGION_NAME = ""
+AWS_ENDPOINT_URL = ""
 FILES_STORE_S3_ACL = "public-read"
+
+# AMQP exporter pipeline
+AMQP_HOST = "localhost:5672"
+AMQP_USERNAME = "guest"
+AMQP_PASSWORD = "guest"
+AMQP_QUEUE = "querido-diario"
+AMQP_EXCHANGE = ""
+AMQP_ROUTING_KEY = "querido-diario"
+
+# Kafka exporter pipeline
+KAFKA_BOOTSTRAP_SERVERS = "localhost:9092"
+KAFKA_TOPIC = "querido-diario"
+
+# SQS exporter pipeline
+SQS_QUEUE_NAME = "querido-diario"
+
+# Kinesis exporter pipeline
+KINESIS_STREAM_NAME = "querido-diario"

--- a/data_collection/requirements.in
+++ b/data_collection/requirements.in
@@ -17,3 +17,5 @@ schematics
 SQLAlchemy
 spidermon[monitoring]
 wheel
+amqp
+kafka-python

--- a/data_collection/requirements.txt
+++ b/data_collection/requirements.txt
@@ -6,6 +6,8 @@
 #
 aiohttp==3.7.4.post0
     # via slackclient
+amqp==5.0.6
+    # via -r requirements.in
 appdirs==1.4.4
     # via
     #   black
@@ -116,6 +118,8 @@ jsonpointer==2.1
     # via jsonschema
 jsonschema[format]==3.2.0
     # via spidermon
+kafka-python==2.0.2
+    # via -r requirements.in
 lxml==4.6.3
     # via
     #   parsel
@@ -254,6 +258,8 @@ urllib3==1.26.4
     #   botocore
     #   requests
     #   sentry-sdk
+vine==5.0.0
+    # via amqp
 virtualenv==20.4.3
     # via pre-commit
 w3lib==1.22.0


### PR DESCRIPTION
## Description
Fix #453 by adding export pipelines for AMQP, Kafka, SQS and Kinesis, since there is no current unit test system this can be tested manually by following these steps:

### Change `settings.py`
Fill the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION_NAME` values in `settings.py` with an IAM user with SQS + Kinesis permissions.

Uncomment `AmqpExporterPipeline`, `KafkaExporterPipeline`, `SQSExporterPipeline` and `KinesisExporterPipeline` pipelines in the `ITEM_PIPELINES` key.

Set the name of the SQS queue in `SQS_QUEUE_NAME` in `settings.py`, just the name, not the ARN.
Set the name of the Kinesis stream name in `KINESIS_STREAM_NAME` in `settings.py`, just the name, not the ARN.

> Notice: Since Kinesis and SQS are AWS only services, those ignore the AWS_ENDPOINT_URL value from `settings.py`.

### Run local instances of RabbitMQ and Kafka
Use podman and execute the script below to create local RabbitMQ and Kafka instances

### Execute some crawler
`scrapy crawl sc_florianopolis`

### Check that the items are published to each queue system
For RabbitMQ
1. Go to http://localhost:15672 and connect with username `guest` and password `guest`

For Kafka
1. Execute a shell inside the Kafka container with `podman exec -it <kafka_container_id> bash`
2. Read the configured topic with `kafka-console-consumer.sh --offset earliest --bootstrap-server localhost:9092 --topic querido-diario --partition 0`

For SQS and Kinesis you can go to your AWS Console

## Open questions
1. Should we use different authentication methods for Kafka?

## Script to run local instances of RabbitMQ and Kafka
```
#!/bin/bash

set -e

POD_NAME="querido-diario"
APP_CONTAINER_NAME="$POD_NAME-app"
RABBITMQ_CONTAINER_NAME="$POD_NAME-rabbitmq"
ZOOKEEPER_CONTAINER_NAME="$POD_NAME-zookeeper"
KAFKA_CONTAINER_NAME="$POD_NAME-kafka"

podman pod create \
    --name $POD_NAME \
    --replace \
    -p "15672:15672" \
    -p "5672:5672" \
    -p "9092:9092" \
    -p "2181:2181"

podman run \
    -d \
    --replace \
    --pod $POD_NAME \
    --name $RABBITMQ_CONTAINER_NAME \
    -e RABBITMQ_DEFAULT_USER=guest \
    -e RABBITMQ_DEFAULT_PASS=guest \
    rabbitmq:management

podman run \
    -d \
    --replace \
    --pod $POD_NAME \
    --name $ZOOKEEPER_CONTAINER_NAME \
    -e ALLOW_ANONYMOUS_LOGIN=yes \
    bitnami/zookeeper:latest

podman run \
    -d \
    --replace \
    --pod $POD_NAME \
    --name $KAFKA_CONTAINER_NAME\
    -e KAFKA_BROKER_ID=1 \
    -e KAFKA_CFG_LISTENERS=PLAINTEXT://:9092 \
    -e KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092 \
    -e KAFKA_CFG_ZOOKEEPER_CONNECT=localhost:2181 \
    -e ALLOW_PLAINTEXT_LISTENER=yes \
    bitnami/kafka:latest
```