### PR TITLE
Pin python version in GitHub actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
     - name: Install shub
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/periodic_crawl.yaml
+++ b/.github/workflows/periodic_crawl.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
     - name: Prepare environment
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/schedule_spider.yaml
+++ b/.github/workflows/schedule_spider.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
     - name: Prepare environment
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Some libraries (python-scrapinghub to be more specific) won't work with Python 3.10 yet. So we need to pin this version or else our actions won't work properly.

Configure Python version following instructions provided in https://github.com/actions/setup-python

After this PR is merged, we need to manually run all our spiders to get data from the last week.