### PR TITLE
Fix Ibitinga-SP Spider

### DIFF
--- a/data_collection/gazette/spiders/sp_ibitinga.py
+++ b/data_collection/gazette/spiders/sp_ibitinga.py
@@ -1,3 +1,5 @@
+import datetime
+
 from gazette.spiders.base.instar import BaseInstarSpider
 
 
@@ -5,4 +7,5 @@ class SpIbitingaSpider(BaseInstarSpider):
     TERRITORY_ID = "3519600"
     name = "sp_ibitinga"
     allowed_domains = ["ibitinga.instarbr.com.br"]
-    start_urls = ["https://www.ibitinga.instarbr.com.br/portal/diario-oficial/"]
+    base_url = "https://www.ibitinga.instarbr.com.br/portal/diario-oficial"
+    start_date = datetime.date(2019, 4, 30)

--- a/scripts/enabled_spiders.py
+++ b/scripts/enabled_spiders.py
@@ -57,6 +57,7 @@ SPIDERS = [
     "sp_campinas",
     "sp_guarulhos",
     "sp_jaboticabal",
+    "sp_ibitinga",
     "sp_jundiai",
     "sp_marilia",
     "sp_santo_andre",


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos. [log](https://gist.github.com/rafaelgotts/7ee7488315cfd558e2c70eacd2b03669/raw/c62668d5e35e29272c293cbbb768e6220a378726/sp_ibitinga_end_date.log)
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log/ERROR` igual a zero).
- [x] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [ ] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

resolve #799 

Não marquei o check dos campos pois não entendi (ainda) como conferir.

Percebi também que faltou um arquivo (edição 113, [link](https://www.ibitinga.instarbr.com.br/portal/diario-oficial/ver/115)) pois não tem data registrada no site, logo ele não aparece quando é feito o filtro por data.