### PR TITLE
Alterada classe BaseSiganetSpider e incluído ma_sao_luis

### DIFF
--- a/data_collection/gazette/spiders/base/siganet.py
+++ b/data_collection/gazette/spiders/base/siganet.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 
 import scrapy
 
@@ -7,22 +7,88 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class BaseSiganetSpider(BaseGazetteSpider):
+    # until now the base url for download is the same in both versions. No need to customise
+    P_BASE_URL_DOWNLOAD = (
+        "https://painel.siganet.net.br/upload/{}/cms/publicacoes/diario"
+    )
+    # P_VERSION
+    # Version 1: (default) ma_coroata e ma_sao_jose_dos_basilios
+    # Version 2: ma_sao_luis
+    P_VERSION = "1"
+    # values for default version 1
+    P_MUST_GET_COOKIE = False  # Not needed in the default version
+    P_URL_DIR_GET_COOKIE = ""  # Not needed in the default version
+    P_URL_DIR_SEARCH = "listarDiario/"
+    P_KEY_URL_FILENAME = "TDI_ARQUIVO"
+    P_KEY_DATE = "TDI_DT_PUBLICACAO"
+    P_KEY_EDITION_NUMBER = "TDI_EDICAO"
+    P_KEY_EXTRA_EDITION = ""  # Not needed in the default version
+    P_KEY_CLIENT_ID = "TDI_TPS_ID"
+    P_CLIENT_ID = ""  # Not needed in the default version
+    P_POWER = "executive_legislative"
+
+    def set_version_params(self, version_number):
+        # values for version 2
+        if version_number == "2":
+            self.P_MUST_GET_COOKIE = True
+            self.P_URL_DIR_GET_COOKIE = (
+                "todasEdicoes/"  # Not needed in the default version
+            )
+            self.P_URL_DIR_SEARCH = "pesquisaEdicoes/"
+            self.P_KEY_URL_FILENAME = "TDO_ASSINADO_ARQUIVO"
+            self.P_KEY_DATE = "TDO_DT_GERACAO"
+            self.P_KEY_EDITION_NUMBER = "TDO_EDICAO"
+            self.P_KEY_EXTRA_EDITION = "TDO_EDICAO_EXTRA"
+            self.P_KEY_CLIENT_ID = "TDI_TPS_ID"
+            self.P_CLIENT_ID = "485"
+            self.P_POWER = "executive_legislative"
+
     def start_requests(self):
-        yield scrapy.Request(f"{self.BASE_URL}/listarDiario")
+        # set the apropriate params according to the version
+        self.set_version_params(self.P_VERSION)
+        """must call the main page to get the cookie
+        otherwise you can't get the json with the listing
+        """
+        if self.P_MUST_GET_COOKIE:
+            yield scrapy.Request(
+                f"{self.BASE_URL}/{self.P_URL_DIR_GET_COOKIE}",
+                callback=self.parse_cookie,
+            )
+        else:
+            yield scrapy.Request(f"{self.BASE_URL}/{self.P_URL_DIR_SEARCH}")
 
     def parse(self, response):
         for gazette in response.json()["data"]:
-            gazette_date = datetime.datetime.strptime(
-                gazette["TDI_DT_PUBLICACAO"], "%Y-%m-%d %H:%M:%S"
-            ).date()
+            gazette_date = gazette[self.P_KEY_DATE]
+            gazette_date = datetime.strptime(gazette_date, "%Y-%m-%d %H:%M:%S").date()
 
-            file_id = gazette["TDI_TPS_ID"].zfill(10)
-            gazette_url = f"https://painel.siganet.net.br/upload/{file_id}/cms/publicacoes/diario/{gazette['TDI_ARQUIVO']}"
+            if self.P_CLIENT_ID == "":
+                gazette_url_client_id = gazette[self.P_KEY_CLIENT_ID].zfill(10)
+            else:
+                gazette_url_client_id = self.P_CLIENT_ID.zfill(10)
+
+            gazette_url_filename = gazette[self.P_KEY_URL_FILENAME]
+            gazette_url_base_download = self.P_BASE_URL_DOWNLOAD.format(
+                gazette_url_client_id
+            )
+            gazette_url = f"{gazette_url_base_download}/{gazette_url_filename}"
+            gazette_edition_number = gazette[self.P_KEY_EDITION_NUMBER]
+            if self.P_KEY_EXTRA_EDITION == "":
+                gazette_is_extra_edition = False
+            else:
+                gazette_is_extra_edition = gazette[self.P_KEY_EXTRA_EDITION].lower()
+                gazette_is_extra_edition = "extra" in gazette_is_extra_edition
 
             if self.start_date <= gazette_date <= self.end_date:
                 yield Gazette(
                     date=gazette_date,
+                    edition_number=gazette_edition_number,
                     file_urls=[gazette_url],
-                    edition_number=gazette["TDI_EDICAO"],
-                    power="executive_legislative",
+                    is_extra_edition=gazette_is_extra_edition,
+                    territory_id=self.TERRITORY_ID,
+                    scraped_at=datetime.utcnow(),
+                    power=self.P_POWER,
                 )
+
+    def parse_cookie(self, response):
+        yield scrapy.Request(f"{self.BASE_URL}/{self.P_URL_DIR_SEARCH}")

--- a/data_collection/gazette/spiders/ma_sao_luis.py
+++ b/data_collection/gazette/spiders/ma_sao_luis.py
@@ -10,3 +10,4 @@ class MaSaoLuis(BaseSiganetSpider):
     allowed_domains = ["diariooficial.saoluis.ma.gov.br"]
     BASE_URL = "https://diariooficial.saoluis.ma.gov.br/dom/dom"
     P_VERSION = "2"  # see BaseSiganetSpider
+    P_POWER = "executive"

--- a/data_collection/gazette/spiders/ma_sao_luis.py
+++ b/data_collection/gazette/spiders/ma_sao_luis.py
@@ -1,0 +1,12 @@
+import datetime
+
+from gazette.spiders.base.siganet import BaseSiganetSpider
+
+
+class MaSaoLuis(BaseSiganetSpider):
+    TERRITORY_ID = "2111300"
+    name = "ma_sao_luis"
+    start_date = datetime.date(1993, 1, 4)
+    allowed_domains = ["diariooficial.saoluis.ma.gov.br"]
+    BASE_URL = "https://diariooficial.saoluis.ma.gov.br/dom/dom"
+    P_VERSION = "2"  # see BaseSiganetSpider


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [x] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [x] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

Alterada classe BaseSiganetSpider (siganet.py) para comportar a versão usada por ma_coroata e ma_sao_jose_dos_basilios  sem quebrar, juntamente com a versão usada por ma_sao_luis. Adicionado spider para ma_sao_luis.

Executei ma_sao_luis, ma_coroata e ma_sao_jose_dos_basilios com sucesso.  Alguns comentários sobre a WARNINGs que ocorreram na execução de São Luis/MA

1. Alguns checksum (arquivos iguais (mesmo checksum) em data diferentes: 

parece ser algum erro que levou a duplicidades de arquivos.

2. tamanho do arquivo maior que o maior que o padrão do scrapy:
Excedeu os 32Mb padrão do Scrapy. Avaliar a possibilidade de alterar esse valor nas configurações. 
https://doc.scrapy.org/en/latest/topics/settings.html?highlight=download_max#std-reqmeta-download_maxsize

Segue o log com todos warnings:

2023-06-19 17:08:01 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (36065267) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/dom-prefeitura-municipal-de-sao-luis-ano-xliii-edicao-0337-assinado.pdf>.
2023-06-19 17:08:09 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/dom-prefeitura-municipal-de-sao-luis-ano-xliii-edicao-0337-assinado.pdf>.
2023-06-19 17:08:14 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (217620867) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-006-S-86F1.pdf>.
2023-06-19 17:08:25 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-006-S-86F1.pdf>.
2023-06-19 17:09:09 [ma_sao_luis] WARNING: Something wrong has happened when adding the gazette in the database. Date: 2015-02-23. File Checksum: dca5588767f19c8d775dd2e317cb2da6. Details: ('(sqlite3.IntegrityError) UNIQUE constraint failed: gazettes.territory_id, gazettes.date, gazettes.file_checksum',)
2023-06-19 17:09:11 [ma_sao_luis] WARNING: Something wrong has happened when adding the gazette in the database. Date: 2015-02-24. File Checksum: af33a169e8eaa7d7684e3c1002ae8bdd. Details: ('(sqlite3.IntegrityError) UNIQUE constraint failed: gazettes.territory_id, gazettes.date, gazettes.file_checksum',)
2023-06-19 17:09:13 [ma_sao_luis] WARNING: Something wrong has happened when adding the gazette in the database. Date: 2015-02-25. File Checksum: bbfebba5e3e64cc583ec987401896f5c. Details: ('(sqlite3.IntegrityError) UNIQUE constraint failed: gazettes.territory_id, gazettes.date, gazettes.file_checksum',)
2023-06-19 17:09:32 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (34254118) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-051-N-1B33.pdf>.
2023-06-19 17:09:34 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (37101525) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2016-053-S-00F8.pdf>.
2023-06-19 17:09:40 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-051-N-1B33.pdf>.
2023-06-19 17:09:43 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2016-053-S-00F8.pdf>.
2023-06-19 17:11:19 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (168516559) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-100-S-D6D3.pdf>.
2023-06-19 17:11:25 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-100-S-D6D3.pdf>.
2023-06-19 17:11:37 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (109342702) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2020-109-S-AFFD.pdf>.
2023-06-19 17:11:45 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2020-109-S-AFFD.pdf>.
2023-06-19 17:12:23 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (45330644) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2018-123-S-870D.pdf>.
2023-06-19 17:12:28 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2018-123-S-870D.pdf>.
2023-06-19 17:12:43 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (36148669) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-127-N-D58C.pdf>.
2023-06-19 17:12:46 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (34337939) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2021-128-S-5212.pdf>.
2023-06-19 17:12:52 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (34830033) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-130-N-6691.pdf>.
2023-06-19 17:12:52 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-127-N-D58C.pdf>.
2023-06-19 17:12:58 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-130-N-6691.pdf>.
2023-06-19 17:13:00 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2021-128-S-5212.pdf>.
2023-06-19 17:13:15 [ma_sao_luis] WARNING: Something wrong has happened when adding the gazette in the database. Date: 2013-07-22. File Checksum: 63d64bca1e92e700dcdcf5062a144711. Details: ('(sqlite3.IntegrityError) UNIQUE constraint failed: gazettes.territory_id, gazettes.date, gazettes.file_checksum',)
2023-06-19 17:14:04 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (90352492) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-165-S-IEVD.pdf>.
2023-06-19 17:14:09 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-165-S-IEVD.pdf>.
2023-06-19 17:14:11 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (69845184) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-169-N-GFTR.pdf>.
2023-06-19 17:14:19 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2022-169-N-GFTR.pdf>.
2023-06-19 17:15:52 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (233851735) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2018-236-S-04F1.pdf>.
2023-06-19 17:15:57 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2018-236-S-04F1.pdf>.
2023-06-19 17:15:58 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (85478923) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2018-239-S-0DC5.pdf>.
2023-06-19 17:16:05 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2018-239-S-0DC5.pdf>.
2023-06-19 17:16:14 [scrapy.core.downloader.handlers.http11] WARNING: Expected response size (50316556) larger than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2017-242-S-9BAE.pdf>.
2023-06-19 17:16:24 [scrapy.core.downloader.handlers.http11] WARNING: Received more bytes than download warn size (33554432) in request <GET https://painel.siganet.net.br/upload/0000000485/cms/publicacoes/diario/DOM-2017-242-S-9BAE.pdf>.