### PR TITLE
Reverte dependências dos projetos

### DIFF
--- a/data_collection/requirements-dev.txt
+++ b/data_collection/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 aiohttp==3.8.3
     # via slackclient
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via aiohttp
 async-timeout==4.0.2
     # via aiohttp
@@ -17,7 +17,7 @@ attrs==22.1.0
     #   jsonschema
     #   service-identity
     #   twisted
-automat==20.2.0
+automat==22.10.0
     # via twisted
 awscli==1.25.90
     # via -r requirements.in
@@ -34,7 +34,7 @@ botocore==1.27.89
     #   awscli
     #   boto3
     #   s3transfer
-build==0.8.0
+build==0.9.0
     # via pip-tools
 cachetools==5.2.0
     # via premailer
@@ -50,7 +50,7 @@ charset-normalizer==2.1.1
     # via
     #   aiohttp
     #   requests
-chompjs==1.1.8
+chompjs==1.1.9
     # via -r requirements.in
 click==8.1.3
     # via
@@ -61,19 +61,19 @@ colorama==0.4.4
     # via awscli
 constantly==15.1.0
     # via twisted
-cryptography==38.0.1
+cryptography==38.0.3
     # via
     #   pyopenssl
     #   scrapy
     #   service-identity
-cssselect==1.1.0
+cssselect==1.2.0
     # via
     #   parsel
     #   premailer
     #   scrapy
 cssutils==2.6.0
     # via premailer
-dateparser==1.1.1
+dateparser==1.1.4
     # via -r requirements.in
 distlib==0.3.6
     # via virtualenv
@@ -83,17 +83,17 @@ filelock==3.8.0
     # via
     #   tldextract
     #   virtualenv
-flake8==5.0.4
+flake8==6.0.0
     # via -r requirements-dev.in
-frozenlist==1.3.1
+frozenlist==1.3.3
     # via
     #   aiohttp
     #   aiosignal
-greenlet==1.1.3
+greenlet==2.0.1
     # via sqlalchemy
 hyperlink==21.0.0
     # via twisted
-identify==2.5.6
+identify==2.5.9
     # via pre-commit
 idna==3.4
     # via
@@ -102,7 +102,7 @@ idna==3.4
     #   requests
     #   tldextract
     #   yarl
-incremental==21.3.0
+incremental==22.10.0
     # via twisted
 isort==5.10.1
     # via -r requirements-dev.in
@@ -144,18 +144,21 @@ mypy-extensions==0.4.3
 nodeenv==1.7.0
     # via pre-commit
 packaging==21.3
-    # via build
-parsel==1.6.0
+    # via
+    #   build
+    #   parsel
+    #   scrapy
+parsel==1.7.0
     # via
     #   itemloaders
     #   scrapy
-pathspec==0.10.1
+pathspec==0.10.2
     # via black
 pep517==0.13.0
     # via build
-pip-tools==6.9.0
+pip-tools==6.10.0
     # via -r requirements-dev.in
-platformdirs==2.5.2
+platformdirs==2.5.4
     # via
     #   black
     #   virtualenv
@@ -165,7 +168,7 @@ premailer==3.10.0
     # via spidermon
 protego==0.2.1
     # via scrapy
-psycopg2-binary==2.9.4
+psycopg2-binary==2.9.5
     # via -r requirements.in
 pyasn1==0.4.8
     # via
@@ -174,19 +177,19 @@ pyasn1==0.4.8
     #   service-identity
 pyasn1-modules==0.2.8
     # via service-identity
-pycodestyle==2.9.1
+pycodestyle==2.10.0
     # via flake8
 pycparser==2.21
     # via cffi
 pydispatcher==2.0.6
     # via scrapy
-pyflakes==2.5.0
+pyflakes==3.0.0
     # via flake8
 pyopenssl==22.1.0
     # via scrapy
 pyparsing==3.0.9
     # via packaging
-pyrsistent==0.18.1
+pyrsistent==0.19.2
     # via jsonschema
 python-dateutil==2.8.2
     # via
@@ -195,9 +198,9 @@ python-dateutil==2.8.2
     #   dateparser
 python-decouple==3.6
     # via -r requirements.in
-python-slugify==6.1.2
+python-slugify==7.0.0
     # via spidermon
-pytz==2022.4
+pytz==2022.6
     # via dateparser
 pytz-deprecation-shim==0.1.0.post0
     # via tzlocal
@@ -207,7 +210,7 @@ pyyaml==5.4.1
     #   pre-commit
 queuelib==1.6.2
     # via scrapy
-regex==2022.3.2
+regex==2022.10.31
     # via dateparser
 requests==2.28.1
     # via
@@ -231,11 +234,11 @@ schematics==2.1.1
     # via -r requirements.in
 scrapinghub==2.4.0
     # via spidermon
-scrapy==2.6.3
+scrapy==2.7.1
     # via
     #   -r requirements.in
     #   spidermon
-sentry-sdk==1.9.10
+sentry-sdk==1.11.1
     # via spidermon
 service-identity==21.1.0
     # via scrapy
@@ -243,7 +246,6 @@ six==1.16.0
     # via
     #   automat
     #   jsonschema
-    #   parsel
     #   protego
     #   python-dateutil
     #   requests-file
@@ -254,7 +256,7 @@ slackclient==2.9.4
     # via spidermon
 spidermon[monitoring]==1.17.0
     # via -r requirements.in
-sqlalchemy==1.4.41
+sqlalchemy==1.4.44
     # via -r requirements.in
 strict-rfc3339==0.7
     # via jsonschema
@@ -269,11 +271,11 @@ tomli==2.0.1
     #   black
     #   build
     #   pep517
-twisted==22.8.0
+twisted==22.10.0
     # via scrapy
 typing-extensions==4.4.0
     # via twisted
-tzdata==2022.4
+tzdata==2022.6
     # via pytz-deprecation-shim
 tzlocal==4.2
     # via dateparser
@@ -282,7 +284,7 @@ urllib3==1.26.12
     #   botocore
     #   requests
     #   sentry-sdk
-virtualenv==20.16.5
+virtualenv==20.16.7
     # via pre-commit
 w3lib==2.0.1
     # via
@@ -291,11 +293,11 @@ w3lib==2.0.1
     #   scrapy
 webcolors==1.12
     # via jsonschema
-wheel==0.37.1
+wheel==0.38.4
     # via pip-tools
 yarl==1.8.1
     # via aiohttp
-zope-interface==5.4.0
+zope-interface==5.5.2
     # via
     #   scrapy
     #   twisted

--- a/data_collection/requirements-dev.txt
+++ b/data_collection/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 aiohttp==3.8.3
     # via slackclient
-aiosignal==1.3.1
+aiosignal==1.2.0
     # via aiohttp
 async-timeout==4.0.2
     # via aiohttp
@@ -17,24 +17,24 @@ attrs==22.1.0
     #   jsonschema
     #   service-identity
     #   twisted
-automat==22.10.0
+automat==20.2.0
     # via twisted
-awscli==1.27.6
+awscli==1.25.90
     # via -r requirements.in
 black==22.10.0
     # via -r requirements-dev.in
 boto==2.49.0
     # via spidermon
-boto3==1.26.6
+boto3==1.24.89
     # via
     #   -r requirements.in
     #   spidermon
-botocore==1.29.6
+botocore==1.27.89
     # via
     #   awscli
     #   boto3
     #   s3transfer
-build==0.9.0
+build==0.8.0
     # via pip-tools
 cachetools==5.2.0
     # via premailer
@@ -61,19 +61,19 @@ colorama==0.4.4
     # via awscli
 constantly==15.1.0
     # via twisted
-cryptography==38.0.3
+cryptography==38.0.1
     # via
     #   pyopenssl
     #   scrapy
     #   service-identity
-cssselect==1.2.0
+cssselect==1.1.0
     # via
     #   parsel
     #   premailer
     #   scrapy
 cssutils==2.6.0
     # via premailer
-dateparser==1.1.3
+dateparser==1.1.1
     # via -r requirements.in
 distlib==0.3.6
     # via virtualenv
@@ -85,15 +85,15 @@ filelock==3.8.0
     #   virtualenv
 flake8==5.0.4
     # via -r requirements-dev.in
-frozenlist==1.3.3
+frozenlist==1.3.1
     # via
     #   aiohttp
     #   aiosignal
-greenlet==2.0.1
+greenlet==1.1.3
     # via sqlalchemy
 hyperlink==21.0.0
     # via twisted
-identify==2.5.8
+identify==2.5.6
     # via pre-commit
 idna==3.4
     # via
@@ -102,7 +102,7 @@ idna==3.4
     #   requests
     #   tldextract
     #   yarl
-incremental==22.10.0
+incremental==21.3.0
     # via twisted
 isort==5.10.1
     # via -r requirements-dev.in
@@ -144,11 +144,8 @@ mypy-extensions==0.4.3
 nodeenv==1.7.0
     # via pre-commit
 packaging==21.3
-    # via
-    #   build
-    #   parsel
-    #   scrapy
-parsel==1.7.0
+    # via build
+parsel==1.6.0
     # via
     #   itemloaders
     #   scrapy
@@ -158,7 +155,7 @@ pep517==0.13.0
     # via build
 pip-tools==6.9.0
     # via -r requirements-dev.in
-platformdirs==2.5.3
+platformdirs==2.5.2
     # via
     #   black
     #   virtualenv
@@ -168,7 +165,7 @@ premailer==3.10.0
     # via spidermon
 protego==0.2.1
     # via scrapy
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.4
     # via -r requirements.in
 pyasn1==0.4.8
     # via
@@ -189,7 +186,7 @@ pyopenssl==22.1.0
     # via scrapy
 pyparsing==3.0.9
     # via packaging
-pyrsistent==0.19.2
+pyrsistent==0.18.1
     # via jsonschema
 python-dateutil==2.8.2
     # via
@@ -200,7 +197,7 @@ python-decouple==3.6
     # via -r requirements.in
 python-slugify==6.1.2
     # via spidermon
-pytz==2022.6
+pytz==2022.4
     # via dateparser
 pytz-deprecation-shim==0.1.0.post0
     # via tzlocal
@@ -234,11 +231,11 @@ schematics==2.1.1
     # via -r requirements.in
 scrapinghub==2.4.0
     # via spidermon
-scrapy==2.7.1
+scrapy==2.6.3
     # via
     #   -r requirements.in
     #   spidermon
-sentry-sdk==1.10.1
+sentry-sdk==1.9.10
     # via spidermon
 service-identity==21.1.0
     # via scrapy
@@ -246,6 +243,7 @@ six==1.16.0
     # via
     #   automat
     #   jsonschema
+    #   parsel
     #   protego
     #   python-dateutil
     #   requests-file
@@ -256,7 +254,7 @@ slackclient==2.9.4
     # via spidermon
 spidermon[monitoring]==1.17.0
     # via -r requirements.in
-sqlalchemy==1.4.43
+sqlalchemy==1.4.41
     # via -r requirements.in
 strict-rfc3339==0.7
     # via jsonschema
@@ -271,11 +269,11 @@ tomli==2.0.1
     #   black
     #   build
     #   pep517
-twisted==22.10.0
+twisted==22.8.0
     # via scrapy
 typing-extensions==4.4.0
     # via twisted
-tzdata==2022.6
+tzdata==2022.4
     # via pytz-deprecation-shim
 tzlocal==4.2
     # via dateparser
@@ -284,7 +282,7 @@ urllib3==1.26.12
     #   botocore
     #   requests
     #   sentry-sdk
-virtualenv==20.16.6
+virtualenv==20.16.5
     # via pre-commit
 w3lib==2.0.1
     # via
@@ -293,11 +291,11 @@ w3lib==2.0.1
     #   scrapy
 webcolors==1.12
     # via jsonschema
-wheel==0.38.4
+wheel==0.37.1
     # via pip-tools
 yarl==1.8.1
     # via aiohttp
-zope-interface==5.5.1
+zope-interface==5.4.0
     # via
     #   scrapy
     #   twisted

--- a/data_collection/requirements.in
+++ b/data_collection/requirements.in
@@ -1,5 +1,5 @@
-awscli
-boto3
+awscli==1.25.90
+boto3==1.24.89
 click
 chompjs
 dateparser

--- a/data_collection/requirements.txt
+++ b/data_collection/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiohttp==3.8.3
     # via slackclient
-aiosignal==1.3.1
+aiosignal==1.2.0
     # via aiohttp
 async-timeout==4.0.2
     # via aiohttp
@@ -17,17 +17,17 @@ attrs==22.1.0
     #   jsonschema
     #   service-identity
     #   twisted
-automat==22.10.0
+automat==20.2.0
     # via twisted
-awscli==1.27.6
+awscli==1.25.90
     # via -r requirements.in
 boto==2.49.0
     # via spidermon
-boto3==1.26.6
+boto3==1.24.89
     # via
     #   -r requirements.in
     #   spidermon
-botocore==1.29.6
+botocore==1.27.89
     # via
     #   awscli
     #   boto3
@@ -52,29 +52,29 @@ colorama==0.4.4
     # via awscli
 constantly==15.1.0
     # via twisted
-cryptography==38.0.3
+cryptography==38.0.1
     # via
     #   pyopenssl
     #   scrapy
     #   service-identity
-cssselect==1.2.0
+cssselect==1.1.0
     # via
     #   parsel
     #   premailer
     #   scrapy
 cssutils==2.6.0
     # via premailer
-dateparser==1.1.3
+dateparser==1.1.1
     # via -r requirements.in
 docutils==0.16
     # via awscli
 filelock==3.8.0
     # via tldextract
-frozenlist==1.3.3
+frozenlist==1.3.1
     # via
     #   aiohttp
     #   aiosignal
-greenlet==2.0.1
+greenlet==1.1.3
     # via sqlalchemy
 hyperlink==21.0.0
     # via twisted
@@ -85,7 +85,7 @@ idna==3.4
     #   requests
     #   tldextract
     #   yarl
-incremental==22.10.0
+incremental==21.3.0
     # via twisted
 itemadapter==0.7.0
     # via
@@ -118,11 +118,7 @@ multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
-packaging==21.3
-    # via
-    #   parsel
-    #   scrapy
-parsel==1.7.0
+parsel==1.6.0
     # via
     #   itemloaders
     #   scrapy
@@ -130,7 +126,7 @@ premailer==3.10.0
     # via spidermon
 protego==0.2.1
     # via scrapy
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.4
     # via -r requirements.in
 pyasn1==0.4.8
     # via
@@ -145,9 +141,7 @@ pydispatcher==2.0.6
     # via scrapy
 pyopenssl==22.1.0
     # via scrapy
-pyparsing==3.0.9
-    # via packaging
-pyrsistent==0.19.2
+pyrsistent==0.18.1
     # via jsonschema
 python-dateutil==2.8.2
     # via
@@ -158,7 +152,7 @@ python-decouple==3.6
     # via -r requirements.in
 python-slugify==6.1.2
     # via spidermon
-pytz==2022.6
+pytz==2022.4
     # via dateparser
 pytz-deprecation-shim==0.1.0.post0
     # via tzlocal
@@ -190,11 +184,11 @@ schematics==2.1.1
     # via -r requirements.in
 scrapinghub==2.4.0
     # via spidermon
-scrapy==2.7.1
+scrapy==2.6.3
     # via
     #   -r requirements.in
     #   spidermon
-sentry-sdk==1.10.1
+sentry-sdk==1.9.10
     # via spidermon
 service-identity==21.1.0
     # via scrapy
@@ -202,6 +196,7 @@ six==1.16.0
     # via
     #   automat
     #   jsonschema
+    #   parsel
     #   protego
     #   python-dateutil
     #   requests-file
@@ -212,7 +207,7 @@ slackclient==2.9.4
     # via spidermon
 spidermon[monitoring]==1.17.0
     # via -r requirements.in
-sqlalchemy==1.4.43
+sqlalchemy==1.4.41
     # via -r requirements.in
 strict-rfc3339==0.7
     # via jsonschema
@@ -220,11 +215,11 @@ text-unidecode==1.3
     # via python-slugify
 tldextract==3.4.0
     # via scrapy
-twisted==22.10.0
+twisted==22.8.0
     # via scrapy
 typing-extensions==4.4.0
     # via twisted
-tzdata==2022.6
+tzdata==2022.4
     # via pytz-deprecation-shim
 tzlocal==4.2
     # via dateparser
@@ -242,7 +237,7 @@ webcolors==1.12
     # via jsonschema
 yarl==1.8.1
     # via aiohttp
-zope-interface==5.5.1
+zope-interface==5.4.0
     # via
     #   scrapy
     #   twisted

--- a/data_collection/requirements.txt
+++ b/data_collection/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiohttp==3.8.3
     # via slackclient
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via aiohttp
 async-timeout==4.0.2
     # via aiohttp
@@ -17,7 +17,7 @@ attrs==22.1.0
     #   jsonschema
     #   service-identity
     #   twisted
-automat==20.2.0
+automat==22.10.0
     # via twisted
 awscli==1.25.90
     # via -r requirements.in
@@ -44,7 +44,7 @@ charset-normalizer==2.1.1
     # via
     #   aiohttp
     #   requests
-chompjs==1.1.8
+chompjs==1.1.9
     # via -r requirements.in
 click==8.1.3
     # via -r requirements.in
@@ -52,29 +52,29 @@ colorama==0.4.4
     # via awscli
 constantly==15.1.0
     # via twisted
-cryptography==38.0.1
+cryptography==38.0.3
     # via
     #   pyopenssl
     #   scrapy
     #   service-identity
-cssselect==1.1.0
+cssselect==1.2.0
     # via
     #   parsel
     #   premailer
     #   scrapy
 cssutils==2.6.0
     # via premailer
-dateparser==1.1.1
+dateparser==1.1.4
     # via -r requirements.in
 docutils==0.16
     # via awscli
 filelock==3.8.0
     # via tldextract
-frozenlist==1.3.1
+frozenlist==1.3.3
     # via
     #   aiohttp
     #   aiosignal
-greenlet==1.1.3
+greenlet==2.0.1
     # via sqlalchemy
 hyperlink==21.0.0
     # via twisted
@@ -85,7 +85,7 @@ idna==3.4
     #   requests
     #   tldextract
     #   yarl
-incremental==21.3.0
+incremental==22.10.0
     # via twisted
 itemadapter==0.7.0
     # via
@@ -118,7 +118,11 @@ multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
-parsel==1.6.0
+packaging==21.3
+    # via
+    #   parsel
+    #   scrapy
+parsel==1.7.0
     # via
     #   itemloaders
     #   scrapy
@@ -126,7 +130,7 @@ premailer==3.10.0
     # via spidermon
 protego==0.2.1
     # via scrapy
-psycopg2-binary==2.9.4
+psycopg2-binary==2.9.5
     # via -r requirements.in
 pyasn1==0.4.8
     # via
@@ -141,7 +145,9 @@ pydispatcher==2.0.6
     # via scrapy
 pyopenssl==22.1.0
     # via scrapy
-pyrsistent==0.18.1
+pyparsing==3.0.9
+    # via packaging
+pyrsistent==0.19.2
     # via jsonschema
 python-dateutil==2.8.2
     # via
@@ -150,9 +156,9 @@ python-dateutil==2.8.2
     #   dateparser
 python-decouple==3.6
     # via -r requirements.in
-python-slugify==6.1.2
+python-slugify==7.0.0
     # via spidermon
-pytz==2022.4
+pytz==2022.6
     # via dateparser
 pytz-deprecation-shim==0.1.0.post0
     # via tzlocal
@@ -160,7 +166,7 @@ pyyaml==5.4.1
     # via awscli
 queuelib==1.6.2
     # via scrapy
-regex==2022.3.2
+regex==2022.10.31
     # via dateparser
 requests==2.28.1
     # via
@@ -184,11 +190,11 @@ schematics==2.1.1
     # via -r requirements.in
 scrapinghub==2.4.0
     # via spidermon
-scrapy==2.6.3
+scrapy==2.7.1
     # via
     #   -r requirements.in
     #   spidermon
-sentry-sdk==1.9.10
+sentry-sdk==1.11.1
     # via spidermon
 service-identity==21.1.0
     # via scrapy
@@ -196,7 +202,6 @@ six==1.16.0
     # via
     #   automat
     #   jsonschema
-    #   parsel
     #   protego
     #   python-dateutil
     #   requests-file
@@ -207,7 +212,7 @@ slackclient==2.9.4
     # via spidermon
 spidermon[monitoring]==1.17.0
     # via -r requirements.in
-sqlalchemy==1.4.41
+sqlalchemy==1.4.44
     # via -r requirements.in
 strict-rfc3339==0.7
     # via jsonschema
@@ -215,11 +220,11 @@ text-unidecode==1.3
     # via python-slugify
 tldextract==3.4.0
     # via scrapy
-twisted==22.8.0
+twisted==22.10.0
     # via scrapy
 typing-extensions==4.4.0
     # via twisted
-tzdata==2022.4
+tzdata==2022.6
     # via pytz-deprecation-shim
 tzlocal==4.2
     # via dateparser
@@ -237,7 +242,7 @@ webcolors==1.12
     # via jsonschema
 yarl==1.8.1
     # via aiohttp
-zope-interface==5.4.0
+zope-interface==5.5.2
     # via
     #   scrapy
     #   twisted

--- a/data_collection/scrapinghub.yml
+++ b/data_collection/scrapinghub.yml
@@ -1,4 +1,4 @@
 project: 601251
-stack: scrapy:2.7-20221020
+stack: scrapy:2.6
 requirements:
   file: requirements.txt


### PR DESCRIPTION
Como mencionado em #778, reverter #773 e #774 seria importante por enquanto para que o upload de arquivos volte a funcionar.

Este PR realiza essa reversão.