### PR TITLE
Remove Bacuri-MA da lista de spiders habilitados

### DIFF
--- a/scripts/enabled_spiders.py
+++ b/scripts/enabled_spiders.py
@@ -62,7 +62,6 @@ SPIDERS = [
     "ma_afonso_cunha",
     "ma_aldeias_altas",
     "ma_axixa",
-    "ma_bacuri",
     "ma_boa_vista_do_gurupi",
     "ma_caxias",
     "ma_centro_do_guilherme",


### PR DESCRIPTION
O município de Bacuri-MA parou de publicar usando SIGANET e passou a publicar em outro sistema (#1007). Retiro a cidade da lista de habilitados para não ficarmos recebendo mensagens de erros enquanto o novo spider não for desenvolvido.