### PR TITLE
Fix pagination infinite loop

### DIFF
--- a/data_collection/gazette/spiders/ms_campo_grande.py
+++ b/data_collection/gazette/spiders/ms_campo_grande.py
@@ -1,8 +1,8 @@
 import base64
 import datetime as dt
-import re
 
 from scrapy import Request
+from w3lib.url import add_or_replace_parameter
 
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
@@ -16,26 +16,29 @@ class MsCampoGrandeSpider(BaseGazetteSpider):
 
     def start_requests(self):
         base_url = "https://diogrande.campogrande.ms.gov.br/wp-admin/admin-ajax.php?action=edicoes_json"
-        initial_date = self.start_date.strftime("%d/%m/%Y")
-        final_date = self.end_date.strftime("%d/%m/%Y")
-        url = f"{base_url}&de={initial_date}&ate{final_date}&start=0"
-        yield Request(url)
+        start_date = self.start_date.strftime("%d/%m/%Y")
+        end_date = self.end_date.strftime("%d/%m/%Y")
+        start = 0
+        url = f"{base_url}&de={start_date}&ate={end_date}&start={start}"
+        yield Request(url, cb_kwargs={"start": start})
 
-    def parse(self, response, sequential=0):
-        data_json = response.json()["data"] or []
-        for entry in data_json:
-            date = dt.datetime.strptime(entry["dia"], "%Y-%m-%d").date()
+    def parse(self, response, start):
+        data_json = response.json()
+
+        gazettes = data_json.get("data") or []
+        for gazette in gazettes:
+            date = dt.datetime.strptime(gazette["dia"], "%Y-%m-%d").date()
 
             if date < self.start_date:
                 return
 
-            day_id = entry["codigodia"]
+            day_id = gazette["codigodia"]
             url_key = f'{{"codigodia":{day_id}}}'
             url_code = base64.b64encode(url_key.encode()).decode()
             url = f"https://diogrande.campogrande.ms.gov.br/download_edicao/{url_code}.pdf"
 
-            edition_number = entry["numero"]
-            title = entry["desctpd"]
+            edition_number = gazette["numero"]
+            title = gazette["desctpd"]
             is_extra_edition = "extra" in title.lower()
             yield Gazette(
                 file_urls=[url],
@@ -45,6 +48,11 @@ class MsCampoGrandeSpider(BaseGazetteSpider):
                 power="executive_legislative",
             )
 
-        next_sequential = sequential + 10
-        next_url = re.sub(r"start=(\d+)", f"start={next_sequential}", response.url)
-        yield Request(next_url, cb_kwargs={"sequential": next_sequential})
+        if start == 0:
+            total_items = int(data_json["recordsTotal"])
+            total_pages = total_items // 10  # We receive 10 results per request
+
+            for page in range(total_pages):
+                new_start = page * 10
+                page_url = add_or_replace_parameter(response.url, "start", new_start)
+                yield Request(page_url, cb_kwargs={"start": new_start})


### PR DESCRIPTION
After fixing a
[TypeError](https://github.com/okfn-brasil/querido-diario/pull/577) the
spider started to run in infinite loop, as if there is no gazettes
result, te parse metho still try to request the next page result.
Without a limit, the spider would run forever. This PR solves that
problem requesting the pages only one time.