### PR TITLE
Adiciona proxy em mg_uberlandia.py

### DIFF
--- a/data_collection/gazette/spiders/mg/mg_uberlandia.py
+++ b/data_collection/gazette/spiders/mg/mg_uberlandia.py
@@ -11,6 +11,8 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class MgUberlandiaSpider(BaseGazetteSpider):
+    zyte_smartproxy_enabled = True
+
     TERRITORY_ID = "3170206"
     name = "mg_uberlandia"
     start_date = datetime.date(2005, 1, 3)


### PR DESCRIPTION
Segunda, o raspador para Uberlândia-MG em produção deu erros 403 (sendo que no teste local não deu esse problema - logs adicionados em #638) e o proxy foi adicionado por conta disso (#1128). O que não adiantou. Depois foi percebido que os testes locais também não funcionavam mais (talvez por ter sido diagnosticada as dinâmicas de raspagem). Fez-se necessário o uso de user-agent (#1129) e não havia mais evidência que o problema era de proxy, por isso o proxy foi retirado. 

Agora, está fazendo apenas a primeira requisição e não permitindo ela, então tentamos o proxy novamente.