### PR TITLE
Adiciona o novo 'prefix' parametro a url de download do documento

### DIFF
--- a/data_collection/gazette/spiders/mg/mg_belo_horizonte.py
+++ b/data_collection/gazette/spiders/mg/mg_belo_horizonte.py
@@ -34,9 +34,8 @@ class MgBeloHorizonteSpider(BaseGazetteSpider):
         gazettes = data["data"]
         for gazette in gazettes:
             is_extra_edition = gazette["tipo_edicao"] != "P"
-            one_day = timedelta(days=1)
-            yesterday_datetime = gazette_date - one_day
-            prefix = (yesterday_datetime.strftime("%Y-%m-%d")).replace("-", "")
+
+            prefix = (gazette_date - timedelta(days=1)).strftime("%Y%m%d")
             gazette_hash = gazette["documento_jornal"]["nome_minio"]
             gazette_url = f"https://api-dom.pbh.gov.br/api/v1/documentos/{gazette_hash}/download?prefix={prefix}"
 

--- a/data_collection/gazette/spiders/mg/mg_belo_horizonte.py
+++ b/data_collection/gazette/spiders/mg/mg_belo_horizonte.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timedelta
 from urllib.parse import urlencode
 
 import scrapy
@@ -33,11 +34,11 @@ class MgBeloHorizonteSpider(BaseGazetteSpider):
         gazettes = data["data"]
         for gazette in gazettes:
             is_extra_edition = gazette["tipo_edicao"] != "P"
-
+            one_day = timedelta(days=1)
+            yesterday_datetime = gazette_date - one_day
+            prefix = (yesterday_datetime.strftime("%Y-%m-%d")).replace("-", "")
             gazette_hash = gazette["documento_jornal"]["nome_minio"]
-            gazette_url = (
-                f"https://api-dom.pbh.gov.br/api/v1/documentos/{gazette_hash}/download"
-            )
+            gazette_url = f"https://api-dom.pbh.gov.br/api/v1/documentos/{gazette_hash}/download?prefix={prefix}"
 
             yield Gazette(
                 date=gazette_date,


### PR DESCRIPTION
Issue: https://github.com/okfn-brasil/querido-diario/issues/1054
#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [x] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [x] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

Foi identificado que adicionaram um parâmetro na chamada que baixa o documento('prefix'), um parâmetro que recebe uma string com a data do dia anterior ao do diário.

![image](https://github.com/okfn-brasil/querido-diario/assets/13931635/521aeef1-66cf-4ef8-b078-93bfdff70fc4)


Foi realizado o ajusta na url de chamada. 
Rodei localmente e retornaram os documentos dos últimos 15 dias.