### PR TITLE
Atualiza spider base DOSP e adiciona Cafelandia-PR

### DIFF
--- a/data_collection/gazette/spiders/pr_cafelandia.py
+++ b/data_collection/gazette/spiders/pr_cafelandia.py
@@ -1,0 +1,10 @@
+from datetime import date
+
+from gazette.spiders.base.dosp import DospGazetteSpider
+
+
+class PrCafelandiaSpider(DospGazetteSpider):
+    TERRITORY_ID = "3508801"
+    name = "pr_cafelandia"
+    code = "4748"
+    start_date = date(2017, 6, 12)


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [x] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [x] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição
- Resolve #895
- Adiciona Cafelandia-PR

Em comparação com o conteúdo de issue #895, agora temos: 
1. `edition_number` sendo apenas números
2. Regex que verifica se há letras (A, B, C...) junto ao número da edição e preenche se é uma edição extra a partir disso.
3. Filtro por data correto

![image](https://github.com/okfn-brasil/querido-diario/assets/44185775/e48380dd-9ae3-4972-93b6-9894f5150603)
