### PR TITLE
Update action to run spider twice a day

### DIFF
--- a/.github/workflows/periodic_crawl.yaml
+++ b/.github/workflows/periodic_crawl.yaml
@@ -2,9 +2,10 @@ name: Daily execution of Spiders
 
 on:
   schedule:
-    # Execute daily at 8AM
-    - cron: "0 8 * * *"
-
+    # Execute twice a day at 8AM/6PM (BRT)
+    - cron: "0 11 * * *"
+    - cron: "0 21 * * *"
+    
 jobs:
   schedule-jobs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Run the spiders twice a day, so we don't need to wait much time between executions in case that we don't get the gazettes of the day in the first run. This is sync with the text extraction process (that will start one hour after).