### PR TITLE
Add monitor failure description to Discord notification

### DIFF
--- a/data_collection/gazette/monitors.py
+++ b/data_collection/gazette/monitors.py
@@ -76,18 +76,26 @@ class CustomSendDiscordMessage(SendDiscordMessage):
         stats = self.data.stats
         n_scraped_items = stats.get("item_scraped_count", 0)
 
+        failures_report = []
+        for result in self.result.monitor_results:
+            if result.status != "FAIL":
+                continue
+            failures_report.append(f"{result.monitor.name}: {result.reason}")
+
         failures = len(self.result.failures)
         emoji = "\U0001F525" if failures > 0 else "\U0001F60E"
 
-        message = "\n".join(
-            [
-                f"*{self.data.spider.name}* {stats['finish_reason']}",
-                f"- Finish time: *{stats['finish_time']}*",
-                f"- Gazettes scraped: *{n_scraped_items}*",
-                f"- {emoji} {failures} failures {emoji}",
-            ]
-        )
-        return message
+        msg_lines = [
+            f"*{self.data.spider.name}* {stats['finish_reason']}",
+            f"- Finish time: *{stats['finish_time']}*",
+            f"- Gazettes scraped: *{n_scraped_items}*",
+            f"- {emoji} {failures} failures {emoji}",
+        ]
+        if failures_report:
+            msg_lines.append("===== FAILURES =====")
+            msg_lines.extend(failures_report)
+
+        return "\n".join(msg_lines)
 
 
 class SpiderCloseMonitorSuite(MonitorSuite):


### PR DESCRIPTION
Include more information about the failures, so it will be easier to understand what happened to a specific job just looking at the Discord notification message content.
