### PR TITLE
Define explicit python version (3.9) on scheduled spider

### DIFF
--- a/.github/workflows/schedule_spider.yaml
+++ b/.github/workflows/schedule_spider.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
     - name: Prepare environment
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
#502 
Olá a todos, este PR altera o schedule spider para explicitar a versão do python a ser utilizada no job - no caso será a 3.9.

Não encontrei as definições destas actions, a solução foi baseada na observação do que consta no arquivo de tests do github actions.