### PR TITLE
Corrige df_brasilia

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
     -   id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/data_collection/gazette/spiders/df_brasilia.py
+++ b/data_collection/gazette/spiders/df_brasilia.py
@@ -30,6 +30,8 @@ MONTH_MAP = {
 
 
 class DfBrasiliaSpider(BaseGazetteSpider):
+    zyte_smartproxy_enabled = True
+
     TERRITORY_ID = "5300108"
     name = "df_brasilia"
     start_date = datetime.date(1967, 12, 25)


### PR DESCRIPTION
Junto ao @giuliocc, percebemos que o raspador de Brasília estava sendo bloqueado por IP. Adicionamos a cidade ao smartproxy da zyte. 

Este PR também corrige versão do isort usada no projeto. 
