### PR TITLE
Add Santana-AP spider

### DIFF
--- a/data_collection/gazette/spiders/ap_santana.py
+++ b/data_collection/gazette/spiders/ap_santana.py
@@ -26,7 +26,7 @@ class ApSantanaSpider(BaseGazetteSpider):
             try:
                 file_html = gazette["arquivo"].split('|')[0]
                 file_url = re.search(r'href=[\'"]?([^\'" >]+)', file_html).group(1)
-            except IndexError:
+            except:
                 continue
 
             yield Gazette(

--- a/data_collection/gazette/spiders/ap_santana.py
+++ b/data_collection/gazette/spiders/ap_santana.py
@@ -1,5 +1,5 @@
-from datetime import date, datetime
 import re
+from datetime import date, datetime
 
 import scrapy
 

--- a/data_collection/gazette/spiders/ap_santana.py
+++ b/data_collection/gazette/spiders/ap_santana.py
@@ -1,7 +1,6 @@
 import re
-from datetime import date, datetime
 
-import scrapy
+from datetime import date, datetime
 
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider

--- a/data_collection/gazette/spiders/ap_santana.py
+++ b/data_collection/gazette/spiders/ap_santana.py
@@ -1,37 +1,39 @@
 import re
-
 from datetime import date, datetime
 
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
+
 class ApSantanaSpider(BaseGazetteSpider):
     TERRITORY_ID = "1600600"
     name = "ap_santana"
     allowed_domains = ["santana.ap.gov.br"]
-    start_urls = ["https://www.santana.ap.gov.br/wp-admin/admin-ajax.php?action=datatables_endpoint"]
+    start_urls = [
+        "https://www.santana.ap.gov.br/wp-admin/admin-ajax.php?action=datatables_endpoint"
+    ]
 
     start_date = date(2019, 1, 8)
 
     def parse(self, response):
         for gazette in response.json()["data"]:
-            gazette_date = datetime.strptime(
-                gazette["data"], "%d/%m/%Y"
-            ).date()
-            
+            gazette_date = datetime.strptime(gazette["data"], "%d/%m/%Y").date()
+
             if gazette_date < self.start_date or self.end_date < gazette_date:
                 continue
-            
-            try:
-                file_html = gazette["arquivo"].split('|')[0]
-                file_url = re.search(r'href=[\'"]?([^\'" >]+)', file_html).group(1)
-            except:
+
+            file_html = gazette["arquivo"]
+            file_url_match = re.search(r'href=[\'"]?([^\'" >]+)[\'"]>Baixar', file_html)
+            if not file_url_match:
                 continue
+
+            file_url = file_url_match.group(1)
 
             yield Gazette(
                 date=gazette_date,
-                file_urls=[file_url],
+                file_urls=[
+                    file_url,
+                ],
                 is_extra_edition=False,
                 power="executive",
             )
-

--- a/data_collection/gazette/spiders/ap_santana.py
+++ b/data_collection/gazette/spiders/ap_santana.py
@@ -1,0 +1,38 @@
+from datetime import date, datetime
+import re
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+class ApSantanaSpider(BaseGazetteSpider):
+    TERRITORY_ID = "1600600"
+    name = "ap_santana"
+    allowed_domains = ["santana.ap.gov.br"]
+    start_urls = ["https://www.santana.ap.gov.br/wp-admin/admin-ajax.php?action=datatables_endpoint"]
+
+    start_date = date(2019, 1, 8)
+
+    def parse(self, response):
+        for gazette in response.json()["data"]:
+            gazette_date = datetime.strptime(
+                gazette["data"], "%d/%m/%Y"
+            ).date()
+            
+            if gazette_date < self.start_date or self.end_date < gazette_date:
+                continue
+            
+            try:
+                file_html = gazette["arquivo"].split('|')[0]
+                file_url = re.search(r'href=[\'"]?([^\'" >]+)', file_html).group(1)
+            except IndexError:
+                continue
+
+            yield Gazette(
+                date=gazette_date,
+                file_urls=[file_url],
+                is_extra_edition=False,
+                power="executive",
+            )
+


### PR DESCRIPTION
#### Checklist - Novo spider
- [X] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [X] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [X] Você verificou que não existe nenhum erro nos logs (`log/ERROR` igual a zero).
- [X] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [X] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

Adiciona spider para extrair os Diários Oficiais do município de Santana - AP  ( closes #683 )
