### PR TITLE
Issue #635 add start and end date filters to rj-niteroi

### DIFF
--- a/data_collection/gazette/spiders/rj_niteroi.py
+++ b/data_collection/gazette/spiders/rj_niteroi.py
@@ -12,7 +12,19 @@ class RjNiteroiSpider(BaseGazetteSpider):
     allowed_domains = ["niteroi.rj.gov.br"]
     start_urls = ["http://www.niteroi.rj.gov.br"]
     download_url = "http://pgm.niteroi.rj.gov.br/downloads/do/{}/{}/{:02d}.pdf"
-    start_date = dt.date(2003, 7, 1)
+    start_date = None
+    end_date = None
+
+    def __init__(self, start_date=None, end_date=None, *args, **kwargs):
+        self.start_date = dt.date(2003, 7, 1)
+        self.end_date = dt.date.today()
+
+        super(RjNiteroiSpider, self).__init__(start_date, end_date)
+
+        self.logger.debug(
+            "Start date is {date}".format(date=self.start_date.isoformat())
+        )
+        self.logger.debug("End date is {date}".format(date=self.end_date.isoformat()))
 
     month_names = [
         "01_Jan",
@@ -30,7 +42,7 @@ class RjNiteroiSpider(BaseGazetteSpider):
     ]
 
     def parse(self, response):
-        parsing_date = dt.date.today()
+        parsing_date = self.end_date
         while parsing_date >= self.start_date:
             month = self.month_names[parsing_date.month - 1]
             url = self.download_url.format(parsing_date.year, month, parsing_date.day)


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [X] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [X] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [X] Você verificou que não existe nenhum erro nos logs (`log/ERROR` igual a zero).
- [X] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [X] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição
Correção da issue https://github.com/okfn-brasil/querido-diario/issues/635
