### PR TITLE
Corrige update de raspadores no banco

### DIFF
--- a/data_collection/gazette/database/models.py
+++ b/data_collection/gazette/database/models.py
@@ -49,46 +49,51 @@ def load_territories(engine):
     logger.info("Populating 'territories' table - Done!")
 
 
+def get_new_spiders(session, territory_spider_map):
+    registered_spiders = session.query(QueridoDiarioSpider).all()
+    registered_spiders_set = {
+        (spider.spider_name, territory.id, spider.date_from)
+        for spider in registered_spiders
+        for territory in spider.territories
+    }
+    only_new_spiders = [
+        spider_info
+        for spider_info in territory_spider_map
+        if spider_info not in registered_spiders_set
+    ]
+    return only_new_spiders
+
+
 def load_spiders(engine, territory_spider_map):
     Session = sessionmaker(bind=engine)
     session = Session()
 
-    if session.query(QueridoDiarioSpider).count() > 0:
-        return
+    table_is_populated = session.query(QueridoDiarioSpider).count() > 0
+    new_spiders = (
+        get_new_spiders(session, territory_spider_map)
+        if table_is_populated
+        else territory_spider_map
+    )
 
     logger.info("Populating 'querido_diario_spider' table - Please wait!")
 
-    spiders = []
-    territory_ids = set()
-    for info in territory_spider_map:
-        spider_name, territory_id, date_from = info
-        spiders.append(
-            QueridoDiarioSpider(spider_name=spider_name, date_from=date_from)
-        )
-        territory_ids.add(territory_id)
-
-    session.add_all(spiders)
-    session.commit()
-
-    spiders = (
-        session.query(QueridoDiarioSpider)
-        .filter(
-            QueridoDiarioSpider.spider_name.in_(set(s[0] for s in territory_spider_map))
-        )
-        .all()
-    )
-    spider_map = {spider.spider_name: spider for spider in spiders}
-
-    territories = session.query(Territory).filter(Territory.id.in_(territory_ids)).all()
+    territories = session.query(Territory).all()
     territory_map = {t.id: t for t in territories}
 
-    for info in territory_spider_map:
-        spider_name, territory_id, _ = info
-        spider = spider_map.get(spider_name)
+    spiders = []
+    for info in new_spiders:
+        spider_name, territory_id, date_from = info
         territory = territory_map.get(territory_id)
-        if spider is not None and territory is not None:
-            spider.territories.append(territory)
+        if territory is not None:
+            spiders.append(
+                QueridoDiarioSpider(
+                    spider_name=spider_name,
+                    date_from=date_from,
+                    territories=[territory],
+                )
+            )
 
+    session.add_all(spiders)
     session.commit()
     logger.info("Populating 'querido_diario_spider' table - Done!")
 


### PR DESCRIPTION
#### Descrição

Ao adicionar um novo raspador no projeto, a tabela no banco de raspadores não está sendo atualizada automaticamente. Este PR verifica quais raspadores estão no projeto e não estão no banco para adicioná-los pelo menos ao executar um novo raspador (idealmente seria um comando a parte).