### PR TITLE
[new spider] Campo Alegre de Lourdes - BA

### DIFF
--- a/data_collection/gazette/spiders/ba/ba_campo_alegre_de_lourdes.py
+++ b/data_collection/gazette/spiders/ba/ba_campo_alegre_de_lourdes.py
@@ -1,0 +1,10 @@
+from datetime import date
+
+from gazette.spiders.base.doem import DoemGazetteSpider
+
+
+class BaCampoAlegreDeLourdesSpider(DoemGazetteSpider):
+    TERRITORY_ID = "2905909"
+    name = "ba_campo_alegre_de_lourdes"
+    start_date = date(2020, 11, 30)  # Primeira edição em 30/11/2020
+    state_city_url_part = "ba/campoalegredelourdes"


### PR DESCRIPTION
**AO ABRIR** um Pull Request de um novo raspador (spider), marque com um `X` cada um dos items do checklist 
abaixo. **NÃO ABRA** um novo Pull Request antes de completar todos os items abaixo.

#### Checklist - Novo spider
- [x] Você executou uma extração completa do spider localmente e os dados retornados estavam corretos.
- [x] Você executou uma extração por período (`start_date` e `end_date` definidos) ao menos uma vez e os dados retornados estavam corretos.
- [x] Você verificou que não existe nenhum erro nos logs (`log_count/ERROR` igual a zero).
- [x] Você definiu o atributo de classe `start_date` no seu spider com a data do Diário Oficial mais antigo disponível na página da cidade.
- [x] Você garantiu que todos os campos que poderiam ser extraídos foram extraídos [de acordo com a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/escrevendo-um-novo-spider.html#definicao-de-campos).

### Descrição

- Add spider para a cidade Campo Alegre de Lourdes - BA usando o spider base DoemGazetteSpider

### Log e outputs:

**Execução completa** 
- Log: [full_ba_campo_alegre_de_lourdes.txt](https://github.com/okfn-brasil/querido-diario/files/14673129/full_ba_campo_alegre_de_lourdes.txt)



- Output: [full_ba_campo_alegre_de_lourdes.csv](https://github.com/okfn-brasil/querido-diario/files/14673128/full_ba_campo_alegre_de_lourdes.csv)


**Execução por período** 
start_date: 2020-11-01
end_date: 2020-12-15

- Log: [log-from-2020-11-01-to-2020-12-15-ba_campo_alegre_de_lourdes.txt](https://github.com/okfn-brasil/querido-diario/files/14673130/log-from-2020-11-01-to-2020-12-15-ba_campo_alegre_de_lourdes.txt)
- Output: [output-from-2020-11-01-to-2020-12-15-ba_campo_alegre_de_lourdes.csv](https://github.com/okfn-brasil/querido-diario/files/14673131/output-from-2020-11-01-to-2020-12-15-ba_campo_alegre_de_lourdes.csv)

solves https://github.com/okfn-brasil/querido-diario/issues/1089
