### PR TITLE
Fix:filtro por data em ro_porto_velho

### DIFF
--- a/data_collection/gazette/spiders/ro_porto_velho.py
+++ b/data_collection/gazette/spiders/ro_porto_velho.py
@@ -1,5 +1,5 @@
-import datetime as dt
 import json
+from datetime import date
 
 from dateparser import parse
 from dateutil.rrule import MONTHLY, rrule
@@ -13,20 +13,21 @@ from gazette.spiders.base import BaseGazetteSpider
 class RoPortoVelho(BaseGazetteSpider):
     TERRITORY_ID = "1100205"
     BASE_URL = "https://www.portovelho.ro.gov.br/dom/datatablearquivosmes/"
-    AVAILABLE_FROM = dt.datetime(2007, 1, 1)
 
     name = "ro_porto_velho"
     allowed_domains = ["portovelho.ro.gov.br"]
+    start_date = date(2007, 1, 1)
 
     def start_requests(self):
-        interval = rrule(MONTHLY, dtstart=self.AVAILABLE_FROM, until=dt.date.today())[
-            ::-1
-        ]
-        for date in interval:
-            yield Request(f"{self.BASE_URL}{date.year}/{date.month}")
+        end_date = self.end_date
+
+        interval = rrule(MONTHLY, dtstart=self.start_date, until=end_date)[::-1]
+        for _date in interval:
+            yield Request(f"{self.BASE_URL}{_date.year}/{_date.month}")
 
     def parse(self, response):
-        paragraphs = json.loads(response.body_as_unicode())["aaData"]
+        paragraphs = json.loads(response.text)["aaData"]
+
         for paragraph, *_ in paragraphs:
             selector = Selector(text=paragraph)
             url = selector.css("p a ::attr(href)").extract_first()
@@ -34,11 +35,18 @@ class RoPortoVelho(BaseGazetteSpider):
             text = selector.css("p strong ::text")
             is_extra_edition = text.extract_first().startswith("Suplemento")
             date = text.re_first(r"\d{1,2} de \w+ de \d{4}")
-            date = parse(date, languages=["pt"]).date()
 
-            yield Gazette(
-                date=date,
-                file_urls=[url],
-                is_extra_edition=is_extra_edition,
-                power="executive_legislative",
-            )
+            # As datas estao vindo com os meses em ingles, de maneira que o parser se confunde
+            # ao processar a data.
+            date = date.replace("de", "of")
+            date = parse(date).date()
+
+            # O JSON retorna todos os arquivos de um determinado mes, mas so queremos de um
+            # determinado periodo
+            if date >= self.start_date and date <= self.end_date:
+                yield Gazette(
+                    date=date,
+                    file_urls=[url],
+                    is_extra_edition=is_extra_edition,
+                    power="executive_legislative",
+                )


### PR DESCRIPTION
Fixing #632

Implementa filtro por data considerando o retorno de dados da plataforma de Diário Oficial de Porto Velho.