### PR TITLE
Adiciona raspador para Porto Nacional-TO (#868)

### DIFF
--- a/data_collection/gazette/spiders/to_porto_nacional.py
+++ b/data_collection/gazette/spiders/to_porto_nacional.py
@@ -1,0 +1,50 @@
+import datetime
+import re
+import scrapy
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+import dateparser
+
+
+class ToPortoNacionalSpider(BaseGazetteSpider):
+    TERRITORY_ID = "1718204"
+    name = "to_porto_nacional"
+    allowed_domains = ["diariooficial.portonacional.to.gov.br"]
+    start_urls = ["https://diariooficial.portonacional.to.gov.br/edicoes"]    
+    start_date = datetime.date(2021, 2, 25)
+    end_date = datetime.datetime.today().date()
+       
+    def parse(self, response):
+            
+        editions = response.xpath('//table[@class="table"]/tbody/tr')    
+        for edition in editions:
+            
+            link = edition.xpath('./td[3]/div/a/@href').get()
+            title = edition.xpath('./td[1]/strong/text()').get()
+            edition_number = re.search(r'EDIÇÃO Nº (\d+)', title).group(1)
+            date_text = edition.xpath('./td[1]/br/following-sibling::text()').get().strip()
+            date = dateparser.parse(date_text, languages=["pt"]).date()
+            is_extra_edition = "suplement" in title.lower()
+            
+            if date < self.start_date:
+                return
+            
+            if date <= self.end_date:
+                
+                gazette_item = Gazette(
+                    date=date,
+                    edition_number=edition_number, 
+                    file_urls=[link], 
+                    power="executive",
+                    is_extra_edition=is_extra_edition,
+                    )
+                
+                yield gazette_item
+        
+        next_page_link = response.xpath('//a[@rel="next"]/@href').get()
+        
+        if next_page_link:
+            yield scrapy.Request( 
+                url=next_page_link,
+                callback=self.parse,
+            ) 


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [x] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [x] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

Raspador de **Porto Nacional (TO)** que resolve a issue #868 
O código foi escrito durante o curso _**Python para a Inovação Cívica**_, nos encontros do _Módulo Extra_, sob a batuta de  @ogecece, e em parceria com @mcaponera, @Leticia07, @dvths e outros alunos do módulo.
