### PR TITLE
Verifica se a razão request/item é menor ou igual ao valor configurado

### DIFF
--- a/data_collection/gazette/monitors.py
+++ b/data_collection/gazette/monitors.py
@@ -27,7 +27,7 @@ class RequestsItemsRatioMonitor(Monitor):
             ratio = n_requests_count / n_scraped_items
             percent = round(ratio * 100, 2)
             allowed_percent = round(max_ratio * 100, 2)
-            self.assertLess(
+            self.assertLessEqual(
                 ratio,
                 max_ratio,
                 msg=f"""{percent}% is greater than the allowed {allowed_percent}%


### PR DESCRIPTION
- No spider de Maringá-PR, existem 2 requests que sempre são realizados, não importa a quantidade de items, e para cada item, podemos ter até 3 requests (alguns redirecionamentos para obter a URL de download do PDF). No caso de 1 item retornado, a razão request/item estava em 5 (que é a razão considerada aceitável). Porém o monitor estava verificando se o resultado era "menor" que a razão e não "menor e igual". Isso estava gerando muitos falsos positivos.