### PR TITLE
Corrige conflitos de produção (#929)

### DIFF
--- a/data_collection/gazette/settings.py
+++ b/data_collection/gazette/settings.py
@@ -1,4 +1,5 @@
-import pkg_resources
+import importlib.resources
+
 from decouple import config
 
 BOT_NAME = "gazette"
@@ -27,7 +28,7 @@ EXTENSIONS = {
 }
 SPIDERMON_ENABLED = config("SPIDERMON_ENABLED", default=True, cast=bool)
 SPIDERMON_VALIDATION_SCHEMAS = [
-    pkg_resources.resource_filename("gazette", "resources/gazette_schema.json")
+    importlib.resources.files("gazette") / "resources/gazette_schema.json"
 ]
 
 SPIDERMON_VALIDATION_ADD_ERRORS_TO_ITEMS = True


### PR DESCRIPTION
### Descrição
Resolve #929 

### Comentários
Atualizando minha venv local com os novos requirements, a execução de Prado-BA - mesmo raspador apontado na issue, coletando apenas desde agosto/23 até hoje, gera os seguintes arquivos: 
[prado_com_erro.csv](https://github.com/okfn-brasil/querido-diario/files/12612259/prado_com_erro.csv) - vazio
[prado_com_erro.txt](https://github.com/okfn-brasil/querido-diario/files/12612261/prado_com_erro.txt)

Ao fazer as atualizações propostas neste PR, temos (para o mesmo período de coleta):
[prado_modificado.csv](https://github.com/okfn-brasil/querido-diario/files/12612271/prado_modificado.csv) - coleta com sucesso
[prado_modificado.txt](https://github.com/okfn-brasil/querido-diario/files/12612273/prado_modificado.txt)

Atualizar a biblioteca deprecada `pkg_resources` foi um dos erros apontados em #929. Segui as instruções em https://importlib-resources.readthedocs.io/en/latest/migration.html para isso. Pareceu funcionar. 

Quanto ao erro de validação apontado na issue #929, há uma issue aberta no repositório do Spidermon, que dialoga com o problema: https://github.com/scrapinghub/spidermon/issues/379. Não tive certeza o que fazer com isso. 

Abro o PR como ponto de partida do que já enderecei, porém talvez haja outras verificações e modificações para fazer.

