### PR TITLE
Múltiplos raspadores para mesma cidade e múltiplas cidades para mesmo raspador

### DIFF
--- a/data_collection/gazette/database/models.py
+++ b/data_collection/gazette/database/models.py
@@ -48,10 +48,55 @@ def load_territories(engine):
         logger.info("Populating 'territories' table - Done!")
 
 
-def initialize_database(database_url):
+def load_spiders(engine, territory_spider_map):
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    if session.query(QueridoDiarioSpider).count() > 0:
+        return
+
+    logger.info("Populating 'querido_diario_spider' table - Please wait!")
+
+    spiders = []
+    territory_ids = set()
+    for info in territory_spider_map:
+        spider_name, territory_id, date_from = info
+        spiders.append(
+            QueridoDiarioSpider(spider_name=spider_name, date_from=date_from)
+        )
+        territory_ids.add(territory_id)
+
+    session.add_all(spiders)
+    session.commit()
+
+    spiders = (
+        session.query(QueridoDiarioSpider)
+        .filter(
+            QueridoDiarioSpider.spider_name.in_(set(s[0] for s in territory_spider_map))
+        )
+        .all()
+    )
+    spider_map = {spider.spider_name: spider for spider in spiders}
+
+    territories = session.query(Territory).filter(Territory.id.in_(territory_ids)).all()
+    territory_map = {t.id: t for t in territories}
+
+    for info in territory_spider_map:
+        spider_name, territory_id, _ = info
+        spider = spider_map.get(spider_name)
+        territory = territory_map.get(territory_id)
+        if spider is not None and territory is not None:
+            spider.territories.append(territory)
+
+    session.commit()
+    logger.info("Populating 'querido_diario_spider' table - Done!")
+
+
+def initialize_database(database_url, territory_spider_map):
     engine = create_engine(database_url)
     create_tables(engine)
     load_territories(engine)
+    load_spiders(engine, territory_spider_map)
     return engine
 
 

--- a/data_collection/gazette/database/models.py
+++ b/data_collection/gazette/database/models.py
@@ -32,20 +32,21 @@ def load_territories(engine):
     Session = sessionmaker(bind=engine)
     session = Session()
 
-    num_territories = session.query(Territory).count()
-    if num_territories == 0:
-        logger.info("Populating 'territories' table - Please wait!")
-        territories_file = pkg_resources.resource_filename(
-            "gazette", "resources/territories.csv"
-        )
-        with open(territories_file, encoding="utf-8") as csvfile:
-            reader = csv.DictReader(csvfile)
-            territories = []
-            for row in reader:
-                territories.append(Territory(**row))
-            session.bulk_save_objects(territories)
-            session.commit()
-        logger.info("Populating 'territories' table - Done!")
+    if session.query(Territory).count() > 0:
+        return
+
+    logger.info("Populating 'territories' table - Please wait!")
+    territories_file = pkg_resources.resource_filename(
+        "gazette", "resources/territories.csv"
+    )
+    with open(territories_file, encoding="utf-8") as csvfile:
+        reader = csv.DictReader(csvfile)
+        territories = []
+        for row in reader:
+            territories.append(Territory(**row))
+        session.bulk_save_objects(territories)
+        session.commit()
+    logger.info("Populating 'territories' table - Done!")
 
 
 def load_spiders(engine, territory_spider_map):

--- a/data_collection/gazette/database/models.py
+++ b/data_collection/gazette/database/models.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     String,
+    Table,
     Text,
     UniqueConstraint,
     create_engine,
@@ -73,6 +74,14 @@ class Gazette(DeclarativeBase):
     __table_args__ = (UniqueConstraint("territory_id", "date", "file_checksum"),)
 
 
+territory_spider_map = Table(
+    "territory_spider_map",
+    DeclarativeBase.metadata,
+    Column("spider_name", ForeignKey("querido_diario_spiders.spider_name")),
+    Column("territory_id", ForeignKey("territories.id")),
+)
+
+
 class Territory(DeclarativeBase):
     __tablename__ = "territories"
     id = Column(String, primary_key=True)
@@ -80,3 +89,26 @@ class Territory(DeclarativeBase):
     state_code = Column(String)
     state = Column(String)
     gazettes = relationship("Gazette", order_by=Gazette.id, back_populates="territory")
+
+
+class QueridoDiarioSpider(DeclarativeBase):
+    __tablename__ = "querido_diario_spiders"
+
+    spider_name = Column(
+        String,
+        doc="As defined in 'name' attribute of each Spider class.",
+        primary_key=True,
+    )
+    date_from = Column(Date, doc="Initial date this Spider is able to gather data.")
+    date_to = Column(
+        Date,
+        doc="Final date this Spider is able to gather data ('null' if able to gather data in current day)",
+        nullable=True,
+    )
+    enabled = Column(
+        Boolean,
+        default=False,
+        doc="Flag to enable/disable Spider to be executed in production.",
+    )
+
+    territories = relationship("Territory", secondary=territory_spider_map)

--- a/data_collection/gazette/spiders/pe/recife_2015.py
+++ b/data_collection/gazette/spiders/pe/recife_2015.py
@@ -1,0 +1,95 @@
+import datetime as dt
+import re
+
+import scrapy
+from dateutil.rrule import DAILY, rrule
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class PeRecifeSpider_1(BaseGazetteSpider):
+    """Recife's (PE) spider for gazettes from 2015 to 2020
+
+    This spider is implemented to crawl Recife's `gazette system
+    <https://www.cepe.com.br/prefeituradiario/>`_ which covers gazettes from 30/04/2015
+    to 01/08/2020. It uses an underlying API to do so.
+
+    There is also a `deprecated system
+    <http://www.recife.pe.gov.br/diariooficial-acervo/>`_ which covers gazettes from 2001
+    to 2016 which is still not implemented.
+
+    Implementation details:
+        The spider generates all dates from the first available date (30/04/2015) until
+        the last (01/08/2020). These dates are used to fetch the name of all available
+        gazettes on that date, including Recife's. Then, the respective documents for
+        Recife's gazettes are requested and the rest if filtered out.
+
+    Gazettes examples:
+        - http://200.238.105.211/cadernos/2020/20200326/8-PrefeituradoRecifeEdicaoExtra/PrefeituradoRecifeEdicaoExtra(20200326).pdf
+        - http://200.238.105.211/cadernos/2020/20200613/8-PrefeituradoRecife/PrefeituradoRecife(20200613).pdf
+        - http://200.238.105.211/cadernos/2020/20200616/8-PrefeituradoRecife/PrefeituradoRecife(20200616).pdf
+    """
+
+    name = "recife_2015"
+    TERRITORY_ID = "2611606"
+
+    start_date = dt.date(2015, 4, 30)
+    end_date = dt.date(2020, 8, 1)
+    allowed_domains = ["ws.cepe.com.br", "200.238.105.211"]
+    EDITIONS_IN_DATE_URL = "https://ws.cepe.com.br/publicar/dows.php?&dia={full_date}"
+    GAZETTE_URL = "http://200.238.105.211/cadernos/{full_year}/{full_date}/{edition_type}/{edition_type_name_only}({full_date}).pdf"
+
+    def start_requests(self):
+        """
+        Requests documents which specifies edition types available for dates.
+        """
+        dates = rrule(freq=DAILY, dtstart=self.start_date, until=self.end_date)
+
+        for date in dates:
+            yield scrapy.Request(
+                url=self.EDITIONS_IN_DATE_URL.format(full_date=date.strftime("%Y%m%d")),
+                meta={"date": date.date()},
+                callback=self.parse_editions_in_date,
+            )
+
+    def parse_editions_in_date(self, response):
+        """
+        Parses available editions to request only Recife's gazette documents.
+        """
+        recife_editions = self._find_recife_editions(response.text)
+        date = response.meta["date"]
+
+        for edition in recife_editions:
+            url = self.GAZETTE_URL.format(
+                full_year=date.strftime("%Y"),
+                full_date=date.strftime("%Y%m%d"),
+                edition_type=edition,
+                edition_type_name_only=re.search(r"\w+$", edition).group(),
+            )
+
+            yield Gazette(
+                date=date,
+                file_urls=[url],
+                is_extra_edition=self._is_extra(edition),
+                power="executive_legislative",
+            )
+
+    def _find_recife_editions(self, text):
+        """
+        Finds editions related to Recife's gazette.
+
+        Filters out entries which are not exclusively related to Recife
+        (e.g. "1-PoderExecutivo").
+        """
+        return (
+            edition
+            for edition in text.split("&")
+            if re.search("prefeituradorecife", edition, re.IGNORECASE)
+        )
+
+    def _is_extra(self, edition):
+        """
+        Checks if edition is extra or not.
+        """
+        return re.search("extra", edition, re.IGNORECASE) is not None

--- a/data_collection/gazette/spiders/pe/recife_2020.py
+++ b/data_collection/gazette/spiders/pe/recife_2020.py
@@ -3,100 +3,12 @@ import re
 
 import scrapy
 from chompjs import parse_js_object
-from dateutil.rrule import DAILY, rrule
 
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
 
-class PeRecifeSpiderAcervo2015A2020(BaseGazetteSpider):
-    """Recife's (PE) spider for gazettes from 2015 to 2020
-
-    This spider is implemented to crawl Recife's `gazette system
-    <https://www.cepe.com.br/prefeituradiario/>`_ which covers gazettes from 30/04/2015
-    to 01/08/2020. It uses an underlying API to do so.
-
-    There is also a `deprecated system
-    <http://www.recife.pe.gov.br/diariooficial-acervo/>`_ which covers gazettes from 2001
-    to 2016 which is still not implemented.
-
-    Implementation details:
-        The spider generates all dates from the first available date (30/04/2015) until
-        the last (01/08/2020). These dates are used to fetch the name of all available
-        gazettes on that date, including Recife's. Then, the respective documents for
-        Recife's gazettes are requested and the rest if filtered out.
-
-    Gazettes examples:
-        - http://200.238.105.211/cadernos/2020/20200326/8-PrefeituradoRecifeEdicaoExtra/PrefeituradoRecifeEdicaoExtra(20200326).pdf
-        - http://200.238.105.211/cadernos/2020/20200613/8-PrefeituradoRecife/PrefeituradoRecife(20200613).pdf
-        - http://200.238.105.211/cadernos/2020/20200616/8-PrefeituradoRecife/PrefeituradoRecife(20200616).pdf
-    """
-
-    name = "pe_recife_acervo_2015_a_2020"
-    TERRITORY_ID = "2611606"
-
-    start_date = dt.date(2015, 4, 30)
-    end_date = dt.date(2020, 8, 1)
-    allowed_domains = ["ws.cepe.com.br", "200.238.105.211"]
-    EDITIONS_IN_DATE_URL = "https://ws.cepe.com.br/publicar/dows.php?&dia={full_date}"
-    GAZETTE_URL = "http://200.238.105.211/cadernos/{full_year}/{full_date}/{edition_type}/{edition_type_name_only}({full_date}).pdf"
-
-    def start_requests(self):
-        """
-        Requests documents which specifies edition types available for dates.
-        """
-        dates = rrule(freq=DAILY, dtstart=self.start_date, until=self.end_date)
-
-        for date in dates:
-            yield scrapy.Request(
-                url=self.EDITIONS_IN_DATE_URL.format(full_date=date.strftime("%Y%m%d")),
-                meta={"date": date.date()},
-                callback=self.parse_editions_in_date,
-            )
-
-    def parse_editions_in_date(self, response):
-        """
-        Parses available editions to request only Recife's gazette documents.
-        """
-        recife_editions = self._find_recife_editions(response.text)
-        date = response.meta["date"]
-
-        for edition in recife_editions:
-            url = self.GAZETTE_URL.format(
-                full_year=date.strftime("%Y"),
-                full_date=date.strftime("%Y%m%d"),
-                edition_type=edition,
-                edition_type_name_only=re.search(r"\w+$", edition).group(),
-            )
-
-            yield Gazette(
-                date=date,
-                file_urls=[url],
-                is_extra_edition=self._is_extra(edition),
-                power="executive_legislative",
-            )
-
-    def _find_recife_editions(self, text):
-        """
-        Finds editions related to Recife's gazette.
-
-        Filters out entries which are not exclusively related to Recife
-        (e.g. "1-PoderExecutivo").
-        """
-        return (
-            edition
-            for edition in text.split("&")
-            if re.search("prefeituradorecife", edition, re.IGNORECASE)
-        )
-
-    def _is_extra(self, edition):
-        """
-        Checks if edition is extra or not.
-        """
-        return re.search("extra", edition, re.IGNORECASE) is not None
-
-
-class PeRecifeSpider(BaseGazetteSpider):
+class PeRecifeSpider_2(BaseGazetteSpider):
     """Raspador para as publicações atuais de Recife (PE)
 
     Este raspador cobre o `sistema de publicações atual de Recife (PE)
@@ -115,10 +27,10 @@ class PeRecifeSpider(BaseGazetteSpider):
         - `Ambas publicações <https://dome.recife.pe.gov.br/dome/doDia.php?dataEdicao=2022-01-29>`_
     """
 
-    name = "pe_recife"
+    name = "recife_2020"
     TERRITORY_ID = "2611606"
 
-    start_date = dt.date(2020, 8, 1)
+    start_date = dt.date(2020, 8, 2)
     allowed_domains = ["dome.recife.pe.gov.br"]
     BASE_URL = "https://dome.recife.pe.gov.br/dome/"
     start_urls = [BASE_URL]

--- a/scripts/enabled_spiders.py
+++ b/scripts/enabled_spiders.py
@@ -54,7 +54,7 @@ SPIDERS = [
     "pa_belem",
     "pe_jaboatao_dos_guararapes",
     "pe_petrolina",
-    "pe_recife",
+    "recife_2020",
     "pb_joao_pessoa",
     "pi_teresina",
     "pr_cafelandia",


### PR DESCRIPTION
Essa é uma alternativa a solução proposta em https://github.com/okfn-brasil/querido-diario/pull/837

Algumas possíveis vantagens:

- Evita alterar o comando `crawl` do Scrapy. Isso reduz o risco de adicionarmos coisas incompatíveis com a `Scrapy Cloud`, plataforme onde estamos executando os raspadores atualmente;

- Manter o comportamento padrão do `scrapy crawl` retira uma barreira para novos desenvolvedores e aquelas com pouca experiência com Scrapy;

- Permite habilitar/desabilitar raspadores existentes alterando o banco de dados (necessário implantar um endpoint na API para gerenciar isso);

- A execução é por spider e não por cidade, já que existem situações onde um spider atende múltiplas cidades;

- A responsabilidade de chamar os spiders certos a partir da data fica totalmente com o agendador de tarefas.

Acredito que esse PR já pode ser mergeado. Porém em seguida é necessário:

- Alterar os scripts de agendamento para fazer as buscas com o banco de dados
- Criar uma API para habilitar/desabilitar spiders

