### PR TITLE
squash new spider pb_santa_rita

### DIFF
--- a/data_collection/gazette/spiders/pb/pb_santa_rita.py
+++ b/data_collection/gazette/spiders/pb/pb_santa_rita.py
@@ -1,0 +1,55 @@
+import re
+from datetime import date, datetime
+
+import scrapy
+from dateutil.rrule import YEARLY, rrule
+from scrapy.http import Response
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class PbSantaRitaSpider(BaseGazetteSpider):
+    TERRITORY_ID = "2513703"
+    name = "pb_santa_rita"
+    allowed_domains = ["santarita.pb.gov.br"]
+    start_date = date(2013, 3, 28)
+
+    def start_requests(self):
+        for yearly_date in rrule(
+            freq=YEARLY, dtstart=self.start_date, until=self.end_date
+        ):
+            url = f"https://santarita.pb.gov.br/diario-oficial/diario-oficial-{yearly_date.year}/"
+            yield scrapy.Request(url, callback=self.parse_year)
+
+    def parse_year(self, response):
+        max_page = response.css(".search-pagination p span:nth-child(2)::text").get()
+
+        for i in range(1, int(max_page) + 1):
+            url = f"{response.url}page/{i}/"
+            yield scrapy.Request(url, dont_filter=True)
+
+    def parse(self, response: Response):
+        gazzetes = response.css(".arq-list-item-content a")
+        for gazzete in gazzetes:
+            url = gazzete.attrib["href"]
+            desc = gazzete.css("h1::text").get()
+
+            raw_date = gazzete.css(".data::text").get().strip()
+            date = datetime.strptime(raw_date, "%d/%m/%Y").date()
+
+            # URLs possuem diferentes padrões de enunciar o numero de edição
+            # exemplos listados podem ser encontrados em https://regexr.com/7qsaa
+            result = re.findall(
+                "DOE-[Nn]?[o°]?-?(\d+A?)|(\d{1,3}A?)-DOE|n\.?-(\d{3,})-|OFICIAL-N?o?-?(\d{2,4}A?)|n_(\d+)|diario-(\d+)",
+                url,
+            )
+            edition_number = max(result[0]) if result else None
+
+            yield Gazette(
+                date=date,
+                edition_number=edition_number,
+                file_urls=[url],
+                is_extra_edition="extra" in desc.lower(),
+                power="executive_legislative",
+            )


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [X] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [X] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [X] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [X] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [X] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

A principal dificuldade em construir essa spider se deu na coleta dos números de edição. O número de edição quando disponibilizado é econtrado apenas na URL de forma não padronizada. Foi necessário criar um padrão de regex que atendesse pelo menos 11 casos de formatação de URL, os quais estão listados aqui: https://regexr.com/7qsaa. 

Resolve #510 