### PR TITLE
São João de Meriti/RJ

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_sao_joao_de_meriti.py
+++ b/data_collection/gazette/spiders/rj/rj_sao_joao_de_meriti.py
@@ -1,0 +1,36 @@
+import datetime as dt
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjSaoJoaoDeMeritiSpider(BaseGazetteSpider):
+    TERRITORY_ID = "3305109"
+    name = "rj_sao_joao_de_meriti"
+    allowed_domains = ["transparencia.meriti.rj.gov.br"]
+    start_urls = ["https://transparencia.meriti.rj.gov.br/diario_oficial_get.php"]
+    BASE_URL = "https://transparencia.meriti.rj.gov.br/ver20230623/WEB-ObterAnexo.rule?sys=LAI&codigo="
+    start_date = dt.date(2017, 1, 1)
+    custom_settings = {"DOWNLOAD_DELAY": 0.5, "RANDOMIZE_DOWNLOAD_DELAY": True}
+
+    def parse(self, response):
+        for gazette_data in response.json():
+            raw_gazette_date = gazette_data["Data_Formatada"]
+            gazette_date = dt.datetime.strptime(raw_gazette_date, "%d/%m/%Y").date()
+
+            if not self.start_date <= gazette_date <= self.end_date:
+                continue
+            gazette_code = gazette_data["Codigo_ANEXO"]
+            # links quebrados no portal de transparência
+            if gazette_code == 1:
+                continue
+            gazette_edition_number = gazette_data["ANEXO"]
+            gazette_url = f"{self.BASE_URL}{gazette_code}"
+
+            yield Gazette(
+                date=gazette_date,
+                edition_number=gazette_edition_number,
+                file_urls=[gazette_url],
+                is_extra_edition=False,
+                power="executive_legislative",
+            )


### PR DESCRIPTION
#### Checklist - Novo spider
- [X] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [X] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [X] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [X] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [X] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição
Construção da spider pra São João de Meriti/RJ através do portal https://transparencia.meriti.rj.gov.br/. 
Consulta mês a mês através do subdomínio _/diario_oficial_get.php_ e desconsidera os itens com código de anexo igual a 1. 
Download delay de 1.5 segundos para evitar o recebimento de error de servidor 500.
Estrutura de código similar ao encontrado para a cidade de Belford Roxo/RJ. 

Resolve #961
