### PR TITLE
Add Rondonópolis-MT #696

### DIFF
--- a/data_collection/gazette/spiders/mt_rondonopolis.py
+++ b/data_collection/gazette/spiders/mt_rondonopolis.py
@@ -11,48 +11,30 @@ class MtRondonopolisSpider(BaseGazetteSpider):
     TERRITORY_ID = "5107602"
     name = "mt_rondonopolis"
     allowed_domains = ["rondonopolis.mt.gov.br"]
-
     BASE_URL = "http://www.rondonopolis.mt.gov.br/diario-oficial/"
-
     start_date = datetime.date(2004, 9, 1)
-    end_date = datetime.date.today()
+
+    custom_settings = {
+        "DOWNLOAD_FAIL_ON_DATALOSS": False,
+    }
 
     def start_requests(self):
         for date in rrule(DAILY, dtstart=self.start_date, until=self.end_date):
+            search_date = date.strftime("%Y-%m-%d")
             yield scrapy.Request(
-                f"{self.BASE_URL}?publish_date={date.date()}&number=&q=",
+                f"{self.BASE_URL}?publish_date={search_date}&number=&q=",
                 cb_kwargs={"gazette_date": date.date()},
             )
 
     def parse(self, response, gazette_date):
-        if response.css("tbody tr").get() is not None:
-            for gazette in response.css("tbody tr"):
-                edition = gazette.css("td:first-child::text").get()
-                pdf_url = response.urljoin(gazette.css("td a::attr(href)").get())
+        for gazette in response.css("tbody tr"):
+            edition_number = gazette.css("td:first-child::text").get()
+            gazette_url = response.urljoin(gazette.css("td a::attr(href)").get())
 
-                if pdf_url.endswith(".pdf") or pdf_url.endswith(".zip"):
-                    item = Gazette(
-                        date=gazette_date,
-                        file_urls=[pdf_url],
-                        is_extra_edition=False,
-                        edition_number=edition,
-                        power="executive",
-                    )
-
-                    yield scrapy.Request(
-                        pdf_url,
-                        callback=self.http_response,
-                        errback=self.http_error,
-                        cb_kwargs={"item": item},
-                    )
-
-                else:
-                    pass
-
-    def http_response(self, response, item):
-        yield Gazette(
-            **item,
-        )
-
-    def http_error(self, failure):
-        pass
+            yield Gazette(
+                date=gazette_date,
+                file_urls=[gazette_url],
+                is_extra_edition=False,
+                edition_number=edition_number,
+                power="executive",
+            )

--- a/data_collection/gazette/spiders/mt_rondonopolis.py
+++ b/data_collection/gazette/spiders/mt_rondonopolis.py
@@ -1,0 +1,34 @@
+import datetime
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class MtRondonopolisSpider(BaseGazetteSpider):
+    TERRITORY_ID = "5107602"
+    name = "mt_rondonopolis"
+    allowed_domains = ["rondonopolis.mt.gov.br/"]
+    start_urls = ["http://www.rondonopolis.mt.gov.br/diario-oficial/"]
+
+    start_date = datetime.date(2022, 10, 10)
+
+    def parse(self, response):
+
+        for gazette in response.css("tbody tr"):
+            edicao = gazette.css("td:first-child::text").get()
+
+            data = gazette.xpath('td[contains(text(), "/")]//text()').get()
+            parsed_data = datetime.datetime.strptime(data, "%d/%m/%y").date()
+
+            if self.start_date > parsed_data:
+                break
+
+            pdf_urls = response.urljoin(gazette.css("td a::attr(href)").get())
+
+            yield Gazette(
+                file_urls=[pdf_urls],
+                date=parsed_data,
+                power="executive",
+                is_extra_edition=False,
+                edition_number=edicao,
+            )

--- a/data_collection/gazette/spiders/mt_rondonopolis.py
+++ b/data_collection/gazette/spiders/mt_rondonopolis.py
@@ -1,62 +1,53 @@
-import scrapy
 import datetime
+
+import scrapy
+from dateutil.rrule import DAILY, rrule
+
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
-from scrapy.spidermiddlewares.httperror import HttpError
+
 
 class MtRondonopolisSpider(BaseGazetteSpider):
     TERRITORY_ID = "5107602"
     name = "mt_rondonopolis"
     allowed_domains = ["rondonopolis.mt.gov.br"]
-    start_urls = ["http://www.rondonopolis.mt.gov.br/diario-oficial/"]
+
+    BASE_URL = "http://www.rondonopolis.mt.gov.br/diario-oficial/"
 
     start_date = datetime.date(2004, 9, 1)
     end_date = datetime.date.today()
 
-    # o diario vai ate a pagina 238
-    # a data mais antiga é 01/09/2004 ; edicao 852
-    # data transiçao para pdf 29/06/11
+    def start_requests(self):
+        for date in rrule(DAILY, dtstart=self.start_date, until=self.end_date):
+            yield scrapy.Request(
+                f"{self.BASE_URL}?publish_date={date.date()}&number=&q=",
+                cb_kwargs={"gazette_date": date.date()},
+            )
 
-    def parse(self, response):
-        to_next = True
-        for gazette in response.css("tbody tr"):    
-            date = gazette.xpath('td[contains(text(), "/")]//text()').get()
-            gazette_date = datetime.datetime.strptime(date, "%d/%m/%y").date()
-            
-            if self.end_date < gazette_date:
-                continue
+    def parse(self, response, gazette_date):
+        if response.css("tbody tr").get() is not None:
+            for gazette in response.css("tbody tr"):
+                edition = gazette.css("td:first-child::text").get()
+                pdf_url = response.urljoin(gazette.css("td a::attr(href)").get())
 
-            if self.start_date > gazette_date:
-                to_next = False
-                break
+                if pdf_url.endswith(".pdf") or pdf_url.endswith(".zip"):
+                    item = Gazette(
+                        date=gazette_date,
+                        file_urls=[pdf_url],
+                        is_extra_edition=False,
+                        edition_number=edition,
+                        power="executive",
+                    )
 
-            edition = gazette.css("td:first-child::text").get()
-            pdf_url = response.urljoin(gazette.css("td a::attr(href)").get())
+                    yield scrapy.Request(
+                        pdf_url,
+                        callback=self.http_response,
+                        errback=self.http_error,
+                        cb_kwargs={"item": item},
+                    )
 
-            if pdf_url.endswith(".pdf") or pdf_url.endswith(".zip"):
-                item = Gazette(
-                    date=gazette_date,
-                    file_urls=[pdf_url],
-                    is_extra_edition=False,
-                    edition_number=edition,
-                    power="executive"
-                )
-
-                yield scrapy.Request(
-                    pdf_url, 
-                    callback=self.http_response, 
-                    errback=self.http_error,
-                    cb_kwargs={"item": item}
-                )
-
-            else: 
-                pass
-
-        if to_next:
-            next_page = response.xpath(
-                '//li[@class="page-item"]/a[contains(text(), "Próxima")]//@href'
-            ).get()
-            yield scrapy.Request(f'http://www.rondonopolis.mt.gov.br/diario-oficial/{next_page}')
+                else:
+                    pass
 
     def http_response(self, response, item):
         yield Gazette(

--- a/data_collection/gazette/spiders/mt_rondonopolis.py
+++ b/data_collection/gazette/spiders/mt_rondonopolis.py
@@ -1,5 +1,5 @@
 import datetime
-
+import scrapy
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
@@ -7,20 +7,23 @@ from gazette.spiders.base import BaseGazetteSpider
 class MtRondonopolisSpider(BaseGazetteSpider):
     TERRITORY_ID = "5107602"
     name = "mt_rondonopolis"
-    allowed_domains = ["rondonopolis.mt.gov.br/"]
+    allowed_domains = ["rondonopolis.mt.gov.br"]
     start_urls = ["http://www.rondonopolis.mt.gov.br/diario-oficial/"]
 
-    start_date = datetime.date(2022, 9, 1)
+    start_date = datetime.date(2004, 9, 1)
 
     # o diario vai ate a pagina 238
     # a data mais antiga é 01/09/2004 ; edicao 852
+    # data transiçao para pdf 29/06/11
 
     def parse(self, response):
-        for gazette in response.css("tbody tr"):
+        to_next = True
+        for gazette in response.css("tbody tr"):    
             date = gazette.xpath('td[contains(text(), "/")]//text()').get()
             parsed_date = datetime.datetime.strptime(date, "%d/%m/%y").date()
 
             if self.start_date > parsed_date:
+                to_next = False
                 break
 
             edition = gazette.css("td:first-child::text").get()
@@ -34,8 +37,8 @@ class MtRondonopolisSpider(BaseGazetteSpider):
                 edition_number=edition,
             )
 
-        next_page = response.xpath(
-            '//li[@class="page-item"]/a[contains(text(), "Próxima")]//@href'
-        ).get()
-        if next_page is not None:
-            yield response.follow(next_page, callback=self.parse)
+        if to_next:
+            next_page = response.xpath(
+                '//li[@class="page-item"]/a[contains(text(), "Próxima")]//@href'
+            ).get()
+            yield scrapy.Request(f'http://www.rondonopolis.mt.gov.br/diario-oficial/{next_page}')

--- a/data_collection/gazette/spiders/mt_rondonopolis.py
+++ b/data_collection/gazette/spiders/mt_rondonopolis.py
@@ -1,8 +1,8 @@
-import datetime
 import scrapy
+import datetime
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
-
+from scrapy.spidermiddlewares.httperror import HttpError
 
 class MtRondonopolisSpider(BaseGazetteSpider):
     TERRITORY_ID = "5107602"
@@ -11,6 +11,7 @@ class MtRondonopolisSpider(BaseGazetteSpider):
     start_urls = ["http://www.rondonopolis.mt.gov.br/diario-oficial/"]
 
     start_date = datetime.date(2004, 9, 1)
+    end_date = datetime.date.today()
 
     # o diario vai ate a pagina 238
     # a data mais antiga é 01/09/2004 ; edicao 852
@@ -20,25 +21,47 @@ class MtRondonopolisSpider(BaseGazetteSpider):
         to_next = True
         for gazette in response.css("tbody tr"):    
             date = gazette.xpath('td[contains(text(), "/")]//text()').get()
-            parsed_date = datetime.datetime.strptime(date, "%d/%m/%y").date()
+            gazette_date = datetime.datetime.strptime(date, "%d/%m/%y").date()
+            
+            if self.end_date < gazette_date:
+                continue
 
-            if self.start_date > parsed_date:
+            if self.start_date > gazette_date:
                 to_next = False
                 break
 
             edition = gazette.css("td:first-child::text").get()
             pdf_url = response.urljoin(gazette.css("td a::attr(href)").get())
 
-            yield Gazette(
-                file_urls=[pdf_url],
-                date=parsed_date,
-                power="executive",
-                is_extra_edition=False,
-                edition_number=edition,
-            )
+            if pdf_url.endswith(".pdf") or pdf_url.endswith(".zip"):
+                item = Gazette(
+                    date=gazette_date,
+                    file_urls=[pdf_url],
+                    is_extra_edition=False,
+                    edition_number=edition,
+                    power="executive"
+                )
+
+                yield scrapy.Request(
+                    pdf_url, 
+                    callback=self.http_response, 
+                    errback=self.http_error,
+                    cb_kwargs={"item": item}
+                )
+
+            else: 
+                pass
 
         if to_next:
             next_page = response.xpath(
                 '//li[@class="page-item"]/a[contains(text(), "Próxima")]//@href'
             ).get()
             yield scrapy.Request(f'http://www.rondonopolis.mt.gov.br/diario-oficial/{next_page}')
+
+    def http_response(self, response, item):
+        yield Gazette(
+            **item,
+        )
+
+    def http_error(self, failure):
+        pass


### PR DESCRIPTION
#### Checklist - Novo spider
- [X] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [X] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [X] Você verificou que não existe nenhum erro nos logs (`log/ERROR` igual a zero).
- [X] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [X] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição
Spider para raspagem dos diários oficiais de Rondonópolis-MT (resolve #696).