### PR TITLE
[Novo spider base]: NucleoGov - Anápolis, GO

### DIFF
--- a/data_collection/gazette/spiders/base/nucleogov.py
+++ b/data_collection/gazette/spiders/base/nucleogov.py
@@ -1,0 +1,41 @@
+import json
+from datetime import datetime
+
+import scrapy
+from dateutil.rrule import DAILY, rrule
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class NucleoGovGazetteSpider(BaseGazetteSpider):
+    def start_requests(self):
+        days = rrule(freq=DAILY, dtstart=self.start_date, until=self.end_date)
+        for day in days:
+            yield scrapy.Request(self.url_base.format(day.strftime("%Y-%m-%d")))
+
+    def parse(self, response):
+        data = json.loads(response.text)
+
+        gazettes = data.get("data")
+        for gazette in gazettes:
+            gazette_urls = []
+
+            if gazette.get("media_legacy"):
+                gazette_urls.append(gazette.get("media_legacy"))
+            else:
+                midias = gazette.get("midias")
+
+                for midia in midias:
+                    gazette_urls.append(midia.get("url"))
+
+            gazette_date = datetime.strptime(gazette.get("data"), "%Y-%m-%d")
+            edition_number = gazette.get("numero")
+
+            yield Gazette(
+                date=gazette_date.date(),
+                file_urls=gazette_urls,
+                edition_number=edition_number,
+                power="executive",
+                is_extra_edition=False,
+            )

--- a/data_collection/gazette/spiders/go/go_anapolis.py
+++ b/data_collection/gazette/spiders/go/go_anapolis.py
@@ -1,0 +1,16 @@
+import datetime as dt
+
+from gazette.spiders.base.nucleogov import NucleoGovGazetteSpider
+
+
+class GoAnapolisSpider(NucleoGovGazetteSpider):
+    name = "go_anapolis"
+    TERRITORY_ID = "5201108"
+    allowed_domains = [
+        "dom.anapolis.go.gov.br",
+    ]
+    url_base = (
+        "https://dom.anapolis.go.gov.br/api/diarios?data={}&calendar=true&situacao=2"
+    )
+
+    start_date = dt.date(2010, 6, 1)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [x] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

Este pull request adiciona o spider base para o sistema NucleoGov, utilizando o mapeador (PR #1019).

##### Observacao

Ao analisar o NucleoGov, notei que existe outro sistema que lista decretos de forma individual via API. Não consegui listar as demais cidades, mas sei que existem municípios de outros estados que utilizam esse sistema. Neste [link](https://acessoainformacao.rioverde.go.leg.br/cidadao/legislacao/decretos) é possível acessar os decretos do município de Rio Verde, Goiás.

Após a aceitação deste PR, criarei os spiders das outras cidades que utilizam o NucleoGov:

###### Municípios que faltam ser integrados:

1. [Diário Oficial de Cariri, TO](https://dom.cariri.to.gov.br/)
2. [Diário Oficial do Paraná, TO](https://diariooficial.parana.to.gov.br/)
3. [Diário Oficial de Jaú, TO](https://diariooficial.jau.to.gov.br/)
4. [Diário Oficial de Valparaíso de Goiás, GO](https://diariooficial.valparaisodegoias.go.gov.br/)

##### Testes

Devido ao intervalo de start_date ser de 2010, meu PC não tem espaço suficiente para fazer uma coleta completa.

Arquivos de teste:
##### ultima
- [go_anapolis.csv](https://github.com/okfn-brasil/querido-diario/files/15473419/go_anapolis.csv)
- [go_anapolis.log](https://github.com/okfn-brasil/querido-diario/files/15473420/go_anapolis.log)

- [ultima_edicao_go_anapolis.log](https://github.com/okfn-brasil/querido-diario/files/15473421/ultima_edicao_go_anapolis.log)

##### maio/2024 - hoje
- [go_anapolis_all.csv](https://github.com/okfn-brasil/querido-diario/files/15473630/go_anapolis_all.csv)
- [go_anapolis_all.log](https://github.com/okfn-brasil/querido-diario/files/15473633/go_anapolis_all.log)
