### PR TITLE
Adiciona mapeador ATENDE

### DIFF
--- a/data_collection/gazette/mapeadores/mapeadoratende.py
+++ b/data_collection/gazette/mapeadores/mapeadoratende.py
@@ -1,0 +1,43 @@
+from gazette.mapeadores.base.mapeador import Mapeador
+
+
+class MapeadorAtende(Mapeador):
+    name = "mapeadoratende"
+
+    # No mapeamento completo, todos os links http foram redirecionados para https.
+    protocols = ["https"]
+
+    def column(self):
+        return "ATENDE"
+
+    def backup_column(self):
+        return "VALID_ATENDE"
+
+    def urls_pattern(self, protocol, city, state_code):
+        # casos conhecidos
+        # https://campomourao.atende.net/?pg=diariooficial
+        # https://gravatai.atende.net/diariooficial/edicao
+        # https://camaqua.atende.net/cidadao/pagina/diario-oficial
+
+        return [
+            # f"{protocol}://{city}.atende.net",
+            f"{protocol}://{city}.atende.net/?pg=diariooficial",
+            f"{protocol}://{city}.atende.net/diariooficial",
+            f"{protocol}://{city}.atende.net/cidadao/pagina/diario-oficial",
+        ]
+
+    def validation(self, response):
+        if "atende.net" in response.text:
+            if (
+                "Diário Oficial" in response.text
+                or "Órgão Oficial Eletrônico" in response.text
+            ):
+                if (
+                    "Diário Oficial não está disponível para esta entidade"
+                    not in response.text
+                    and "Página indisponível no momento" not in response.text
+                    and "Nenhum Resultado Encontrado" not in response.text
+                    and "Diário Oficial dos Municípios" not in response.text
+                ):
+                    return True
+        return False

--- a/data_collection/gazette/mapeadores/mapeadoratende.py
+++ b/data_collection/gazette/mapeadores/mapeadoratende.py
@@ -1,3 +1,5 @@
+import scrapy
+
 from gazette.mapeadores.base.mapeador import Mapeador
 
 
@@ -6,6 +8,9 @@ class MapeadorAtende(Mapeador):
 
     # No mapeamento completo, todos os links http foram redirecionados para https.
     protocols = ["https"]
+
+    # A list with States to be mapped. If empty, defaults to map All.
+    # states_to_map = ['mg', 'pr', 'rs', 'sc', 'sp']
 
     def column(self):
         return "ATENDE"
@@ -25,6 +30,87 @@ class MapeadorAtende(Mapeador):
             f"{protocol}://{city}.atende.net/diariooficial",
             f"{protocol}://{city}.atende.net/cidadao/pagina/diario-oficial",
         ]
+
+    def start_requests(self):
+        # self.logger.debug(f"STATES_MAP: {repr(self.states_to_map)} {len(self.states_to_map)}")
+        self.read_csv("dados_mapeamento")
+        self.add_column_key()  # add column to fill with search results
+
+        for i in range(len(self.territories)):
+            # Raise TypeError: Mapeador.log() got an unexpected keyword argument 'level'.
+            # Should be renamed to print_status().
+            self.log(i)
+            # self.print_status(i)
+
+            name, state_code = self.format_str(
+                self.territories[i]["name"], self.territories[i]["state_code"]
+            )
+            # if len(self.states_to_map) > 0 and state_code not in self.states_to_map:
+            #     continue
+            for protocol_option in self.protocols:
+                for name_option in self.city_name_generator(name):
+                    for url_option in self.urls_pattern(
+                        protocol_option, name_option, state_code
+                    ):
+                        yield scrapy.Request(
+                            url_option, callback=self.parse, cb_kwargs=dict(index=i)
+                        )
+
+        self.save_csv("dados_mapeamento")
+
+    def parse(self, response, index):
+        # Get information regarding City and State.
+        gov_br_city_state = response.xpath(
+            '//a[contains(@href, "mailto:")][1]/@href'
+        ).re(r"@(\w+)\.(\w+)\.gov\.br")
+        address_city_state = response.css("div.mapa-texto span.linha::text").re(
+            r"\w.+- ?([\w\s]+)/(\w+)"
+        )
+        # Get information regarding 'diario' links.
+        links_diario_oficial = response.xpath(
+            '//a[contains(@href, "diario")][1]/@href'
+        ).getall()
+
+        if self.validation(response):
+            if response.url not in self.territories[index][self.column()]:
+                self.territories[index][self.column()].append(response.url)
+            if (
+                len(gov_br_city_state) > 0
+                and gov_br_city_state not in self.territories[index][self.column()]
+            ):
+                self.territories[index][self.column()].append(gov_br_city_state)
+            if (
+                len(address_city_state) > 0
+                and address_city_state not in self.territories[index][self.column()]
+            ):
+                self.territories[index][self.column()].append(address_city_state)
+            if (
+                len(links_diario_oficial) > 0
+                and links_diario_oficial not in self.territories[index][self.column()]
+            ):
+                self.territories[index][self.column()].append(links_diario_oficial)
+        elif response.url not in self.territories[index][self.backup_column()]:
+            self.territories[index][self.backup_column()].append(response.url)
+            if (
+                len(gov_br_city_state) > 0
+                and gov_br_city_state
+                not in self.territories[index][self.backup_column()]
+            ):
+                self.territories[index][self.backup_column()].append(gov_br_city_state)
+            if (
+                len(address_city_state) > 0
+                and address_city_state
+                not in self.territories[index][self.backup_column()]
+            ):
+                self.territories[index][self.backup_column()].append(address_city_state)
+            if (
+                len(links_diario_oficial) > 0
+                and links_diario_oficial
+                not in self.territories[index][self.backup_column()]
+            ):
+                self.territories[index][self.backup_column()].append(
+                    links_diario_oficial
+                )
 
     def validation(self, response):
         if "atende.net" in response.text:


### PR DESCRIPTION
Implementa a sugestão apresentada em [919 (comment)](https://github.com/okfn-brasil/querido-diario/issues/919/#issuecomment-1821736963)
> NOTA: Link para a página de cada município: `https://{city}.atende.net` 

**Por não ser um domínio governamental** (diferente de `.{uf}.gov.br`), apresenta o problema conhecido: `encontra URLs de interesse, mas vincula na cidade errada`. 

### Considerações sobre desempenho:
1. Ao retirar o `http` dos protocolos de mapeamento e **não** tentar mapear o link 'base' para a página de cada município `{protocol}://{city}.atende.net`, o **tempo para mapear 500 cidades** (tempo entre backups parciais) foi reduzido de 2h40min para 25 minutos.
---

**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

## Checklist - Novo Mapeador
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [ ] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
[ **N.A.:** Não se aplica, pois **ALGUNS** erros são esperados no processo de mapeamento. ]

## Descrição

Adiciona mapeador ATENDE
Amplia solução para #919 