### PR TITLE
 Fix date, datetime and database validation to allow upgrade of Spidermon (Variation)

### DIFF
--- a/data_collection/gazette/items.py
+++ b/data_collection/gazette/items.py
@@ -15,3 +15,5 @@ class Gazette(scrapy.Item):
     scraped_at = scrapy.Field()
     file_urls = scrapy.Field()
     files = scrapy.Field()
+    _validation = scrapy.Field()
+    date_string = scrapy.Field()

--- a/data_collection/gazette/pipelines.py
+++ b/data_collection/gazette/pipelines.py
@@ -98,7 +98,9 @@ class SQLDatabasePipeline:
             gazette_item["file_path"] = file_info["path"]
             gazette_item["file_url"] = file_info["url"]
             gazette_item["file_checksum"] = file_info["checksum"]
-            gazette_item["scraped_at"] = dt.datetime.fromisoformat(gazette_item['scraped_at'][:-1])
+            gazette_item["scraped_at"] = dt.datetime.fromisoformat(
+                gazette_item["scraped_at"][:-1]
+            )
 
             gazette = Gazette(**gazette_item)
             session.add(gazette)
@@ -109,7 +111,7 @@ class SQLDatabasePipeline:
                     f"Something wrong has happened when adding the gazette in the database. "
                     f"Date: {gazette_item['date']}. "
                     f"File Checksum: {gazette_item['file_checksum']}. "
-                    f"Details: {exc.args}\n{gazette_item}\n{type(gazette_item['date'])}"
+                    f"Details: {exc.args}"
                 )
                 session.rollback()
 

--- a/data_collection/gazette/resources/gazette_schema.json
+++ b/data_collection/gazette/resources/gazette_schema.json
@@ -2,8 +2,8 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
-        "date": {
-            "description": "Date of the gazzete",
+        "date_string": {
+            "description": "Date to validation",
             "type": "string",
             "format": "date"
         },
@@ -60,7 +60,7 @@
         }
     },
     "required": [
-        "date",
+        "date_string",
         "territory_id",
         "power",
         "scraped_at"

--- a/data_collection/gazette/settings.py
+++ b/data_collection/gazette/settings.py
@@ -1,10 +1,11 @@
-import pkg_resources
+import importlib.resources
 from decouple import config
 
 BOT_NAME = "gazette"
 SPIDER_MODULES = ["gazette.spiders"]
 NEWSPIDER_MODULE = "gazette.spiders"
 ROBOTSTXT_OBEY = False
+
 ITEM_PIPELINES = {
     "gazette.pipelines.GazetteDateFilteringPipeline": 100,
     "gazette.pipelines.DefaultValuesPipeline": 200,
@@ -27,7 +28,7 @@ EXTENSIONS = {
 }
 SPIDERMON_ENABLED = config("SPIDERMON_ENABLED", default=True, cast=bool)
 SPIDERMON_VALIDATION_SCHEMAS = [
-    pkg_resources.resource_filename("gazette", "resources/gazette_schema.json")
+    importlib.resources.files("gazette") / "resources/gazette_schema.json"
 ]
 
 SPIDERMON_VALIDATION_ADD_ERRORS_TO_ITEMS = True


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [ ] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [x] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

PR referente a uma variação do #935 

Esse PR foi testado com todas as dependências do QD atualizada do commit de id: `963eddf` link: #926

No formato do #935 ele conserta a questão com a key "date" e "scraped_at":
```py
def process_item(self, item, spider):
        item["territory_id"] = getattr(spider, "TERRITORY_ID")

        # Date manipulation to allow jsonschema to validate correctly
        item["date"] = str(item["date"])
        item["scraped_at"] = dt.datetime.utcnow().isoformat("T") + "Z"

        return item
```
Porém, algo no bloco acima esta impedindo de preencher o campo "files" com {path, url, checksum, status} no item antes da validação rodar. (Não fui muito atrás do porque)

Para continuar acabei mantendo o antigo `def process_item(self, item, spider):` e adicionando `date_string = scrapy.Field()` em Gazette, ele sera responsável por ser um "date" que será convertido em string e validado.

```py
default_field_values = {
        "territory_id": lambda spider: getattr(spider, "TERRITORY_ID"),
        "scraped_at": lambda spider: dt.datetime.utcnow().isoformat("T") + "Z",
        "date_string": lambda item: str(item["date"]),
    }

    def process_item(self, item, spider):
        for field in self.default_field_values:
            if field not in item:
                if field == "date_string":
                    item[field] = self.default_field_values.get(field)(item)
                else:
                    item[field] = self.default_field_values.get(field)(spider)
        return item
```

Como transformamos  "scraped_at" em string ele não é mais compatível com o padrão do banco de dados.
Para corrigi usei o bloco abaixo

```py
gazette_item["file_path"] = file_info["path"]
            gazette_item["file_url"] = file_info["url"]
            gazette_item["file_checksum"] = file_info["checksum"]
            gazette_item["scraped_at"] = dt.datetime.fromisoformat(
                gazette_item["scraped_at"][:-1]
            )
```

Esse PR é mais uma tentativa de ajudar @rennerocha que estava trabalhando no assunto, levantando questões que podem surgir ao tenta resolver o problema de "_validation".

Com uma outra forma de formatar o  item["date"] e item["scraped_at"] em `def process_item` não vamos precisar criar `date_string = scrapy.Field()` o que deixa o código mais limpo.




Alguns Logs e comandos de teste:
`scrapy crawl ma_bacurituba -a start_date=2023-09-01 -s LOG_FILE=log_ma_bacurituba.txt`
`scrapy crawl mg_candeias -a start_date=2023-09-01 -s LOG_FILE=log_mg_candeias.txt`
[log_ma_bacurituba.txt](https://github.com/okfn-brasil/querido-diario/files/12665019/log_ma_bacurituba.txt)
[log_mg_candeias.txt](https://github.com/okfn-brasil/querido-diario/files/12665020/log_mg_candeias.txt)
