### PR TITLE
Modificando pa_ananindeua que estava quebrado

### DIFF
--- a/data_collection/gazette/spiders/pa_ananindeua.py
+++ b/data_collection/gazette/spiders/pa_ananindeua.py
@@ -1,7 +1,8 @@
-from datetime import datetime
+from datetime import datetime, date
+import re
 
 import dateparser
-from scrapy import Request
+import scrapy
 
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
@@ -11,36 +12,46 @@ class PaAnanindeuaSpider(BaseGazetteSpider):
     TERRITORY_ID = "1500800"
     name = "pa_ananindeua"
     allowed_domains = ["ananindeua.pa.gov.br"]
-    start_urls = ["http://www.ananindeua.pa.gov.br/diario/inicio/diarios-pdf"]
-    FILE_ELEMENT_CSS = "div#content div div#online_arquivo a::attr(href)"
-    DATE_ELEMENT_CSS = "div#content div div#online_data::text"
-    DATE_FORMAT = "%d/%m/%Y"
+    URL_BASE = "https://www.ananindeua.pa.gov.br"
+    NUMBER_REGEX = re.compile(r"DI[AÁ]RIO N.\s*(\d+)", re.IGNORECASE)
+    DATE_REGEX = re.compile(r"Data da Publicação: (.+)", re.IGNORECASE)
+    start_date = date(2008, 12, 1)
 
-    def parse(self, response):
-        # Year ids are not truly sequential, this offset prevent from missing someone
-        offset = 5
-        avaliable_years_ids = datetime.now().year - 2008
+    def start_requests(self):
+        url = f"{self.URL_BASE}/diario_oficial?titulo=&dataini={self.start_date}&datafim={self.end_date}&order=1&go=Buscar&bt_buscar=buscar"
+        yield scrapy.Request(url, callback=self.parse_page)
 
-        for year_id, month_id in zip(
-            range(1, avaliable_years_ids + offset), range(1, 13)
-        ):
-            yield Request(
-                url=f"{response.url}?id={year_id}&mes={month_id}",
-                callback=self.parse_month,
+    def parse_page(self, response):
+        # pagination
+        next_page_url = response.css("div#pgnav_next>a::attr(href)").get()
+        if next_page_url != None:
+            yield scrapy.Request(
+                f"{self.URL_BASE}{next_page_url}", callback=self.parse_page
             )
-
-    def parse_month(self, response):
-        file_urls = response.css(self.FILE_ELEMENT_CSS).extract()
-        dates = response.css(self.DATE_ELEMENT_CSS).extract()
-
-        for date_str, file_url in zip(dates, file_urls):
-            date = dateparser.parse(date_str, date_formats=[self.DATE_FORMAT]).date()
-            url = response.urljoin(file_url)
+        # gazettes on page
+        all_gazette_cards = response.css("div.item_lic")
+        for gazette_card in all_gazette_cards:
+            card_title = gazette_card.css("div>div::text").get().strip()
+            match = self.NUMBER_REGEX.search(card_title)
+            if match:
+                gazette_number = match.group(1)
+            else:
+                gazette_number = ""
+            gazette_date = self.DATE_REGEX.search(
+                gazette_card.css("div>div>div::text").get().strip()
+            ).group(1)
+            gazette_date = dateparser.parse(
+                gazette_date, settings={"DATE_ORDER": "DMY"}
+            )
+            gazette_date = gazette_date.date()
+            url = gazette_card.css("a::attr(href)").get()
+            gazette_url = f"{self.URL_BASE}{url}"
 
             yield Gazette(
-                date=date,
-                file_urls=[url],
-                is_extra_edition="extra" in url.lower(),
+                date=gazette_date,
+                edition_number=gazette_number,
+                file_urls=[gazette_url],
+                is_extra_edition="extra" in card_title.lower(),
                 territory_id=self.TERRITORY_ID,
                 scraped_at=datetime.utcnow(),
                 power="executive",


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [x] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [x] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição
Modificado pa_ananindeua para adaptar ao novo sistema, já que o antigo estava quebrado.

Após execução tudo ok, apenas WARNINGs ('(sqlite3.IntegrityError) UNIQUE constraint failed: gazettes.territory_id, gazettes.date, gazettes.file_checksum',) de arquivos com checksum duplicados.
