### PR TITLE
Enabling Brasilia-DF spider

### DIFF
--- a/data_collection/gazette/spiders/df_brasilia.py
+++ b/data_collection/gazette/spiders/df_brasilia.py
@@ -21,8 +21,8 @@ class DfBrasiliaSpider(BaseGazetteSpider):
     def start_requests(self):
         """Requests page that has a list of all available years."""
         initial_year = self.start_date.year
-        end_year = datetime.date.today().year
-        for year in range(initial_year, end_year + 1):
+        end_year = self.end_date.year
+        for year in range(end_year, initial_year - 1, -1):
             yield Request(
                 f"{self.GAZETTE_URL}?dir={year}",
                 meta={"year": year},

--- a/scripts/enabled_spiders.py
+++ b/scripts/enabled_spiders.py
@@ -5,6 +5,7 @@ SPIDERS = [
     "al_maceio",
     "ba_salvador",
     "ba_feira_de_santana",
+    "df_brasilia",
     "go_goiania",
     "mg_belo_horizonte",
     "ms_campo_grande",


### PR DESCRIPTION
* Fix spider to use default `end_date` if not provided
* Enable it to be executed daily