### PR TITLE
Modifica spider DOEM para coletar mais diários (#1041)

### DIFF
--- a/data_collection/gazette/spiders/ba/ba_acajutiba.py
+++ b/data_collection/gazette/spiders/ba/ba_acajutiba.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaAcajutibaSpider(DoemGazetteSpider):
     TERRITORY_ID = "2900306"
     name = "ba_acajutiba"
-    start_date = date(2018, 1, 2)
     state_city_url_part = "ba/acajutiba"
+    start_date = date(2013, 1, 30)

--- a/data_collection/gazette/spiders/ba/ba_alagoinhas.py
+++ b/data_collection/gazette/spiders/ba/ba_alagoinhas.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaAlagoinhasSpider(DoemGazetteSpider):
     TERRITORY_ID = "2900702"
     name = "ba_alagoinhas"
-    start_date = date(2018, 1, 2)  # edition_number 1.950
     state_city_url_part = "ba/alagoinhas"
+    start_date = date(2015, 1, 28)

--- a/data_collection/gazette/spiders/ba/ba_alcobaca.py
+++ b/data_collection/gazette/spiders/ba/ba_alcobaca.py
@@ -7,4 +7,4 @@ class BaAlcobacaSpider(DoemGazetteSpider):
     TERRITORY_ID = "2900801"
     name = "ba_alcobaca"
     state_city_url_part = "ba/alcobaca"
-    start_date = date(2012, 1, 2)
+    start_date = date(2017, 3, 3)

--- a/data_collection/gazette/spiders/ba/ba_alcobaca.py
+++ b/data_collection/gazette/spiders/ba/ba_alcobaca.py
@@ -7,4 +7,4 @@ class BaAlcobacaSpider(DoemGazetteSpider):
     TERRITORY_ID = "2900801"
     name = "ba_alcobaca"
     state_city_url_part = "ba/alcobaca"
-    start_date = date(2017, 3, 3)
+    start_date = date(2012, 1, 2)

--- a/data_collection/gazette/spiders/ba/ba_angical.py
+++ b/data_collection/gazette/spiders/ba/ba_angical.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaAngicalSpider(DoemGazetteSpider):
     TERRITORY_ID = "2901403"
     name = "ba_angical"
-    start_date = date(2021, 1, 4)
     state_city_url_part = "ba/angical"
+    start_date = date(2021, 1, 4)

--- a/data_collection/gazette/spiders/ba/ba_caetite.py
+++ b/data_collection/gazette/spiders/ba/ba_caetite.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaCaetiteSpider(DoemGazetteSpider):
     TERRITORY_ID = "2905206"
     name = "ba_caetite"
-    start_date = date(2021, 4, 27)
     state_city_url_part = "ba/caetite"
+    start_date = date(2021, 4, 27)

--- a/data_collection/gazette/spiders/ba/ba_campo_alegre_de_lourdes.py
+++ b/data_collection/gazette/spiders/ba/ba_campo_alegre_de_lourdes.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaCampoAlegreDeLourdesSpider(DoemGazetteSpider):
     TERRITORY_ID = "2905909"
     name = "ba_campo_alegre_de_lourdes"
-    start_date = date(2020, 11, 30)  # Primeira edição em 30/11/2020
     state_city_url_part = "ba/campoalegredelourdes"
+    start_date = date(2020, 11, 30)

--- a/data_collection/gazette/spiders/ba/ba_campo_formoso.py
+++ b/data_collection/gazette/spiders/ba/ba_campo_formoso.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaCampoFormosoSpider(DoemGazetteSpider):
     TERRITORY_ID = "2906006"
     name = "ba_campo_formoso"
-    start_date = date(2018, 1, 3)  # edition_number 873
     state_city_url_part = "ba/campoformoso"
+    start_date = date(2013, 1, 31)

--- a/data_collection/gazette/spiders/ba/ba_canudos.py
+++ b/data_collection/gazette/spiders/ba/ba_canudos.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaCanudosSpider(DoemGazetteSpider):
     TERRITORY_ID = "2906824"
     name = "ba_canudos"
-    start_date = date(2013, 1, 4)  # edition number 444
     state_city_url_part = "ba/canudos"
+    start_date = date(2013, 1, 4)

--- a/data_collection/gazette/spiders/ba/ba_cipo.py
+++ b/data_collection/gazette/spiders/ba/ba_cipo.py
@@ -7,4 +7,4 @@ class BaCipoSpider(DoemGazetteSpider):
     TERRITORY_ID = "2907905"
     name = "ba_cipo"
     state_city_url_part = "ba/cipo"
-    start_date = date(2012, 1, 2)
+    start_date = date(2021, 1, 4)

--- a/data_collection/gazette/spiders/ba/ba_cipo.py
+++ b/data_collection/gazette/spiders/ba/ba_cipo.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaCipoSpider(DoemGazetteSpider):
     TERRITORY_ID = "2907905"
     name = "ba_cipo"
-    start_date = date(2021, 1, 4)
     state_city_url_part = "ba/cipo"
+    start_date = date(2012, 1, 2)

--- a/data_collection/gazette/spiders/ba/ba_cotegipe.py
+++ b/data_collection/gazette/spiders/ba/ba_cotegipe.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaCotegipeSpider(DoemGazetteSpider):
     TERRITORY_ID = "2909406"
     name = "ba_cotegipe"
-    start_date = date(2023, 1, 5)
     state_city_url_part = "ba/cotegipe"
+    start_date = date(2023, 1, 5)

--- a/data_collection/gazette/spiders/ba/ba_cristopolis.py
+++ b/data_collection/gazette/spiders/ba/ba_cristopolis.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaCristopolisSpider(DoemGazetteSpider):
     TERRITORY_ID = "2909703"
     name = "ba_cristopolis"
-    start_date = date(2021, 1, 12)
     state_city_url_part = "ba/cristopolis"
+    start_date = date(2021, 1, 12)

--- a/data_collection/gazette/spiders/ba/ba_cruz_das_almas.py
+++ b/data_collection/gazette/spiders/ba/ba_cruz_das_almas.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaCruzDasAlmasSpider(DoemGazetteSpider):
     TERRITORY_ID = "2909802"
     name = "ba_cruz_das_almas"
-    start_date = date(2021, 4, 1)
     state_city_url_part = "ba/cruzdasalmas"
+    start_date = date(2021, 4, 1)

--- a/data_collection/gazette/spiders/ba/ba_esplanada.py
+++ b/data_collection/gazette/spiders/ba/ba_esplanada.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaEsplanadaSpider(DoemGazetteSpider):
     TERRITORY_ID = "2910602"
     name = "ba_esplanada"
-    start_date = date(2021, 1, 4)
     state_city_url_part = "ba/esplanada"
+    start_date = date(2021, 1, 4)

--- a/data_collection/gazette/spiders/ba/ba_formosa_do_rio_preto.py
+++ b/data_collection/gazette/spiders/ba/ba_formosa_do_rio_preto.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaFormosaDoRioPretoSpider(DoemGazetteSpider):
     TERRITORY_ID = "2911105"
     name = "ba_formosa_do_rio_preto"
-    start_date = date(2021, 1, 4)
     state_city_url_part = "ba/formosadoriopreto"
+    start_date = date(2021, 1, 4)

--- a/data_collection/gazette/spiders/ba/ba_irara.py
+++ b/data_collection/gazette/spiders/ba/ba_irara.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaIraraSpider(DoemGazetteSpider):
     TERRITORY_ID = "2914505"
     name = "ba_irara"
-    start_date = date(2018, 1, 3)
     state_city_url_part = "ba/irara"
+    start_date = date(2014, 4, 24)

--- a/data_collection/gazette/spiders/ba/ba_itaberaba.py
+++ b/data_collection/gazette/spiders/ba/ba_itaberaba.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaItaberabaSpider(DoemGazetteSpider):
     TERRITORY_ID = "2914703"
     name = "ba_itaberaba"
-    start_date = date(2022, 7, 4)
     state_city_url_part = "ba/itaberaba"
+    start_date = date(2022, 7, 4)

--- a/data_collection/gazette/spiders/ba/ba_itamaraju.py
+++ b/data_collection/gazette/spiders/ba/ba_itamaraju.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaItamarajuSpider(DoemGazetteSpider):
     TERRITORY_ID = "2915601"
     name = "ba_itamaraju"
-    start_date = date(2008, 3, 28)
     state_city_url_part = "ba/itamaraju"
+    start_date = date(2008, 3, 28)

--- a/data_collection/gazette/spiders/ba/ba_itapicuru.py
+++ b/data_collection/gazette/spiders/ba/ba_itapicuru.py
@@ -7,4 +7,4 @@ class BaItapicuruSpider(DoemGazetteSpider):
     TERRITORY_ID = "2916500"
     name = "ba_itapicuru"
     state_city_url_part = "ba/itapicuru"
-    start_date = date(2014, 1, 2)
+    start_date = date(2021, 1, 4)

--- a/data_collection/gazette/spiders/ba/ba_itapicuru.py
+++ b/data_collection/gazette/spiders/ba/ba_itapicuru.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaItapicuruSpider(DoemGazetteSpider):
     TERRITORY_ID = "2916500"
     name = "ba_itapicuru"
-    start_date = date(2021, 1, 4)
     state_city_url_part = "ba/itapicuru"
+    start_date = date(2014, 1, 2)

--- a/data_collection/gazette/spiders/ba/ba_ituacu.py
+++ b/data_collection/gazette/spiders/ba/ba_ituacu.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaItuacuSpider(DoemGazetteSpider):
     TERRITORY_ID = "2917201"
     name = "ba_ituacu"
-    start_date = date(2018, 1, 2)
     state_city_url_part = "ba/ituacu"
+    start_date = date(2015, 2, 4)

--- a/data_collection/gazette/spiders/ba/ba_jaguaquara.py
+++ b/data_collection/gazette/spiders/ba/ba_jaguaquara.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaJaguaquaraSpider(DoemGazetteSpider):
     TERRITORY_ID = "2917607"
     name = "ba_jaguaquara"
-    start_date = date(2021, 4, 5)
     state_city_url_part = "ba/jaguaquara"
+    start_date = date(2021, 4, 5)

--- a/data_collection/gazette/spiders/ba/ba_juazeiro.py
+++ b/data_collection/gazette/spiders/ba/ba_juazeiro.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaJuazeiroSpider(DoemGazetteSpider):
     TERRITORY_ID = "2918407"
     name = "ba_juazeiro"
-    start_date = date(2018, 1, 2)  # edition_number 1.135
     state_city_url_part = "ba/juazeiro"
+    start_date = date(2013, 2, 1)

--- a/data_collection/gazette/spiders/ba/ba_laje.py
+++ b/data_collection/gazette/spiders/ba/ba_laje.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaLajeSpider(DoemGazetteSpider):
     TERRITORY_ID = "2918803"
     name = "ba_laje"
-    start_date = date(2020, 1, 8)
     state_city_url_part = "ba/laje"
+    start_date = date(2020, 1, 8)

--- a/data_collection/gazette/spiders/ba/ba_lajedao.py
+++ b/data_collection/gazette/spiders/ba/ba_lajedao.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaLajedaoSpider(DoemGazetteSpider):
     TERRITORY_ID = "2918902"
     name = "ba_lajedao"
-    start_date = date(2021, 4, 14)
     state_city_url_part = "ba/lajedao"
+    start_date = date(2021, 4, 14)

--- a/data_collection/gazette/spiders/ba/ba_macajuba.py
+++ b/data_collection/gazette/spiders/ba/ba_macajuba.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaMacajubaSpider(DoemGazetteSpider):
     TERRITORY_ID = "2919603"
     name = "ba_macajuba"
-    start_date = date(2014, 3, 17)
     state_city_url_part = "ba/macajuba"
+    start_date = date(2014, 3, 17)

--- a/data_collection/gazette/spiders/ba/ba_mascote.py
+++ b/data_collection/gazette/spiders/ba/ba_mascote.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaMascoteSpider(DoemGazetteSpider):
     TERRITORY_ID = "2920908"
     name = "ba_mascote"
-    start_date = date(2010, 1, 4)  # edition number 1
     state_city_url_part = "ba/mascote"
+    start_date = date(2010, 1, 4)

--- a/data_collection/gazette/spiders/ba/ba_monte_santo.py
+++ b/data_collection/gazette/spiders/ba/ba_monte_santo.py
@@ -7,4 +7,4 @@ class BaMonteSantoSpider(DoemGazetteSpider):
     TERRITORY_ID = "2921500"
     name = "ba_monte_santo"
     state_city_url_part = "ba/montesanto"
-    start_date = date(2013, 1, 9)
+    start_date = date(2021, 1, 2)

--- a/data_collection/gazette/spiders/ba/ba_monte_santo.py
+++ b/data_collection/gazette/spiders/ba/ba_monte_santo.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaMonteSantoSpider(DoemGazetteSpider):
     TERRITORY_ID = "2921500"
     name = "ba_monte_santo"
-    start_date = date(2021, 1, 2)
     state_city_url_part = "ba/montesanto"
+    start_date = date(2013, 1, 9)

--- a/data_collection/gazette/spiders/ba/ba_morro_do_chapeu.py
+++ b/data_collection/gazette/spiders/ba/ba_morro_do_chapeu.py
@@ -7,4 +7,4 @@ class BaMorroDoChapeuSpider(DoemGazetteSpider):
     TERRITORY_ID = "2921708"
     name = "ba_morro_do_chapeu"
     state_city_url_part = "ba/morrodochapeu"
-    start_date = date(2013, 3, 1)
+    start_date = date(2021, 1, 6)

--- a/data_collection/gazette/spiders/ba/ba_morro_do_chapeu.py
+++ b/data_collection/gazette/spiders/ba/ba_morro_do_chapeu.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaMorroDoChapeuSpider(DoemGazetteSpider):
     TERRITORY_ID = "2921708"
     name = "ba_morro_do_chapeu"
-    start_date = date(2021, 1, 6)
     state_city_url_part = "ba/morrodochapeu"
+    start_date = date(2013, 3, 1)

--- a/data_collection/gazette/spiders/ba/ba_mucuri.py
+++ b/data_collection/gazette/spiders/ba/ba_mucuri.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaMucuriSpider(DoemGazetteSpider):
     TERRITORY_ID = "2922003"
     name = "ba_mucuri"
-    start_date = date(2018, 1, 3)
     state_city_url_part = "ba/mucuri"
+    start_date = date(2011, 4, 5)

--- a/data_collection/gazette/spiders/ba/ba_prado.py
+++ b/data_collection/gazette/spiders/ba/ba_prado.py
@@ -7,4 +7,4 @@ class BaPradoSpider(DoemGazetteSpider):
     TERRITORY_ID = "2925501"
     name = "ba_prado"
     state_city_url_part = "ba/prado"
-    start_date = date(2018, 1, 2)
+    start_date = date(2013, 2, 4)

--- a/data_collection/gazette/spiders/ba/ba_santa_rita_de_cassia.py
+++ b/data_collection/gazette/spiders/ba/ba_santa_rita_de_cassia.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaSantaRitaDeCassiaSpider(DoemGazetteSpider):
     TERRITORY_ID = "2928406"
     name = "ba_santa_rita_de_cassia"
-    start_date = date(2021, 1, 4)
     state_city_url_part = "ba/santaritadecassia"
+    start_date = date(2021, 1, 4)

--- a/data_collection/gazette/spiders/ba/ba_santo_estevao.py
+++ b/data_collection/gazette/spiders/ba/ba_santo_estevao.py
@@ -7,4 +7,4 @@ class BaSantoEstevaoSpider(DoemGazetteSpider):
     TERRITORY_ID = "2928802"
     name = "ba_santo_estevao"
     state_city_url_part = "ba/santoestevao"
-    start_date = date(2009, 11, 9)
+    start_date = date(2017, 1, 6)

--- a/data_collection/gazette/spiders/ba/ba_santo_estevao.py
+++ b/data_collection/gazette/spiders/ba/ba_santo_estevao.py
@@ -7,4 +7,4 @@ class BaSantoEstevaoSpider(DoemGazetteSpider):
     TERRITORY_ID = "2928802"
     name = "ba_santo_estevao"
     state_city_url_part = "ba/santoestevao"
-    start_date = date(2017, 1, 6)
+    start_date = date(2009, 11, 9)

--- a/data_collection/gazette/spiders/ba/ba_satiro_dias.py
+++ b/data_collection/gazette/spiders/ba/ba_satiro_dias.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaSatiroDiasSpider(DoemGazetteSpider):
     TERRITORY_ID = "2929701"
     name = "ba_satiro_dias"
-    start_date = date(2021, 3, 30)
     state_city_url_part = "ba/satirodias"
+    start_date = date(2021, 3, 30)

--- a/data_collection/gazette/spiders/ba/ba_senhor_do_bonfim.py
+++ b/data_collection/gazette/spiders/ba/ba_senhor_do_bonfim.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaSenhorDoBonfimSpider(DoemGazetteSpider):
     TERRITORY_ID = "2930105"
     name = "ba_senhor_do_bonfim"
-    start_date = date(2018, 1, 2)  # edition_number 1.503
     state_city_url_part = "ba/senhordobonfim"
+    start_date = date(2013, 1, 3)

--- a/data_collection/gazette/spiders/ba/ba_tapiramuta.py
+++ b/data_collection/gazette/spiders/ba/ba_tapiramuta.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class BaTapiramutaSpider(DoemGazetteSpider):
     TERRITORY_ID = "2931301"
     name = "ba_tapiramuta"
-    start_date = date(2021, 1, 4)
     state_city_url_part = "ba/tapiramuta"
+    start_date = date(2021, 1, 4)

--- a/data_collection/gazette/spiders/ba/ba_tucano.py
+++ b/data_collection/gazette/spiders/ba/ba_tucano.py
@@ -7,4 +7,4 @@ class BaTucanoSpider(DoemGazetteSpider):
     TERRITORY_ID = "2931905"
     name = "ba_tucano"
     state_city_url_part = "ba/tucano"
-    start_date = date(2018, 1, 2)
+    start_date = date(2013, 1, 4)

--- a/data_collection/gazette/spiders/pe/pe_petrolina.py
+++ b/data_collection/gazette/spiders/pe/pe_petrolina.py
@@ -1,4 +1,4 @@
-import datetime as dt
+from datetime import date
 
 from gazette.spiders.base.doem import DoemGazetteSpider
 
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class PePetrolinaSpider(DoemGazetteSpider):
     TERRITORY_ID = "2611101"
     name = "pe_petrolina"
-    start_date = dt.date(2014, 3, 6)
     state_city_url_part = "pe/petrolina"
+    start_date = date(2014, 3, 6)

--- a/data_collection/gazette/spiders/pr/pr_ipiranga.py
+++ b/data_collection/gazette/spiders/pr/pr_ipiranga.py
@@ -1,0 +1,10 @@
+from datetime import date
+
+from gazette.spiders.base.doem import DoemGazetteSpider
+
+
+class PrIpirangaSpider(DoemGazetteSpider):
+    TERRITORY_ID = "4110508"
+    name = "pr_ipiranga"
+    state_city_url_part = "pr/ipiranga"
+    start_date = date(2015, 9, 28)

--- a/data_collection/gazette/spiders/pr/pr_tamboara.py
+++ b/data_collection/gazette/spiders/pr/pr_tamboara.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class PrTamboaraSpider(DoemGazetteSpider):
     TERRITORY_ID = "4126702"
     name = "pr_tamboara"
-    start_date = date(2022, 8, 22)
     state_city_url_part = "pr/tamboara"
+    start_date = date(2022, 8, 22)

--- a/data_collection/gazette/spiders/se/se_nossa_senhora_do_socorro.py
+++ b/data_collection/gazette/spiders/se/se_nossa_senhora_do_socorro.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 class SeNossaSenhoraDoSocorroSpider(DoemGazetteSpider):
     TERRITORY_ID = "2804805"
     name = "se_nossa_senhora_do_socorro"
-    start_date = date(2022, 11, 7)  # edition_number 1
     state_city_url_part = "se/nossasenhoradosocorro"
+    start_date = date(2022, 11, 7)


### PR DESCRIPTION
Esta PR faz: 
- Em 218e838b99c846b81b0af6d358235cacfd38f720, uma modificação foi adicionada na classe DOEM para navegar o site por meio do padrão de construção da URL ao invés do filtro de pesquisa do site, que mostra menos diários do que existem de fato ( resolve #1041 )
-  Em 2b3a163203bc0cfc083122110b17e62156e44ed9 atualiza 16 raspadores com a data mais antiga disponível. Testes abaixo.
-  Com o avanço do mapeamento (#919) passamos a criar raspadores de forma automatizada para cada padrão, o `script` usado recriou raspadores já integrados, mas forçando seu layout a ser estritamente igual. Na prática, não altera nada substancial, é meramente estilo, mas adiciono a modificação (em 0638df7b66a5d612f591312219fe403c49090a66) para facilitar futuras verificações. 

## Logs

### Coleta de intervalo
Dos 16 raspadores com data inicial modificada, testei 4 deles com a coleta de um período anterior ao que o raspador tinha antes. Como a lógica de criação de URLs do raspador é mensal, escolhi um intervalo de metade de um mês até metade de outro (`2016-04-15 a 2016-05-25`) para confirmar o filtro. Não foram encontrados problemas em nenhum deles.

[ba_cipo-periodo.log](https://github.com/user-attachments/files/15519491/ba_cipo-periodo.log) | [ba_cipo-periodo.csv](https://github.com/user-attachments/files/15519492/ba_cipo-periodo.csv)
[ba_campo_formoso-periodo.log](https://github.com/user-attachments/files/15519493/ba_campo_formoso-periodo.log) | [ba_campo_formoso-periodo.csv](https://github.com/user-attachments/files/15519494/ba_campo_formoso-periodo.csv)
[ba_alagoinhas-periodo.log](https://github.com/user-attachments/files/15519497/ba_alagoinhas-periodo.log) | [ba_alagoinhas-periodo.csv](https://github.com/user-attachments/files/15519498/ba_alagoinhas-periodo.csv)
[ba_acajutiba-periodo.log](https://github.com/user-attachments/files/15519499/ba_acajutiba-periodo.log) | [ba_acajutiba-periodo.csv](https://github.com/user-attachments/files/15519500/ba_acajutiba-periodo.csv)

### Coleta da série completa
Como é sabido que DOEM tem casos de municípios que param de contratar o serviço e depois voltam, foi feita a coleta completa de todos os 16 raspadores que tiveram seu `start_date` atualizado para verificar a presença de longos intervalos que possam indicar ocorrências desse tipo.

#### Casos sem interrupções
- ba_alagoinhas --- [ba_alagoinhas-completo.log](https://github.com/user-attachments/files/15519616/ba_alagoinhas-completo.log) | [ba_alagoinhas-completo.csv](https://github.com/user-attachments/files/15519631/ba_alagoinhas-completo.csv)
- ba_campo_formoso --- [ba_campo_formoso-completo.log](https://github.com/user-attachments/files/15519661/ba_campo_formoso-completo.log) | [ba_campo_formoso-completo.csv](https://github.com/user-attachments/files/15519662/ba_campo_formoso-completo.csv)
- ba_irara --- [ba_irara-completo.log](https://github.com/user-attachments/files/15519666/ba_irara-completo.log) | [ba_irara-completo.csv](https://github.com/user-attachments/files/15519667/ba_irara-completo.csv)
- ba_ituacu --- [ba_ituacu-completo.log](https://github.com/user-attachments/files/15519670/ba_ituacu-completo.log) | [ba_ituacu-completo.csv](https://github.com/user-attachments/files/15519671/ba_ituacu-completo.csv)
- ba_juazeiro --- [ba_juazeiro-completo.log](https://github.com/user-attachments/files/15520259/ba_juazeiro-completo.log) | [ba_juazeiro-completo.csv](https://github.com/user-attachments/files/15520260/ba_juazeiro-completo.csv)
- ba_mucuri --- [ba_mucuri-completo.log](https://github.com/user-attachments/files/15520191/ba_mucuri-completo.log) | [ba_mucuri-completo.csv](https://github.com/user-attachments/files/15520192/ba_mucuri-completo.csv)
- ba_prado  --- [ba_prado-completo.log](https://github.com/user-attachments/files/15520193/ba_prado-completo.log) | [ba_prado-completo.csv](https://github.com/user-attachments/files/15520194/ba_prado-completo.csv)
- ba_senhor_do_bonfim --- [ba_senhor_do_bonfim-completo.log](https://github.com/user-attachments/files/15520195/ba_senhor_do_bonfim-completo.log) | [ba_senhor_do_bonfim-completo.csv](https://github.com/user-attachments/files/15520196/ba_senhor_do_bonfim-completo.csv)
- ba_tucano --- [ba_tucano-completo.log](https://github.com/user-attachments/files/15520198/ba_tucano-completo.log) | [ba_tucano-completo.csv](https://github.com/user-attachments/files/15520199/ba_tucano-completo.csv)

#### Casos com interrupções
- ba_acajutiba --- [ba_acajutiba-completo.log](https://github.com/user-attachments/files/15519575/ba_acajutiba-completo.log) | [ba_acajutiba-completo.csv](https://github.com/user-attachments/files/15519576/ba_acajutiba-completo.csv)
Ausente intervalo de aprox. 4 meses: 2013-08-27 a 2014-01-13

- ba_alcobaca --- [ba_alcobaca-completo.log](https://github.com/user-attachments/files/15519656/ba_alcobaca-completo.log) | [ba_alcobaca-completo.csv](https://github.com/user-attachments/files/15519657/ba_alcobaca-completo.csv)
Ausente intervalo de aprox. 4 anos: 2013-04-23 a 2017-03-03

- ba_cipo --- [ba_cipo-completo.log](https://github.com/user-attachments/files/15519664/ba_cipo-completo.log) | [ba_cipo-completo.csv](https://github.com/user-attachments/files/15519665/ba_cipo-completo.csv)
Ausente intervalo de aprox. 4 anos: 2017-02-24 a 2021-01-04

- ba_itapicuru --- [ba_itapicuru-completo.log](https://github.com/user-attachments/files/15519668/ba_itapicuru-completo.log) | [ba_itapicuru-completo.csv](https://github.com/user-attachments/files/15519669/ba_itapicuru-completo.csv)
Ausente intervalo de aprox. 4 anos: 2017-01-03 a 2021-01-04

- ba_monte_santo --- [ba_monte_santo-completo.log](https://github.com/user-attachments/files/15519672/ba_monte_santo-completo.log) | [ba_monte_santo-completo.csv](https://github.com/user-attachments/files/15519673/ba_monte_santo-completo.csv)
Ausente intervalo de aprox. 4 anos: 2017-01-30 a 2021-01-06

- ba_morro_do_chapeu --- [ba_morro_do_chapeu-completo.log](https://github.com/user-attachments/files/15520189/ba_morro_do_chapeu-completo.log) | [ba_morro_do_chapeu-completo.csv](https://github.com/user-attachments/files/15520190/ba_morro_do_chapeu-completo.csv)
Ausente intervalo de aprox. 4 anos: 2017-01-30 a 2021-01-06

- ba_santo_estevao --- [ba_santo_estevao-completo.log](https://github.com/user-attachments/files/15520269/ba_santo_estevao-completo.log) | [ba_santo_estevao-completo.csv](https://github.com/user-attachments/files/15520270/ba_santo_estevao-completo.csv)
Ausente intervalo de aprox. 4 anos: 2013-01-30 a 2017-01-06

### Novo raspador
A PR também adiciona um novo município, que não apresenta erros de raspagem ou interrupções na série histórica
[pr_ipiranga-completo.csv](https://github.com/user-attachments/files/15520308/pr_ipiranga-completo.csv) | [pr_ipiranga-completo.log](https://github.com/user-attachments/files/15520307/pr_ipiranga-completo.log)
