### PR TITLE
Comando para listar spiders habilitados em produção

### DIFF
--- a/data_collection/gazette/commands/qd-list-enabled.py
+++ b/data_collection/gazette/commands/qd-list-enabled.py
@@ -1,0 +1,53 @@
+import datetime
+
+from scrapy.commands import ScrapyCommand
+from scrapy.exceptions import UsageError
+
+from gazette.utils import get_enabled_spiders
+
+
+class Command(ScrapyCommand):
+    requires_project = True
+
+    def add_options(self, parser):
+        ScrapyCommand.add_options(self, parser)
+        parser.add_argument(
+            "--start_date",
+            dest="start_date",
+            default=None,
+            metavar="VALUE",
+            help="List spiders enabled from date (format: YYYY-MM-DD)",
+        )
+        parser.add_argument(
+            "--end_date",
+            dest="end_date",
+            default=None,
+            metavar="VALUE",
+            help="List spiders enabled until date (format: YYYY-MM-DD)",
+        )
+
+    def short_desc(self):
+        return "List production enabled spiders"
+
+    def run(self, args, opts):
+        start_date, end_date = None, None
+
+        if opts.start_date is not None:
+            try:
+                start_date = datetime.datetime.strptime(opts.start_date, "%Y-%m-%d")
+            except ValueError:
+                raise UsageError("'start_date' must match YYYY-MM-DD format")
+
+        if opts.end_date is not None:
+            try:
+                end_date = datetime.datetime.strptime(opts.end_date, "%Y-%m-%d")
+            except ValueError:
+                raise UsageError("'end_date' must match YYYY-MM-DD format")
+
+        print("\nEnabled spiders\n===============")
+        for spider_name in get_enabled_spiders(
+            database_url=self.settings["QUERIDODIARIO_DATABASE_URL"],
+            start_date=start_date,
+            end_date=end_date,
+        ):
+            print(spider_name)

--- a/data_collection/gazette/settings.py
+++ b/data_collection/gazette/settings.py
@@ -57,3 +57,5 @@ FILES_STORE_S3_ACL = config("FILES_STORE_S3_ACL", default="public-read")
 
 DOWNLOADER_MIDDLEWARES = {"scrapy_zyte_smartproxy.ZyteSmartProxyMiddleware": 610}
 ZYTE_SMARTPROXY_APIKEY = "<SMARTPROXY_APIKEY>"
+
+COMMANDS_MODULE = "gazette.commands"

--- a/data_collection/gazette/utils.py
+++ b/data_collection/gazette/utils.py
@@ -1,0 +1,24 @@
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from gazette.database.models import QueridoDiarioSpider
+
+
+def get_enabled_spiders(*, database_url, start_date=None, end_date=None):
+    """Return list of all currently enabled spiders within date period.
+    If start_date and/or end_date are provided, it will return only
+    the enabled spiders that are within the requested date period.
+    """
+    engine = create_engine(database_url)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    stmt = select(QueridoDiarioSpider).where(QueridoDiarioSpider.enabled.is_(True))
+    if start_date is not None:
+        stmt = stmt.where(QueridoDiarioSpider.date_from <= start_date)
+    if end_date is not None:
+        stmt = stmt.where(QueridoDiarioSpider.date_to >= end_date)
+
+    result = session.execute(stmt)
+    for spider in result.scalars():
+        yield spider.spider_name


### PR DESCRIPTION
- Criação de comando para permitir a listagem dos spiders que estão habilitados para execução em linha de comando
- Criação de função utilitária para retornar lista de spiders habilitados em produção (será usado quando o agendamento de spiders se basear nas informações do banco de dados)