### PR TITLE
Adiciona raspador para AMA (AL)

### DIFF
--- a/data_collection/gazette/resources/territories.csv
+++ b/data_collection/gazette/resources/territories.csv
@@ -5569,3 +5569,4 @@ id,name,state_code,state
 3557154,Zacarias,SP,São Paulo
 2114007,Zé Doca,MA,Maranhão
 4219853,Zortéa,SC,Santa Catarina
+2700000,Associação dos Municípios Alagoanos,AL,Alagoas

--- a/data_collection/gazette/spiders/al/al_associacao_municipios.py
+++ b/data_collection/gazette/spiders/al/al_associacao_municipios.py
@@ -1,7 +1,10 @@
+import datetime
+
 from gazette.spiders.base.sigpub import SigpubGazetteSpider
 
 
 class AlAssociacaoMunicipiosSpider(SigpubGazetteSpider):
     name = "al_associacao_municipios"
     TERRITORY_ID = "2700000"
-    CALENDAR_URL = "https://www.diariomunicipal.com.br/ama"
+    CALENDAR_URL = "https://www.diariomunicipal.com.br/ama/"
+    start_date = datetime.date(2014, 4, 10)

--- a/scripts/enabled_spiders.py
+++ b/scripts/enabled_spiders.py
@@ -2,6 +2,7 @@
 # automatically in production
 SPIDERS = [
     "al_maceio",
+    "al_associacao_municipios",
     "am_manaus",
     "ap_macapa",
     "ap_santana",


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [X] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [X] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [X] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [X] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [X] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

A data inicial de publicação foi descoberta na força bruta, colocando a data inicial em 2009 e tendo o primeiro arquivo baixado apenas em 10/04/2014.

Esqueci de salvar o log, mas executei a raspagem completa localmente algumas vezes sem maiores problemas e tudo foi devidamente processado pelo data-processing local.

Estou adicionando uma entrada no `territories.csv` para a associação. Não necessariamente ficará lá, mas por enquanto é necessário para reproduzir o processamento de dados localmente (a inserção também já foi feita no banco de produção). 

**Não mesclar esse PR antes de https://github.com/okfn-brasil/querido-diario-data-processing/pull/64 ser mesclado**