### PR TITLE
Fix Arraial do Cabo-RJ

### DIFF
--- a/data_collection/gazette/spiders/rj_arraial_do_cabo.py
+++ b/data_collection/gazette/spiders/rj_arraial_do_cabo.py
@@ -1,8 +1,11 @@
+import datetime
+
 from gazette.spiders.base.instar import BaseInstarSpider
 
 
 class RjArraialdoCabopider(BaseInstarSpider):
     TERRITORY_ID = "3300258"
     name = "rj_arraial_do_cabo"
-    allowed_domains = ["rraial.rj.gov.br/"]
-    start_urls = ["https://www.arraial.rj.gov.br/portal/diario-oficial"]
+    allowed_domains = ["arraial.rj.gov.br"]
+    base_url = "https://www.arraial.rj.gov.br/portal/diario-oficial"
+    start_date = datetime.date(2019, 2, 7)

--- a/scripts/enabled_spiders.py
+++ b/scripts/enabled_spiders.py
@@ -40,6 +40,7 @@ SPIDERS = [
     "pi_teresina",
     "pr_curitiba",
     "pr_londrina",
+    "rj_arraial_do_cabo",
     "rj_belford_roxo",
     "rj_nova_iguacu",
     "rj_rio_de_janeiro",


### PR DESCRIPTION
#### Checklist - Novo spider
- [X] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [X] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [X] Você verificou que não existe nenhum erro nos logs (`log/ERROR` igual a zero).
- [X] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [X] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

O código antigo não estava extraindo os diários, fiz algumas alterações e incluí a data de início (resolve https://github.com/okfn-brasil/querido-diario/issues/796). 