### PR TITLE
Configura execução uma vez por dia

### DIFF
--- a/.github/workflows/periodic_crawl.yaml
+++ b/.github/workflows/periodic_crawl.yaml
@@ -2,8 +2,7 @@ name: Daily execution of Spiders
 
 on:
   schedule:
-    # Execute twice a day at 8AM/6PM (BRT)
-    - cron: "0 11 * * *"
+    # Execute once a day at 6PM (BRT)
     - cron: "0 21 * * *"
 
 jobs:


### PR DESCRIPTION
Estamos com um problema com a Zyte: os raspadores que duravam cerca de 1 minuto para executar, estão levando de 10 a 30 inesperadamente, fazendo com que a execução completa dos 161 raspadores leve mais de 12 horas. 

Um ticket foi aberto para encaminhar a situação, mas temporariamente, estamos reduzindo a execução de raspadores para uma vez por dia já que uma das ondas não está sendo adequadamente executada pela anterior estar durando muito.