### PR TITLE
[Revisão Retroativa] São José dos Campos/SP

### DIFF
--- a/data_collection/gazette/spiders/sp/sp_sao_jose_dos_campos.py
+++ b/data_collection/gazette/spiders/sp/sp_sao_jose_dos_campos.py
@@ -1,57 +1,39 @@
-import dateparser
-from scrapy import FormRequest
+from datetime import date, datetime
+
+from dateutil.rrule import DAILY, rrule
+from scrapy.http import Request
 
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
 
 class SpSaoJoseDosCamposSpider(BaseGazetteSpider):
-    TERRITORY_ID = "3549904"
-
-    GAZETTE_NAME_CSS = "td:last-child a::text"
-    GAZETTE_URL_CSS = "td:last-child a::attr(href)"
-    GAZETTE_DATE_CSS = "td:nth-child(2)::text"
-    NEXT_PAGE_LINK_CSS = ".paginador_anterior_proxima a"
-    JAVASCRIPT_POSTBACK_REGEX = r"javascript:__doPostBack\('(.*)',''\)"
-
-    allowed_domains = ["servicos2.sjc.sp.gov.br"]
     name = "sp_sao_jose_dos_campos"
-    start_urls = [
-        "http://servicos2.sjc.sp.gov.br/servicos/portal_da_transparencia/boletim_municipio.aspx"
-    ]
+    TERRITORY_ID = "3549904"
+    allowed_domains = ["diariodomunicipio.sjc.sp.gov.br"]
+    api_url = "https://diariodomunicipio.sjc.sp.gov.br/apifront/portal/edicoes/edicoes_from_data/"
+    start_date = date(2015, 8, 7)
+
+    def start_requests(self):
+        for daily_date in rrule(
+            freq=DAILY, dtstart=self.start_date, until=self.end_date
+        ):
+            url = f'{self.api_url}{daily_date.strftime("%Y-%m-%d")}.json'
+
+            yield Request(url)
 
     def parse(self, response):
-        for element in response.css("#corpo table tr"):
-            if element.css("th").extract():
-                continue
-
-            date = element.css(self.GAZETTE_DATE_CSS).extract_first()
-            date = dateparser.parse(date, languages=["pt"]).date()
-            url = element.css(self.GAZETTE_URL_CSS).extract_first()
-            gazette_title = element.css(self.GAZETTE_NAME_CSS).extract_first()
-            is_extra = "Extra" in gazette_title
-
+        data = response.json()
+        if data["erro"]:
+            return
+        for gazzete in data["itens"]:
             yield Gazette(
-                date=date,
-                file_urls=[url],
-                is_extra_edition=is_extra,
+                date=datetime.strptime(gazzete["data"], "%d/%m/%Y").date(),
+                edition_number=gazzete["numero"],
+                is_extra_edition=gazzete["suplemento"] != 0
+                and gazzete["suplemento"] != "",
                 power="executive_legislative",
-            )
-
-        for element in response.css(self.NEXT_PAGE_LINK_CSS):
-            if not element.css("a::text").extract_first() == "Próxima":
-                continue
-
-            event_target = element.css("a::attr(href)")
-            event_target = event_target.re(self.JAVASCRIPT_POSTBACK_REGEX).pop()
-
-            yield FormRequest.from_response(
-                response,
-                callback=self.parse,
-                formname="aspnetForm",
-                formxpath="//form[@id='aspnetForm']",
-                formdata={"__EVENTARGUMENT": "", "__EVENTTARGET": event_target},
-                dont_click=True,
-                dont_filter=True,
-                method="POST",
+                file_urls=[
+                    f'https://diariodomunicipio.sjc.sp.gov.br/portal/edicoes/download/{gazzete["id"]}'
+                ],
             )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [X] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [X] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [X] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [X] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [X] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [X] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

A spider atual está defasada, pois consulta o domínio https://servicos2.sjc.sp.gov.br/, sendo que atualmente os boletins são disponibilizados através do site https://diariodomunicipio.sjc.sp.gov.br/

#### Logs

coleta da última edição (27/03/2024 até então)
[sp_sao_jose_dos_campos_marco_2024.log](https://github.com/okfn-brasil/querido-diario/files/14805050/sp_sao_jose_dos_campos_marco_2024.log)

coleta arbitrária
[sp_sao_jose_dos_campos_setembro_2022.log](https://github.com/okfn-brasil/querido-diario/files/14805051/sp_sao_jose_dos_campos_setembro_2022.log)
[sp_sao_jose_dos_campos_setembro_2022.csv](https://github.com/okfn-brasil/querido-diario/files/14805053/sp_sao_jose_dos_campos_setembro_2022.csv)

coleta completa
[sp_sao_jose_dos_campos_completo.log](https://github.com/okfn-brasil/querido-diario/files/14805095/sp_sao_jose_dos_campos_completo.log)
[sp_sao_jose_dos_campos_completo.csv](https://github.com/okfn-brasil/querido-diario/files/14805096/sp_sao_jose_dos_campos_completo.csv)

resolve #1123
