### PR TITLE
Incluindo parâmetro de start_date e end_date no spider de Niterói/RJ.…

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_niteroi.py
+++ b/data_collection/gazette/spiders/rj/rj_niteroi.py
@@ -11,8 +11,9 @@ class RjNiteroiSpider(BaseGazetteSpider):
     name = "rj_niteroi"
     allowed_domains = ["niteroi.rj.gov.br"]
     start_urls = ["http://www.niteroi.rj.gov.br"]
-    download_url = "http://pgm.niteroi.rj.gov.br/downloads/do/{}/{}/{:02d}.pdf"
+    download_url = "http://www.niteroi.rj.gov.br/wp-content/uploads/do/{}/{}/{:02d}.pdf"
     start_date = dt.date(2003, 7, 1)
+    end_date = dt.date.today()
 
     month_names = [
         "01_Jan",
@@ -30,7 +31,8 @@ class RjNiteroiSpider(BaseGazetteSpider):
     ]
 
     def parse(self, response):
-        parsing_date = dt.date.today()
+        parsing_date = self.end_date
+
         while parsing_date >= self.start_date:
             month = self.month_names[parsing_date.month - 1]
             url = self.download_url.format(parsing_date.year, month, parsing_date.day)


### PR DESCRIPTION
… fixes okfn-brasil/querido-diario#635

**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [X ] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [X ] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [X ] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [X ] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [X ] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

Resolve o problema de limitação de start and end date do spider de Niterói/RJ.