### PR TITLE
Ajuste de São Paulo, SP para funcionar nos moldes atuais do QD (de 2017-06-01 em diante)

### DIFF
--- a/data_collection/gazette/spiders/sp/sp_sao_paulo.py
+++ b/data_collection/gazette/spiders/sp/sp_sao_paulo.py
@@ -32,7 +32,7 @@ class SpSaoPauloSpider(BaseGazetteSpider):
     start_date = date(2017, 6, 1)
 
     def start_requests(self):
-        for day in rrule(freq=DAILY, dtstart=self.start_date, until=date.today()):
+        for day in rrule(freq=DAILY, dtstart=self.start_date, until=self.end_date):
             url = f"{self.BASE_URL}/nav_v6/header.asp?txtData={day.strftime('%d/%m/%Y')}&cad=1"
             yield scrapy.Request(url, cb_kwargs=dict(day=day.date()))
 

--- a/data_collection/gazette/spiders/sp/sp_sao_paulo.py
+++ b/data_collection/gazette/spiders/sp/sp_sao_paulo.py
@@ -1,6 +1,6 @@
 import locale
 import re
-from datetime import date, datetime
+from datetime import date
 
 import scrapy
 from dateutil.rrule import DAILY, rrule
@@ -48,5 +48,4 @@ class SpSaoPauloSpider(BaseGazetteSpider):
             is_extra_edition=False,
             territory_id=self.TERRITORY_ID,
             power="executive",
-            scraped_at=datetime.utcnow(),
         )


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [X] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [X] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [X] Você verificou que não existe nenhum erro nos logs (`log/ERROR` igual a zero).
- [X] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [X] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

De acordo com http://www.docidadesp.imprensaoficial.com.br/Busca.aspx (sim, sem s de https), o serviço de diários oficiais da cidade de São Paulo, SP fornece arquivos dos diários oficiais desde 1975-12-02. Eu verifiquei o spider existente e fiz ajustes para atender a solicitação de períodos arbitrários.

Algo que gostaria de discutir é se seria o caso de fazer modificações para incluir o intervalo pendente de 1975-12-02 até 2017-05-31. Pela minha triagem inicial precisaria fazer tratamento de ViewState, similar a alguns municipios que usam esse tipo de mecanismo mas exige um pouco mais de análise.