### PR TITLE
pb_joao_pessoa: Pequena correção para restringir pela data final (end…

### DIFF
--- a/data_collection/gazette/spiders/pb/pb_joao_pessoa.py
+++ b/data_collection/gazette/spiders/pb/pb_joao_pessoa.py
@@ -28,12 +28,13 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
                 raw_gazette_date, "%d/%m/%Y"
             ).date()
 
-            yield Gazette(
-                date=gazette_date,
-                edition_number=edition_number,
-                file_urls=[gazette_url],
-                power="executive_legislative",
-            )
+            if gazette_date >= self.start_date and gazette_date <= self.end_date:
+                yield Gazette(
+                    date=gazette_date,
+                    edition_number=edition_number,
+                    file_urls=[gazette_url],
+                    power="executive_legislative",
+                )
 
             if gazette_date < self.start_date:
                 follow_next_page = False

--- a/data_collection/gazette/spiders/pb/pb_joao_pessoa.py
+++ b/data_collection/gazette/spiders/pb/pb_joao_pessoa.py
@@ -13,8 +13,6 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
     start_urls = ["https://www.joaopessoa.pb.gov.br/doe-jp/"]
 
     def parse(self, response):
-        follow_next_page = True
-
         gazettes = response.css("h4.card-title")
         for gazette in gazettes:
             gazette_url = gazette.xpath(".//following-sibling::a/@href").get()
@@ -28,18 +26,18 @@ class PbJoaoPessoaSpider(BaseGazetteSpider):
                 raw_gazette_date, "%d/%m/%Y"
             ).date()
 
-            if gazette_date >= self.start_date and gazette_date <= self.end_date:
-                yield Gazette(
-                    date=gazette_date,
-                    edition_number=edition_number,
-                    file_urls=[gazette_url],
-                    power="executive_legislative",
-                )
+            if gazette_date > self.end_date:
+                continue
+            elif gazette_date < self.start_date:
+                return
 
-            if gazette_date < self.start_date:
-                follow_next_page = False
-                break
+            yield Gazette(
+                date=gazette_date,
+                edition_number=edition_number,
+                file_urls=[gazette_url],
+                power="executive_legislative",
+            )
 
         next_page_url = response.css("a.next::attr(href)").get()
-        if follow_next_page and next_page_url:
+        if next_page_url:
             yield scrapy.Request(next_page_url)


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

Não é o caso de novo spider. É manutenção de antigo. De qualquer modo, estou checando a lista

#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [x] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [x] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição
pb_joao_pessoa: Pequena correção para restringir a coleta de itens pelas datas (start_date e end_date), principalmente para a data final, pois estava raspando até a data mais recente.