### PR TITLE
Corrige nome de parâmetro da action schedule_spider

### DIFF
--- a/.github/workflows/schedule_spider.yaml
+++ b/.github/workflows/schedule_spider.yaml
@@ -10,7 +10,7 @@ on:
         description: 'Start date (YYYY-MM-DD)'
         required: false
       end_date:
-        description: 'Start date (YYYY-MM-DD)'
+        description: 'End date (YYYY-MM-DD)'
         required: false
 
 jobs:


### PR DESCRIPTION
#### Descrição

Corrige nome do parâmetro "end date" da action `schedule_spider` que aparece na interface.