### PR TITLE
Ignore W503 on flake8 due to black and flake8 conflicts

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-ignore=E501
+ignore=E501, W503


### PR DESCRIPTION
Mensagem do commit:

Since black is opinionated about some formatting rules, it violates the current W503 rule in flake8

As per https://www.flake8rules.com/rules/W503.html there is a discussion to change the W503 to match the same way black adopts but while this change has not been applied we should ignore the W503 rule for now

**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider - N/A já que não é um spider
- [ ] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [ ] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [ ] Você verificou que não existe nenhum erro nos logs (`log/ERROR` igual a zero).
- [ ] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [ ] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

Abri esse PR pelo fato de que para os commits de spiders com condições compostas, W503 é acionado como um erro na etapa de análise de flake8, o que é causado devido à formatação aplicada por black.

Talvez não tivesse necessidade de abrir um PR somente com esse commit, mas como estou acertando dois PRs distintos, achei melhor abrir um somente com essa mudança.