### PR TITLE
Fix spider for Maringá/PR

### DIFF
--- a/data_collection/gazette/spiders/pr_maringa.py
+++ b/data_collection/gazette/spiders/pr_maringa.py
@@ -14,31 +14,36 @@ class PrMaringaSpider(BaseGazetteSpider):
 
     def start_requests(self):
         """
-        @url http://venus.maringa.pr.gov.br/arquivos/orgao_oficial/paginar_orgao_oficial_ano.php
+        @url http://venus.maringa.pr.gov.br/arquivos/orgao_oficial/seleciona_ano_oom.php
         @returns requests 1
         """
+        yield scrapy.FormRequest(
+            "http://venus.maringa.pr.gov.br/arquivos/orgao_oficial/seleciona_ano_oom.php",
+            callback=self.parse_form,
+        )
+
+    def parse_form(self, response):
         todays_date = date.today()
         current_year = todays_date.year
         for year in range(current_year, 2006, -1):
-            yield scrapy.FormRequest(
-                "http://venus.maringa.pr.gov.br/arquivos/orgao_oficial/paginar_orgao_oficial_ano.php",
+            yield scrapy.FormRequest.from_response(
+                response,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
+                formnumber=0,
                 formdata={"ano": str(year), "entrar": "Buscar"},
                 callback=self.parse_year,
             )
 
     def parse_year(self, response):
-        rows = response.css("table tr")[1:]
+        rows = response.css("table tr")[3:]
         for row in rows:
-            gazette_id = row.css("td:nth-child(1) a::attr(href)").re_first(
-                r".*/[oO]{2}[mM] (.*)\.pdf"
-            )
+            gazette_file_link = row.css("td:nth-child(1) a::attr(href)").extract_first()
             gazette_date = row.css("td:nth-child(2) font > font::text").extract_first()
             yield Gazette(
                 date=parse(gazette_date, languages=["pt"]).date(),
-                file_urls=[
-                    f"http://venus.maringa.pr.gov.br/arquivos/orgao_oficial/arquivos/oom%20{gazette_id}.pdf"
-                ],
-                is_extra_edition=any(caracter.isalpha() for caracter in gazette_id),
+                file_urls=[gazette_file_link],
+                is_extra_edition=any(
+                    caracter.isalpha() for caracter in gazette_file_link.split(" ")[-1]
+                ),
                 power="executive_legislative",
             )


### PR DESCRIPTION
Este PR resolve a issue #465 .

Mudanças:
- O endpoint do spider `pr_maringa.py` foi atualizado para http://venus.maringa.pr.gov.br/arquivos/orgao_oficial/seleciona_ano_oom.php

- Além de uma nova URL, a formatação da página também mudou, sendo necessário atualizar a forma que o parse estava sendo realizado