### PR TITLE
new spider Jacareí/SP

### DIFF
--- a/data_collection/gazette/spiders/sp/sp_jacarei.py
+++ b/data_collection/gazette/spiders/sp/sp_jacarei.py
@@ -1,0 +1,46 @@
+import re
+from datetime import date
+
+import dateutil
+from scrapy.http import Request
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class SpJacareiSpider(BaseGazetteSpider):
+    TERRITORY_ID = "3524402"
+    name = "sp_jacarei"
+    allowed_domains = [
+        "boletinsoficiais.geosiap.net",
+        "geosiap.s3-sa-east-1.amazonaws.com",
+    ]
+    base_url = "https://boletinsoficiais.geosiap.net/api/pmjacarei/publicacao/bo_arquivos_public?inativos=false"
+    start_date = date(2004, 3, 27)
+
+    def start_requests(self):
+        url = self.base_url
+        url += f'&dt_inicial={self.start_date.strftime("%Y-%m-%d")}&dt_final={self.end_date.strftime("%Y-%m-%d")}'
+
+        yield Request(url, callback=self.parse_info)
+
+    def parse_info(self, response):
+        data = response.json()["data"]
+        for gazzete in data:
+            url = f'https://boletinsoficiais.geosiap.net/api/pmjacarei/publicacao/get_url_arquivo/{gazzete["id"]}'
+            yield Request(url, meta=gazzete)
+
+    def parse(self, response):
+        gazzete = response.meta
+        gazzete_date = dateutil.parser.isoparse(gazzete["dt_publicacao"]).date()
+        match = re.findall("(\d+)", gazzete["nome_arquivo"])
+        gazzete_number = match[0] if match else ""
+        gazzete_url = response.json()["url"]
+
+        yield Gazette(
+            date=gazzete_date,
+            edition_number=gazzete_number,
+            file_urls=[gazzete_url],
+            is_extra_edition=gazzete_number == "",
+            power="executive_legislative",
+        )


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [X] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [X ] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [ X] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [ X] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [X ] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição

Os boletins podem ser consultados por intervalo de datas através da api https://boletinsoficiais.geosiap.net/api/pmjacarei

#### Logs
[log_sp_jacarei.txt](https://github.com/okfn-brasil/querido-diario/files/14142193/log_sp_jacarei.txt)
[log_sp_jacarei.csv](https://github.com/okfn-brasil/querido-diario/files/14142194/log_sp_jacarei.csv)


resolve #1071 