### PR TITLE
Update end date parameter to allow filter by period

### DIFF
--- a/data_collection/gazette/spiders/base/sigpub.py
+++ b/data_collection/gazette/spiders/base/sigpub.py
@@ -76,7 +76,9 @@ class SigpubGazetteSpider(BaseGazetteSpider):
 
     def available_dates_form_fields(self):
         """Generates dates and corresponding form fields for availability endpoint."""
-        available_dates = rrule(freq=DAILY, dtstart=self.start_date, until=date.today())
+        available_dates = rrule(
+            freq=DAILY, dtstart=self.start_date, until=self.end_date
+        )
         for query_date in available_dates:
             form_fields = {
                 "calendar[day]": str(query_date.day),


### PR DESCRIPTION
We need to allow to run the spider providing and `end_date` attribute, to avoid extra request for dates that we are not interested. By default `end_date` is set to the current date if not provided.