### PR TITLE
Send notification to Telegram only on failures

### DIFF
--- a/data_collection/gazette/monitors.py
+++ b/data_collection/gazette/monitors.py
@@ -100,4 +100,4 @@ class SpiderCloseMonitorSuite(MonitorSuite):
         ItemValidationMonitor,
     ]
 
-    monitors_finished_actions = [CustomSendTelegramMessage]
+    monitors_failed_actions = [CustomSendTelegramMessage]


### PR DESCRIPTION
With the increase in the number of spiders sending notification in
Telegram for successful executions is creating too many noise making it
difficult to see the failures.