### PR TITLE
Add Taiobeiras (MG)

### DIFF
--- a/data_collection/gazette/spiders/mg_taiobeiras.py
+++ b/data_collection/gazette/spiders/mg_taiobeiras.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.instar import BaseInstarSpider
+
+
+class MgTaiobeiras(BaseInstarSpider):
+    TERRITORY_ID = "3168002"
+    name = "mg_taiobeiras"
+    allowed_domains = ["taiobeiras.mg.gov.br"]
+    base_url = "https://www.taiobeiras.mg.gov.br/portal/diario-oficial"
+    start_date = date(2022, 12, 31)  # Primeira edicao

--- a/scripts/enabled_spiders.py
+++ b/scripts/enabled_spiders.py
@@ -28,6 +28,7 @@ SPIDERS = [
     "mg_contagem",
     "mg_itauna",
     "mg_nova_serrana",
+    "mg_taiobeiras",
     "mg_uberaba",
     "mg_varzea_da_palma",
     "ms_campo_grande",


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log/ERROR` igual a zero).
- [x] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [x] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

Inclusão de três municípios que utilizam o sistema Instar de gerenciamento de diários oficiais em Minas Gerais, sendo estes, Januária, Onça de Pitangui e Taiobeiras. Em relação ao município de [Onça de Pitangui](www.oncadopitangui.mg.gov.br/), a cidade utiliza dois nomes (Onça de(do) Pitangui), portanto, utilizei somente o nome ao qual consta no IBGE e na aba [Dados do Município](https://www.oncadopitangui.mg.gov.br/portal/servicos/1008/dados-do-municipio/).
