### PR TITLE
new spider Taubaté/SP

### DIFF
--- a/data_collection/gazette/spiders/sp/sp_taubate.py
+++ b/data_collection/gazette/spiders/sp/sp_taubate.py
@@ -1,0 +1,40 @@
+import re
+from datetime import date, datetime
+
+from dateutil.rrule import DAILY, rrule
+from scrapy.http import Request
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class SpTaubaSpider(BaseGazetteSpider):
+    TERRITORY_ID = "3554102"
+    name = "sp_taubate"
+    allowed_domains = ["plenussistemas.dioenet.com.br"]
+    base_url = "https://plenussistemas.dioenet.com.br/list/taubate?secao="
+    start_date = date(2022, 12, 8)
+
+    def start_requests(self):
+        for daily_date in rrule(
+            freq=DAILY, dtstart=self.start_date, until=self.end_date
+        ):
+            yield Request(f'{self.base_url}&d={daily_date.strftime("%d/%m/%Y")}')
+
+    def parse(self, response):
+        for gazzete in response.css("ul.lista-diarios li"):
+            desc = gazzete.css(".col-one span::text").get()
+            gazzete_number = re.findall("\d+", desc)[0]
+
+            elem = gazzete.css(".col-two a.btn")
+            gazzete_url = elem.attrib["href"]
+            raw_date = re.findall("(\d{2}/\d{2}/\d{4})", elem.attrib["title"])[0]
+            gazzete_date = datetime.strptime(raw_date, "%d/%m/%Y").date()
+
+            yield Gazette(
+                date=gazzete_date,
+                edition_number=gazzete_number,
+                is_extra_edition=False,
+                power="executive_legislative",
+                file_urls=[gazzete_url],
+            )


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [X] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [X] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [X] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [X] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [X] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

#### Descrição
Os boletins podem ser consultados em intervalos de datas através do endereço https://plenussistemas.dioenet.com.br/list/taubate.

#### Logs
[log_sp_taubate.txt](https://github.com/okfn-brasil/querido-diario/files/14142625/log_sp_taubate.txt)
[log_sp_taubate.csv](https://github.com/okfn-brasil/querido-diario/files/14142626/log_sp_taubate.csv)

resolve #1071