### PR TITLE
Take num of items returned in current job for days with no gazette mo…

### DIFF
--- a/data_collection/gazette/monitors.py
+++ b/data_collection/gazette/monitors.py
@@ -61,8 +61,10 @@ class ComparisonBetweenSpiderExecutionsMonitor(Monitor):
                 .filter(JobStats.spider == self.data.spider.name)
                 .all()
             )
-            extracted_in_period = sum(
-                [stat.job_stats.get("item_scraped_count", 0) for stat in job_stats]
+            n_scraped_items = self.data.stats.get("item_scraped_count", 0)
+            extracted_in_period = (
+                sum([stat.job_stats.get("item_scraped_count", 0) for stat in job_stats])
+                + n_scraped_items
             )
             self.assertNotEqual(
                 extracted_in_period,


### PR DESCRIPTION
…nitor

Without considering the number of items returned in the current job, we got false failures when we get items in the latest job.
