### PR TITLE
Add ValeGazetteSpider e alguns municípios que a utilizam   

### DIFF
--- a/data_collection/gazette/spiders/base/vale.py
+++ b/data_collection/gazette/spiders/base/vale.py
@@ -1,0 +1,75 @@
+from datetime import date
+from re import findall
+
+import scrapy
+import scrapy.resolver
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class ValeGazetteSpider(BaseGazetteSpider):
+    """
+    Base spider for cities using the Framework Vale as design system.
+    """
+
+    def start_requests(self):
+        yield scrapy.Request(url=self._get_url(page=1), callback=self._parse_pagination)
+
+    def _parse_pagination(self, response):
+        last_page = response.css('[title="Última página"] ::attr(href)').get()
+        if last_page:
+            number_last_page = int(last_page.split("/")[-1])
+        else:
+            number_last_page = 0
+        for i in range(number_last_page + 1):
+            yield scrapy.Request(self._get_url(page=i))
+
+    def _get_url(self, page):
+        start_date = self.start_date.strftime("%Y-%m-%d")
+        end_date = self.end_date.strftime("%Y-%m-%d")
+        url = (
+            f"https://{self.allowed_domains[0]}/diariooficial/"
+            f"pesquisa/all/all/{start_date}/{end_date}/{page}"
+        )
+        return url
+
+    def _get_gazette_date(self, gazette):
+        MONTHS = {
+            "janeiro": "01",
+            "fevereiro": "02",
+            "março": "03",
+            "abril": "04",
+            "maio": "05",
+            "junho": "06",
+            "julho": "07",
+            "agosto": "08",
+            "setembro": "09",
+            "outubro": "10",
+            "novembro": "11",
+            "dezembro": "12",
+        }
+
+        website_date_text = gazette.xpath(
+            './/*[contains(text(), "Publicado")]/text()'
+        ).get()
+        [day, month, year] = findall(r", (.*) de (.*) de (.*)", website_date_text)[0]
+        datetime_date = date(int(year), int(MONTHS[month]), int(day))
+        return datetime_date
+
+    def parse(self, response):
+        gazettes = response.css(".ant-list-item")
+
+        for gazette in gazettes:
+            gazette_date = self._get_gazette_date(gazette)
+            file_url = gazette.css("a ::attr(href)").get()
+            edition_text = "".join(gazette.css(".edition-number ::text").getall())
+            edition_number = findall(r"(\d+)", edition_text)[0]
+            is_extra_edition = "Extra" in edition_text
+            yield Gazette(
+                date=gazette_date,
+                file_urls=[file_url],
+                edition_number=edition_number,
+                is_extra_edition=is_extra_edition,
+                power="executive",
+            )

--- a/data_collection/gazette/spiders/to/to_buriti_do_tocantins.py
+++ b/data_collection/gazette/spiders/to/to_buriti_do_tocantins.py
@@ -1,0 +1,10 @@
+from datetime import date
+
+from gazette.spiders.base.vale import ValeGazetteSpider
+
+
+class ToBuritiDoTocantinsSpider(ValeGazetteSpider):
+    TERRITORY_ID = "1703800"
+    name = "to_buriti_do_tocantins"
+    allowed_domains = ["diario.buritidotocantins.to.gov.br"]
+    start_date = date(2017, 3, 20)

--- a/data_collection/gazette/spiders/to/to_cristalandia.py
+++ b/data_collection/gazette/spiders/to/to_cristalandia.py
@@ -1,0 +1,10 @@
+from datetime import date
+
+from gazette.spiders.base.vale import ValeGazetteSpider
+
+
+class ToCristalandiaSpider(ValeGazetteSpider):
+    TERRITORY_ID = "1706100"
+    name = "to_cristalandia"
+    allowed_domains = ["diario.cristalandia.to.gov.br"]
+    start_date = date(2017, 3, 13)

--- a/data_collection/gazette/spiders/to/to_pium.py
+++ b/data_collection/gazette/spiders/to/to_pium.py
@@ -1,0 +1,10 @@
+from datetime import date
+
+from gazette.spiders.base.vale import ValeGazetteSpider
+
+
+class ToPiumSpider(ValeGazetteSpider):
+    TERRITORY_ID = "1717503"
+    name = "to_pium"
+    allowed_domains = ["diario.pium.to.gov.br"]
+    start_date = date(2021, 4, 14)


### PR DESCRIPTION
*AO ABRIR* uma Pull Request de um novo raspador (spider), marque com um X cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O layout não se parece com nenhum caso [da lista de layouts padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um layout padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [X] É um layout padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [X] Não utilizo custom_settings em meu raspador.

#### Testes
- [X] Uma coleta-teste *da última edição* foi feita. O arquivo de .log deste teste está anexado na PR.
- [X] Uma coleta-teste *por intervalo arbitrário* foi feita. Os arquivos de `.log`e .csv deste teste estão anexados na PR.
- [X] Uma coleta-teste *completa* foi feita. Os arquivos de .log e .csv deste teste estão anexados na PR.

#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [X] Eu verifiquei os arquivos .csv gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [X] Eu verifiquei os arquivos de .log gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição
Esse PR resolve  #1116 assim como adiciona mais três municípios (to_buriti_do_tocantins, to_pium, to_cristalandia)


Coleta-teste completa:
[to_buriti_do_tocantins-full-extraction.csv](https://github.com/okfn-brasil/querido-diario/files/14952714/to_buriti_do_tocantins-full-extraction.csv)
[to_buriti_do_tocantins-full-extraction.log](https://github.com/okfn-brasil/querido-diario/files/14952715/to_buriti_do_tocantins-full-extraction.log)

[to_pium-full-extraction.csv](https://github.com/okfn-brasil/querido-diario/files/14952738/to_pium-full-extraction.csv)
[to_pium-full-extraction.log](https://github.com/okfn-brasil/querido-diario/files/14952740/to_pium-full-extraction.log)

[to_cristalandia-full-extraction.csv](https://github.com/okfn-brasil/querido-diario/files/14952766/to_cristalandia-full-extraction.csv)
[to_cristalandia-full-extraction.log](https://github.com/okfn-brasil/querido-diario/files/14952767/to_cristalandia-full-extraction.log)


Coleta-teste intervalo arbitrário:

[to_buriti_do_tocantins-2022-12-31--2024-04-11.csv](https://github.com/okfn-brasil/querido-diario/files/14952893/to_buriti_do_tocantins-2022-12-31--2024-04-11.csv)
[to_buriti_do_tocantins-2022-12-31--2024-04-11.log](https://github.com/okfn-brasil/querido-diario/files/14952895/to_buriti_do_tocantins-2022-12-31--2024-04-11.log)

[to_pium-2022-12-31--2024-04-11.csv](https://github.com/okfn-brasil/querido-diario/files/14952868/to_pium-2022-12-31--2024-04-11.csv)
[to_pium-2022-12-31--2024-04-11.log](https://github.com/okfn-brasil/querido-diario/files/14952869/to_pium-2022-12-31--2024-04-11.log)

[to_cristalandia-2022-12-31--2024-04-11.csv](https://github.com/okfn-brasil/querido-diario/files/14952837/to_cristalandia-2022-12-31--2024-04-11.csv)
[to_cristalandia-2022-12-31--2024-04-11.log](https://github.com/okfn-brasil/querido-diario/files/14952838/to_cristalandia-2022-12-31--2024-04-11.log)

Coleta-teste última edição:

[to_buriti_do_tocantins-last-edition.log](https://github.com/okfn-brasil/querido-diario/files/14962985/to_buriti_do_tocantins-last-edition.log)

[to_cristalandia-last-edition.log](https://github.com/okfn-brasil/querido-diario/files/14962968/to_cristalandia-last-edition.log)

[to_pium-last-edition.log](https://github.com/okfn-brasil/querido-diario/files/14962956/to_pium-last-edition.log)
