### PR TITLE
Adiciona vários spider de MG - Barbacena | Carmo do Rio Claro | Onça do Pitangui | Juatuba

### DIFF
--- a/data_collection/gazette/spiders/mg/mg_carmo_do_rio_claro.py
+++ b/data_collection/gazette/spiders/mg/mg_carmo_do_rio_claro.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.instar import BaseInstarSpider
+
+
+class MgCarmoDoRioClaroSpider(BaseInstarSpider):
+    TERRITORY_ID = "3114402"
+    name = "mg_carmo_do_rio_claro"
+    allowed_domains = ["carmodorioclaro.mg.gov.br"]
+    base_url = "https://www.carmodorioclaro.mg.gov.br/portal/diario-oficial"
+    start_date = date(2021, 5, 14)

--- a/data_collection/gazette/spiders/mg/mg_juatuba.py
+++ b/data_collection/gazette/spiders/mg/mg_juatuba.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.instar import BaseInstarSpider
+
+
+class MgJuatubaSpider(BaseInstarSpider):
+    TERRITORY_ID = "3136652"
+    name = "mg_juatuba"
+    allowed_domains = ["juatuba.mg.gov.br"]
+    base_url = "https://www.juatuba.mg.gov.br/portal/diario-oficial"
+    start_date = date(2016, 1, 5)

--- a/data_collection/gazette/spiders/mg/mg_onca_do_pitangui.py
+++ b/data_collection/gazette/spiders/mg/mg_onca_do_pitangui.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.instar import BaseInstarSpider
+
+
+class MgOncaDoPitanguiSpider(BaseInstarSpider):
+    TERRITORY_ID = "3151404"
+    name = "mg_onca_do_pitangui"
+    allowed_domains = ["oncadopitangui.mg.gov.br"]
+    base_url = "https://www.oncadopitangui.mg.gov.br/portal/diario-oficial"
+    start_date = date(2021, 5, 24)


### PR DESCRIPTION
#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [x] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [x] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

Adicionando vários spiders para o estado de Minas Gerais(MG) - **Barbacena** | **Carmo do Rio Claro** | **Onça do Pitangui** | **Juatuba**

---

#### Informações Complementares:

**Barbacena, MG: 3105608**
- https://www1.barbacena.mg.gov.br/portal/diario-oficial
- https://cidades.ibge.gov.br/brasil/mg/barbacena/panorama

**Carmo do Rio Claro, MG: 3114402**
- https://www.carmodorioclaro.mg.gov.br/portal/diario-oficial
- https://cidades.ibge.gov.br/brasil/mg/carmo-do-rio-claro/panorama

**Onça do Pitangui, MG: 3151404**
- https://www.oncadopitangui.mg.gov.br/portal/diario-oficial
- https://cidades.ibge.gov.br/brasil/mg/pitangui/panorama

**Juatuba, MG: 3136652**
- https://www.juatuba.mg.gov.br/portal/diario-oficial
- https://cidades.ibge.gov.br/brasil/mg/juatuba/panorama


