### PR TITLE
Create command to schedule all enable spiders with a start date

### DIFF
--- a/.github/workflows/schedule_spider_by_date.yaml
+++ b/.github/workflows/schedule_spider_by_date.yaml
@@ -1,0 +1,35 @@
+name: Schedule All Enabled Spiders Crawl
+
+on:
+  workflow_dispatch:
+    inputs:
+      start_date:
+        description: 'Start date (YYYY-MM-DD)'
+        required: true
+
+jobs:
+  schedule:
+    runs-on: ubuntu-latest
+    env:
+      SHUB_APIKEY: ${{ secrets.SHUB_APIKEY }}
+      SCRAPY_CLOUD_PROJECT_ID: ${{ secrets.SCRAPY_CLOUD_PROJECT_ID }}
+      FILES_STORE: ${{ secrets.FILES_STORE }}
+      QUERIDODIARIO_DATABASE_URL: ${{ secrets.QUERIDODIARIO_DATABASE_URL }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}
+      AWS_REGION_NAME: ${{ secrets.AWS_REGION_NAME }}
+      SPIDERMON_DISCORD_FAKE: ${{ secrets.SPIDERMON_DISCORD_FAKE }}
+      SPIDERMON_DISCORD_WEBHOOK_URL: ${{ secrets.SPIDERMON_DISCORD_WEBHOOK_URL }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Prepare environment
+      run: |
+        python -m pip install --upgrade pip
+        pip install click python-decouple scrapinghub
+    - name: Schedule partial crawl
+      if: ${{ github.event.inputs.start_date }}
+      run: python scripts/scheduler.py schedule-all-spiders-by-date --start_date ${{ github.event.inputs.start_date }}

--- a/scripts/scheduler.py
+++ b/scripts/scheduler.py
@@ -64,5 +64,15 @@ def schedule_enabled_spiders():
         _schedule_job(start_date=YESTERDAY, full=False, spider_name=spider_name)
 
 
+@click.option(
+    "--start_date",
+    help="Start date that we want to scrape all enabled spiders.",
+)
+@cli.command()
+def schedule_all_spiders_by_date(start_date):
+    for spider_name in enabled_spiders.SPIDERS:
+        _schedule_job(start_date, full=False, spider_name=spider_name)
+
+
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
This command allows us to schedule all enabled spiders after a specific date. This would be useful if we want to run many spiders at the same time, without requiring to schedule wach one individually.