### PR TITLE
Refatoração para o uso de um spider base para DIONET

### DIFF
--- a/data_collection/gazette/spiders/base/dionet.py
+++ b/data_collection/gazette/spiders/base/dionet.py
@@ -1,0 +1,57 @@
+from dateutil.rrule import DAILY, rrule
+from scrapy.http import Request
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class DionetGazetteSpider(BaseGazetteSpider):
+    """
+    Base Spider for all cities using IONEWS' DIONET product
+
+    In addition to the normal spider attributes, for this base spider
+    we must define three other class attributes:
+
+        - json_list_url
+            A template string with three fields:
+                - year
+                - month
+                - day
+        - gazette_id_url
+            A template string with one field:
+                - gazette_id
+        - power
+            A str with the gazette power. Default value: "executive"
+    """
+
+    json_list_url = ""
+    gazette_id_url = ""
+    power = "executive"
+
+    def start_requests(self):
+        for date_ in rrule(freq=DAILY, dtstart=self.start_date, until=self.end_date):
+            day = str(date_.day).zfill(2)
+            month = str(date_.month).zfill(2)
+            url = self.json_list_url.format(
+                year=date_.year,
+                month=month,
+                day=day,
+            )
+            yield Request(url=url, cb_kwargs={"gazette_date": date_.date()})
+
+    def parse(self, response, gazette_date):
+        gazette_data = response.json()
+        if gazette_data["erro"]:
+            return
+
+        items = gazette_data.get("itens", [])
+        for item in items:
+            gazette_id = item["id"]
+            gazette_url = self.gazette_id_url.format(gazette_id=gazette_id)
+            is_extra_edition = item["suplemento"] == 1
+            yield Gazette(
+                date=gazette_date,
+                file_urls=[gazette_url],
+                is_extra_edition=is_extra_edition,
+                power=self.power,
+            )

--- a/data_collection/gazette/spiders/base/dionet.py
+++ b/data_collection/gazette/spiders/base/dionet.py
@@ -10,33 +10,20 @@ class DionetGazetteSpider(BaseGazetteSpider):
     Base Spider for all cities using IONEWS' DIONET product
 
     In addition to the normal spider attributes, for this base spider
-    we must define three other class attributes:
-
-        - json_list_url
-            A template string with three fields:
-                - year
-                - month
-                - day
-        - gazette_id_url
-            A template string with one field:
-                - gazette_id
-        - power
-            A str with the gazette power. Default value: "executive"
+    one other class attributes may be necessary:
+        - subtheme
     """
 
-    json_list_url = ""
-    gazette_id_url = ""
-    power = "executive"
+    url_subtheme = ""
 
     def start_requests(self):
         for date_ in rrule(freq=DAILY, dtstart=self.start_date, until=self.end_date):
             day = str(date_.day).zfill(2)
             month = str(date_.month).zfill(2)
-            url = self.json_list_url.format(
-                year=date_.year,
-                month=month,
-                day=day,
-            )
+
+            api_path = f"/apifront/portal/edicoes/edicoes_from_data/{date_.year}-{month}-{day}.json"
+            url = "".join([self.BASE_URL, api_path, self.url_subtheme])
+
             yield Request(url=url, cb_kwargs={"gazette_date": date_.date()})
 
     def parse(self, response, gazette_date):
@@ -47,11 +34,15 @@ class DionetGazetteSpider(BaseGazetteSpider):
         items = gazette_data.get("itens", [])
         for item in items:
             gazette_id = item["id"]
-            gazette_url = self.gazette_id_url.format(gazette_id=gazette_id)
+            gazette_url = f"{self.BASE_URL}/portal/edicoes/download/{gazette_id}"
+
             is_extra_edition = item["suplemento"] == 1
+            edition_number = item["numero"]
+
             yield Gazette(
                 date=gazette_date,
                 file_urls=[gazette_url],
                 is_extra_edition=is_extra_edition,
-                power=self.power,
+                edition_number=edition_number,
+                power="executive",
             )

--- a/data_collection/gazette/spiders/es/es_associacao_municipios.py
+++ b/data_collection/gazette/spiders/es/es_associacao_municipios.py
@@ -7,12 +7,7 @@ class EsAssociacaoMunicipiosSpider(DionetGazetteSpider):
     TERRITORY_ID = "3200000"
     name = "es_associacao_municipios"
     allowed_domains = ["ioes.dio.es.gov.br"]
-
     start_date = date(2021, 3, 1)
 
-    json_list_url = (
-        "https://ioes.dio.es.gov.br"
-        "/apifront/portal/edicoes/edicoes_from_data/{year}-{month}-{day}.json"
-        "?subtheme=dom"
-    )
-    gazette_id_url = "https://ioes.dio.es.gov.br/portal/edicoes/download/{gazette_id}"
+    BASE_URL = "https://ioes.dio.es.gov.br"
+    url_subtheme = "?subtheme=dom"

--- a/data_collection/gazette/spiders/es/es_associacao_municipios.py
+++ b/data_collection/gazette/spiders/es/es_associacao_municipios.py
@@ -1,28 +1,18 @@
-from dateparser import parse
+from datetime import date
 
-from gazette.items import Gazette
-from gazette.spiders.base import BaseGazetteSpider
+from gazette.spiders.base.dionet import DionetGazetteSpider
 
 
-class EsAssociacaoMunicipiosSpider(BaseGazetteSpider):
+class EsAssociacaoMunicipiosSpider(DionetGazetteSpider):
     TERRITORY_ID = "3200000"
     name = "es_associacao_municipios"
-    allowed_domains = ["diariomunicipales.org.br"]
-    start_urls = ["https://diariomunicipales.org.br/?r=site/edicoes&Edicao_page=1"]
+    allowed_domains = ["ioes.dio.es.gov.br"]
 
-    def parse(self, response):
-        for gazette_node in response.css(".items tbody tr"):
-            url = gazette_node.css("[download]::attr(href)").extract_first()
-            date = gazette_node.css("td::text")[1].extract()
-            date = parse(date, languages=["pt"]).date()
-            yield Gazette(
-                date=date,
-                file_urls=[url],
-                is_extra_edition=False,
-                power="executive",
-            )
+    start_date = date(2021, 3, 1)
 
-        css_path = ".pagination .next:not(.disabled) a::attr(href)"
-        next_page_url = response.css(css_path).extract_first()
-        if next_page_url:
-            yield response.follow(next_page_url)
+    json_list_url = (
+        "https://ioes.dio.es.gov.br"
+        "/apifront/portal/edicoes/edicoes_from_data/{year}-{month}-{day}.json"
+        "?subtheme=dom"
+    )
+    gazette_id_url = "https://ioes.dio.es.gov.br/portal/edicoes/download/{gazette_id}"

--- a/data_collection/gazette/spiders/es/es_serra.py
+++ b/data_collection/gazette/spiders/es/es_serra.py
@@ -1,42 +1,18 @@
-import datetime
+from datetime import date
 
-import scrapy
-from dateutil.rrule import DAILY, rrule
-
-from gazette.items import Gazette
-from gazette.spiders.base import BaseGazetteSpider
+from gazette.spiders.base.dionet import DionetGazetteSpider
 
 
-class EsSerraSpider(BaseGazetteSpider):
+class EsSerraSpider(DionetGazetteSpider):
     TERRITORY_ID = "3205002"
     name = "es_serra"
     allowed_domains = ["ioes.dio.es.gov.br"]
 
-    start_date = datetime.date(2021, 1, 1)
+    start_date = date(2021, 1, 1)
 
-    def start_requests(self):
-        for date in rrule(freq=DAILY, dtstart=self.start_date, until=self.end_date):
-            day = str(date.day).zfill(2)
-            month = str(date.month).zfill(2)
-            url = f"https://ioes.dio.es.gov.br/apifront/portal/edicoes/edicoes_from_data/{date.year}-{month}-{day}.json?subtheme=diariodaserra"
-            yield scrapy.Request(url=url, cb_kwargs={"gazette_date": date.date()})
-
-    def parse(self, response, gazette_date):
-        gazette_data = response.json()
-        if gazette_data["erro"]:
-            return
-
-        items = gazette_data.get("itens", [])
-        for item in items:
-            gazette_id = item["id"]
-            gazette_url = (
-                f"https://ioes.dio.es.gov.br/portal/edicoes/download/{gazette_id}"
-            )
-            is_extra_edition = item["suplemento"] == 1
-            yield Gazette(
-                date=gazette_date,
-                edition_number=item["numero"],
-                file_urls=[gazette_url],
-                is_extra_edition=is_extra_edition,
-                power="executive",
-            )
+    json_list_url = (
+        "https://ioes.dio.es.gov.br"
+        "/apifront/portal/edicoes/edicoes_from_data/{year}-{month}-{day}.json"
+        "?subtheme=diariodaserra"
+    )
+    gazette_id_url = "https://ioes.dio.es.gov.br/portal/edicoes/download/{gazette_id}"

--- a/data_collection/gazette/spiders/es/es_serra.py
+++ b/data_collection/gazette/spiders/es/es_serra.py
@@ -7,12 +7,7 @@ class EsSerraSpider(DionetGazetteSpider):
     TERRITORY_ID = "3205002"
     name = "es_serra"
     allowed_domains = ["ioes.dio.es.gov.br"]
-
     start_date = date(2021, 1, 1)
 
-    json_list_url = (
-        "https://ioes.dio.es.gov.br"
-        "/apifront/portal/edicoes/edicoes_from_data/{year}-{month}-{day}.json"
-        "?subtheme=diariodaserra"
-    )
-    gazette_id_url = "https://ioes.dio.es.gov.br/portal/edicoes/download/{gazette_id}"
+    BASE_URL = "https://ioes.dio.es.gov.br"
+    url_subtheme = "?subtheme=diariodaserra"

--- a/data_collection/gazette/spiders/ms/ms_corumba.py
+++ b/data_collection/gazette/spiders/ms/ms_corumba.py
@@ -7,11 +7,6 @@ class MsCorumba(DionetGazetteSpider):
     TERRITORY_ID = "5003207"
     name = "ms_corumba"
     allowed_domains = ["do.corumba.ms.gov.br"]
-
     start_date = date(2012, 6, 26)
 
-    json_list_url = (
-        "https://do.corumba.ms.gov.br"
-        "/apifront/portal/edicoes/edicoes_from_data/{year}-{month}-{day}.json"
-    )
-    gazette_id_url = "https://do.corumba.ms.gov.br/portal/edicoes/download/{gazette_id}"
+    BASE_URL = "https://do.corumba.ms.gov.br"

--- a/data_collection/gazette/spiders/ms_corumba.py
+++ b/data_collection/gazette/spiders/ms_corumba.py
@@ -1,0 +1,17 @@
+from datetime import date
+
+from gazette.spiders.base.dionet import DionetGazetteSpider
+
+
+class MsCorumba(DionetGazetteSpider):
+    TERRITORY_ID = "5003207"
+    name = "ms_corumba"
+    allowed_domains = ["do.corumba.ms.gov.br"]
+
+    start_date = date(2012, 6, 26)
+
+    json_list_url = (
+        "https://do.corumba.ms.gov.br"
+        "/apifront/portal/edicoes/edicoes_from_data/{year}-{month}-{day}.json"
+    )
+    gazette_id_url = "https://do.corumba.ms.gov.br/portal/edicoes/download/{gazette_id}"

--- a/data_collection/gazette/spiders/rj/rj_rio_de_janeiro.py
+++ b/data_collection/gazette/spiders/rj/rj_rio_de_janeiro.py
@@ -1,41 +1,17 @@
-import datetime
+from datetime import date
 
-import scrapy
-from dateutil.rrule import DAILY, rrule
-
-from gazette.items import Gazette
-from gazette.spiders.base import BaseGazetteSpider
+from gazette.spiders.base.dionet import DionetGazetteSpider
 
 
-class RjRioDeJaneiroSpider(BaseGazetteSpider):
+class RjRioDeJaneiroSpider(DionetGazetteSpider):
     TERRITORY_ID = "3304557"
     name = "rj_rio_de_janeiro"
     allowed_domains = ["doweb.rio.rj.gov.br"]
 
-    start_date = datetime.date(2006, 3, 16)
+    start_date = date(2006, 3, 16)
 
-    def start_requests(self):
-        for date in rrule(freq=DAILY, dtstart=self.start_date, until=self.end_date):
-            day = str(date.day).zfill(2)
-            month = str(date.month).zfill(2)
-            url = f"https://doweb.rio.rj.gov.br/apifront/portal/edicoes/edicoes_from_data/{date.year}-{month}-{day}.json"
-            yield scrapy.Request(url=url, cb_kwargs={"gazette_date": date.date()})
-
-    def parse(self, response, gazette_date):
-        gazette_data = response.json()
-        if gazette_data["erro"]:
-            return
-
-        items = gazette_data.get("itens", [])
-        for item in items:
-            gazette_id = item["id"]
-            gazette_url = (
-                f"https://doweb.rio.rj.gov.br/portal/edicoes/download/{gazette_id}"
-            )
-            is_extra_edition = item["suplemento"] == 1
-            yield Gazette(
-                date=gazette_date,
-                file_urls=[gazette_url],
-                is_extra_edition=is_extra_edition,
-                power="executive",
-            )
+    json_list_url = (
+        "https://doweb.rio.rj.gov.br"
+        "/apifront/portal/edicoes/edicoes_from_data/{year}-{month}-{day}.json"
+    )
+    gazette_id_url = "https://doweb.rio.rj.gov.br/portal/edicoes/download/{gazette_id}"

--- a/data_collection/gazette/spiders/rj/rj_rio_de_janeiro.py
+++ b/data_collection/gazette/spiders/rj/rj_rio_de_janeiro.py
@@ -7,11 +7,6 @@ class RjRioDeJaneiroSpider(DionetGazetteSpider):
     TERRITORY_ID = "3304557"
     name = "rj_rio_de_janeiro"
     allowed_domains = ["doweb.rio.rj.gov.br"]
-
     start_date = date(2006, 3, 16)
 
-    json_list_url = (
-        "https://doweb.rio.rj.gov.br"
-        "/apifront/portal/edicoes/edicoes_from_data/{year}-{month}-{day}.json"
-    )
-    gazette_id_url = "https://doweb.rio.rj.gov.br/portal/edicoes/download/{gazette_id}"
+    BASE_URL = "https://doweb.rio.rj.gov.br"

--- a/data_collection/gazette/spiders/ro/ro_jaru.py
+++ b/data_collection/gazette/spiders/ro/ro_jaru.py
@@ -1,0 +1,12 @@
+from datetime import date
+
+from gazette.spiders.base.dionet import DionetGazetteSpider
+
+
+class RoJaruSpider(DionetGazetteSpider):
+    TERRITORY_ID = "1100114"
+    name = "ro_jaru"
+    allowed_domains = ["doe.jaru.ro.gov.br"]
+    start_date = date(2022, 1, 1)
+
+    BASE_URL = "https://doe.jaru.ro.gov.br"

--- a/data_collection/gazette/spiders/sp/sp_sao_jose_dos_campos.py
+++ b/data_collection/gazette/spiders/sp/sp_sao_jose_dos_campos.py
@@ -1,57 +1,12 @@
-import dateparser
-from scrapy import FormRequest
+from datetime import date
 
-from gazette.items import Gazette
-from gazette.spiders.base import BaseGazetteSpider
+from gazette.spiders.base.dionet import DionetGazetteSpider
 
 
-class SpSaoJoseDosCamposSpider(BaseGazetteSpider):
+class SpSaoJoseDosCamposSpider(DionetGazetteSpider):
     TERRITORY_ID = "3549904"
-
-    GAZETTE_NAME_CSS = "td:last-child a::text"
-    GAZETTE_URL_CSS = "td:last-child a::attr(href)"
-    GAZETTE_DATE_CSS = "td:nth-child(2)::text"
-    NEXT_PAGE_LINK_CSS = ".paginador_anterior_proxima a"
-    JAVASCRIPT_POSTBACK_REGEX = r"javascript:__doPostBack\('(.*)',''\)"
-
-    allowed_domains = ["servicos2.sjc.sp.gov.br"]
     name = "sp_sao_jose_dos_campos"
-    start_urls = [
-        "http://servicos2.sjc.sp.gov.br/servicos/portal_da_transparencia/boletim_municipio.aspx"
-    ]
+    allowed_domains = ["diariodomunicipio.sjc.sp.gov.br"]
+    start_date = date(2015, 8, 7)
 
-    def parse(self, response):
-        for element in response.css("#corpo table tr"):
-            if element.css("th").extract():
-                continue
-
-            date = element.css(self.GAZETTE_DATE_CSS).extract_first()
-            date = dateparser.parse(date, languages=["pt"]).date()
-            url = element.css(self.GAZETTE_URL_CSS).extract_first()
-            gazette_title = element.css(self.GAZETTE_NAME_CSS).extract_first()
-            is_extra = "Extra" in gazette_title
-
-            yield Gazette(
-                date=date,
-                file_urls=[url],
-                is_extra_edition=is_extra,
-                power="executive_legislative",
-            )
-
-        for element in response.css(self.NEXT_PAGE_LINK_CSS):
-            if not element.css("a::text").extract_first() == "Próxima":
-                continue
-
-            event_target = element.css("a::attr(href)")
-            event_target = event_target.re(self.JAVASCRIPT_POSTBACK_REGEX).pop()
-
-            yield FormRequest.from_response(
-                response,
-                callback=self.parse,
-                formname="aspnetForm",
-                formxpath="//form[@id='aspnetForm']",
-                formdata={"__EVENTARGUMENT": "", "__EVENTTARGET": event_target},
-                dont_click=True,
-                dont_filter=True,
-                method="POST",
-            )
+    BASE_URL = "https://diariodomunicipio.sjc.sp.gov.br"


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [X] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [X] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [X] Você verificou que não existe nenhum erro nos logs (`log/ERROR` igual a zero).
- [X] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [X] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

PR com proposta de resolução parcial do item #724, refatorando o código comum a dois spiders já em produção:
- `rj_rio_de_janeiro`
  - [log](https://gist.github.com/ayharano/47f439ab3351cd898de61ea43f0f93d5/raw/f09f7785db0291c0b36af2434078dbb8adb8d3fc/rj_rio_de_janieiro.log)
  - [md5sum dos arquivos](https://gist.github.com/ayharano/47f439ab3351cd898de61ea43f0f93d5/raw/f09f7785db0291c0b36af2434078dbb8adb8d3fc/rj_rio_de_janeiro.md5sum.txt)
- `es_serra`
  - [log](https://gist.githubusercontent.com/ayharano/47f439ab3351cd898de61ea43f0f93d5/raw/f09f7785db0291c0b36af2434078dbb8adb8d3fc/es_serra.log)
  - [md5sum dos arquivos](https://gist.githubusercontent.com/ayharano/47f439ab3351cd898de61ea43f0f93d5/raw/f09f7785db0291c0b36af2434078dbb8adb8d3fc/es_serra.md5sum.txt)

Refatorando um spider que ainda não está em produção (aparentemente não é possível acessar os dados anteriores ao start_date da refatoração):
- `es_associacao_municipios`
  - [log](https://gist.githubusercontent.com/ayharano/47f439ab3351cd898de61ea43f0f93d5/raw/faa8b72585c682ee8476c4efc2ce191e577af5d7/es_associacao_municipios.log)

Adicionando um spider novo:
- `ms_corumba`
  - [log](https://gist.githubusercontent.com/ayharano/47f439ab3351cd898de61ea43f0f93d5/raw/65aae7225b6a9aa21d2d18320b2c2f9275910e11/ms_corumba.log)