### PR TITLE
Adicionando nova spider SP-Taboão Da Serra

### DIFF
--- a/data_collection/gazette/spiders/sp_taboao_da_serra.py
+++ b/data_collection/gazette/spiders/sp_taboao_da_serra.py
@@ -1,0 +1,63 @@
+from datetime import datetime, date
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class SpTaboaoDaSerraSpider(BaseGazetteSpider):
+
+    """
+    Raspador para as Publicaçoes dos Diarios Oficiais de Taboão da Serra.
+    Atualmente Publicando apenas em uma unica pagina.
+    """
+
+    TERRITORY_ID = "3552809"
+    name = "sp_taboao_da_serra"
+    allowed_domains = ["ts.sp.gov.br"]
+    start_urls = ["https://prefeitura.ts.sp.gov.br/imprensa-oficial/"]
+    start_date = date(2021, 1, 4)
+    end_date = datetime.today().date()
+
+    def parse(self, response):
+
+        links = self.filtro_links(divs=response.css('div[class*=elementor-button-wrapper]'))
+        datas_edits = response.css('div[class*=jet-listing-dynamic-field__content]::text').getall()
+        datas, edits = datas_edits[::2], datas_edits[1::2]
+
+        for info in range(len(links)):
+            data = datetime.strptime(datas[info], "%d/%m/%Y").date()
+            edition_number = edits[info].replace("Edição ", "")
+            if self.start_date <= data <= self.end_date:
+                yield Gazette(
+                    date=data,
+                    edition_number=edition_number,
+                    file_urls=[
+                        links[info],
+                    ],
+                    is_extra_edition=edits[info][-1] in "Ee",
+                    power="legislative",
+                )
+
+    @staticmethod
+    def filtro_links(divs):
+
+        """
+        :param divs: Recebe uma lista de Tags Div para extrair links do PDF
+        :return: Lista com links PDF
+        """
+
+        listas = {
+            "Lista Principal": [],
+            "Lista Complemento": []
+        }
+
+        for links in divs:
+            if links.css('span[class*=elementor-button-text]::text').get() == "Link externo":
+                listas["Lista Principal"].append(links.css('a::attr(href)').get())
+            if links.css('i').get():
+                listas["Lista Complemento"].append(links.css('a::attr(href)').get())
+
+        for filtro in range(len(listas["Lista Principal"])):
+            if str(listas["Lista Principal"][filtro]).find("pdf") == -1:
+                listas["Lista Principal"][filtro] = listas["Lista Complemento"][filtro]
+
+        return listas["Lista Principal"]


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log/ERROR` igual a zero).
- [x] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [x] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

Adiciona spider para Taboão Da Serra, SP

Todos os Diarios Oficiais recentes disponíveis em https://prefeitura.ts.sp.gov.br/imprensa-oficial/ estão sendo coletados pelo códigos.

Todos os Diarios estão em uma única pagina. Irei ficar de olho caso eles mudem isso e se for encontrado algum lugar com os diários mais antigos para poder fazer o acréscimo ao código 