### PR TITLE
Resolve o erro No module named 'tzdata' no Windows

### DIFF
--- a/data_collection/requirements-dev.txt
+++ b/data_collection/requirements-dev.txt
@@ -946,6 +946,9 @@ types-python-dateutil==2.8.19.14 \
 typing-extensions==4.8.0 \
     --hash=sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0 \
     --hash=sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef
+tzdata==2023.3 ; platform_system == "Windows" \
+    --hash=sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a \
+    --hash=sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda
 tzlocal==5.1 \
     --hash=sha256:2938498395d5f6a898ab8009555cb37a4d360913ad375d4747ef16826b03ef23 \
     --hash=sha256:a5ccb2365b295ed964e0a98ad076fe10c495591e75505d34f154d60a7f1ed722

--- a/data_collection/requirements.in
+++ b/data_collection/requirements.in
@@ -13,3 +13,4 @@ scrapy
 scrapy-zyte-smartproxy
 SQLAlchemy
 spidermon
+tzdata; platform_system == "Windows"

--- a/data_collection/requirements.txt
+++ b/data_collection/requirements.txt
@@ -872,6 +872,9 @@ types-python-dateutil==2.8.19.14 \
 typing-extensions==4.8.0 \
     --hash=sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0 \
     --hash=sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef
+tzdata==2023.3 ; platform_system == "Windows" \
+    --hash=sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a \
+    --hash=sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda
 tzlocal==5.1 \
     --hash=sha256:2938498395d5f6a898ab8009555cb37a4d360913ad375d4747ef16826b03ef23 \
     --hash=sha256:a5ccb2365b295ed964e0a98ad076fe10c495591e75505d34f154d60a7f1ed722


### PR DESCRIPTION
Inclui 'tzdata' quando o ambiente for instalado no Windows.
Resolve #962

**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [ ] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [ ] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [ ] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [ ] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [ ] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição
Inclui 'tzdata' quando o ambiente for instalado no Windows.
Resolve #962 
