### PR TITLE
[novo spider] Cariacica-ES

### DIFF
--- a/data_collection/gazette/spiders/es_cariacica.py
+++ b/data_collection/gazette/spiders/es_cariacica.py
@@ -1,0 +1,64 @@
+import datetime
+import re
+from urllib.parse import urlencode, urlparse, urlunparse
+
+from dateutil.rrule import WEEKLY, rrule
+from scrapy.http import Request
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class EsCariacicaSpider(BaseGazetteSpider):
+    name = "es_cariacica"
+    TERRITORY_ID = "3201308"
+    start_date = datetime.date(2014, 7, 1)
+    BASE_URL = "https://www.cariacica.es.gov.br/publicacoes/diario-oficial/"
+
+    def start_requests(self):
+        search_period = rrule(freq=WEEKLY, dtstart=self.start_date, until=self.end_date)
+
+        for date in search_period:
+            start = date.strftime("%Y-%m-%d")
+            last_day = date + datetime.timedelta(days=6)
+
+            if last_day.date() > self.end_date:
+                end = self.end_date.strftime("%Y-%m-%d")
+            else:
+                end = last_day.strftime("%Y-%m-%d")
+
+            interval = {"inicio": start, "fim": end}
+            url = f"{self.BASE_URL}?{urlencode(interval)}"
+
+            yield Request(url=url, callback=self.parse_week)
+
+    def parse_week(self, response):
+        cards_list = response.css("div.card div.card-header")
+
+        for card in cards_list[1:]:
+            date = card.xpath("./b/text()").get()
+            gazette_date = datetime.datetime.strptime(date, "%d/%m/%Y").date()
+
+            card_content = card.xpath("./following-sibling::table/tr")
+            for gazette in card_content[1:]:
+                link = response.urljoin(gazette.xpath("./td[4]/a/@href").get())
+                gazette_link = self._url_fix(link)
+
+                title = gazette.xpath("./td[1]/text()").get()
+                extra_edition = "extra" in title.lower()
+                edition = re.search(r"EDIÇÃO (N.+?)?(\d+)", title)
+                gazette_edition = edition.group(2) if edition is not None else ""
+
+                yield Gazette(
+                    date=gazette_date,
+                    file_urls=[gazette_link],
+                    is_extra_edition=extra_edition,
+                    edition_number=gazette_edition,
+                    power="executive_legislative",
+                )
+
+    def _url_fix(self, link):
+        link = urlparse(link)
+        fixed_path = link.path.replace("uploads/2", "uploads//2")
+        link = link._replace(scheme="https", path=fixed_path)
+        return urlunparse(link)

--- a/scripts/enabled_spiders.py
+++ b/scripts/enabled_spiders.py
@@ -14,6 +14,7 @@ SPIDERS = [
     "ba_senhor_do_bonfim",
     "ce_sobral",
     "df_brasilia",
+    "es_cariacica",
     "es_serra",
     "es_vila_velha",
     "go_aparecida_de_goiania",


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [x] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [x] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição
Este PR finaliza o trabalho começado por @cecivieira no PR #448. Não consegui reabrir o PR e continuar por lá, por isso submeto um novo.