### PR TITLE
Retira São José dos Basílios (MA) de produção

### DIFF
--- a/scripts/enabled_spiders.py
+++ b/scripts/enabled_spiders.py
@@ -72,7 +72,6 @@ SPIDERS = [
     "ma_maranhaozinho",
     "ma_nina_rodrigues",
     "ma_santo_antonio_dos_lopes",
-    "ma_sao_jose_dos_basilios",
     "ma_sao_vicente_ferrer",
     "ma_viana",
     "ma_ze_doca",


### PR DESCRIPTION
Já havia sido percebido que o raspador não estava mais funcionando (#1008), porém ficou faltando retirá-lo da lista. Estamos há semanas recebendo erro de raspagem por conta disso.
