### PR TITLE
Verificando falta de extensão

### DIFF
--- a/data_collection/gazette/pipelines.py
+++ b/data_collection/gazette/pipelines.py
@@ -167,4 +167,8 @@ class QueridoDiarioFilesPipeline(FilesPipeline):
         # class we replace that with the territory_id and gazette date.
         datestr = item["date"].strftime("%Y-%m-%d")
         filename = Path(filepath).name
+
+        if not filename.count(".pdf"):
+            filename = filename + ".pdf"
+
         return str(Path(item["territory_id"], datestr, filename))


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [x] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [x] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

PR referente #819

Fiz o levantamento que de **250478** diários raspados,  **53,95%** deles que equivale a um total de **135139** diários, estão sem extensão e como já foi descrito em #819 é um problema para os usuários do Windows.
Dados levantados ➡️ [Dados](https://docs.google.com/spreadsheets/d/1-otBxgWGeg58lbbsfKl9ZUoTz1quREPK/edit#gid=328086594)

Escolhi 5 dos municípios com mais diários sem extensão para fazer os teste: `Cuiabá`, `Santos`, `Rio de Janeiro`, `Santo André` e `Belém`.
![image](https://github.com/okfn-brasil/querido-diario/assets/94500122/232e0714-3209-49ab-aeee-cddbe4ec086a)

#

Primeiro testei eles sem o validador de extensão, para confirmar que eles não estavam sendo armazenados com `.pdf`.
Segui os logs confirmando a falta de extensão:
[log_pa_belem_sem_extensão.txt](https://github.com/okfn-brasil/querido-diario/files/12774154/log_pa_belem_sem_extensao.txt)
[log_rj_rio_de_janeiro_sem_extensão.txt](https://github.com/okfn-brasil/querido-diario/files/12774155/log_rj_rio_de_janeiro_sem_extensao.txt)
[log_sp_santo_andre_sem_extensão.txt](https://github.com/okfn-brasil/querido-diario/files/12774156/log_sp_santo_andre_sem_extensao.txt)
[log_sp_santos_sem_extensão.txt](https://github.com/okfn-brasil/querido-diario/files/12774157/log_sp_santos_sem_extensao.txt)
[log_mt_cuiaba_sem_extensão.txt](https://github.com/okfn-brasil/querido-diario/files/12774158/log_mt_cuiaba_sem_extensao.txt)

Como vemos em todos os registros dos logs o `path` está sem extensão.
Exemplo: `'path': '5103403\\2023-09-04\\ebb9ca864c1569b7cdb25e599e00a49b77d38b4c'`

#

Agora segue os mesmo rapadores, com o validador colocado na `pipelines.py`.
Logs:
[log_pa_belem_com_extensão.txt](https://github.com/okfn-brasil/querido-diario/files/12774161/log_pa_belem_com_extensao.txt)
[log_rj_rio_de_janeiro_com_extensão.txt](https://github.com/okfn-brasil/querido-diario/files/12774162/log_rj_rio_de_janeiro_com_extensao.txt)
[log_sp_santo_andre_com_extensão.txt](https://github.com/okfn-brasil/querido-diario/files/12774163/log_sp_santo_andre_com_extensao.txt)
[log_sp_santos_com_extensão.txt](https://github.com/okfn-brasil/querido-diario/files/12774164/log_sp_santos_com_extensao.txt)
[log_mt_cuiaba_com_extensão.txt](https://github.com/okfn-brasil/querido-diario/files/12774165/log_mt_cuiaba_com_extensao.txt)

Vemos que agora todos eles estão com extensão correta em `path`.
Exemplo: `'path': '5103403\\2023-09-04\\ebb9ca864c1569b7cdb25e599e00a49b77d38b4c.pdf',`

#

E para finalizar fiz teste com 5 dos municípios com mais diários que estão com extensão corretamente: `Porto Alegre`, `Goiânia`, `Manaus`, `Salvador` e `Natal`
![image](https://github.com/okfn-brasil/querido-diario/assets/94500122/52ac9a78-9972-4326-9640-7d6d2a8ba6f7)

Segue os logs:

[log_rn_natal.txt](https://github.com/okfn-brasil/querido-diario/files/12774181/log_rn_natal.txt)
[log_rs_porto_alegre.txt](https://github.com/okfn-brasil/querido-diario/files/12774182/log_rs_porto_alegre.txt)
[log_am_manaus.txt](https://github.com/okfn-brasil/querido-diario/files/12774183/log_am_manaus.txt)
[log_ba_salvador.txt](https://github.com/okfn-brasil/querido-diario/files/12774184/log_ba_salvador.txt)
[log_go_goiania.txt](https://github.com/okfn-brasil/querido-diario/files/12774185/log_go_goiania.txt)

Vemos que eles se encontram sem erros e com as extensão ainda correta, mesmo com o validador já inserido a `pipelines.py`.

# 

**Obs:** Acredito que tenha forma mais "legante" de fazer essa validação que posteriormente poderia ser aplicada. Mas já deixo o PR até eu ver isso e a ideia se alguém tiver uma melhor abordagem. 
