### PR TITLE
Simplifica definição de extensão de arquivo baixado

### DIFF
--- a/data_collection/requirements-dev.txt
+++ b/data_collection/requirements-dev.txt
@@ -248,6 +248,9 @@ docutils==0.16 \
 filelock==3.12.4 \
     --hash=sha256:08c21d87ded6e2b9da6728c3dff51baf1dcecf973b768ef35bcbc3447edb9ad4 \
     --hash=sha256:2e6f249f1f3654291606e046b09f1fd5eac39b360664c27f5aad072012f8bcbd
+filetype==1.2.0 \
+    --hash=sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb \
+    --hash=sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25
 flake8==6.1.0 \
     --hash=sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23 \
     --hash=sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5

--- a/data_collection/requirements.in
+++ b/data_collection/requirements.in
@@ -3,6 +3,7 @@ boto3==1.24.89
 click
 chompjs
 dateparser
+filetype
 itemadapter
 jinja2
 psycopg2-binary

--- a/data_collection/requirements.txt
+++ b/data_collection/requirements.txt
@@ -216,6 +216,9 @@ docutils==0.16 \
 filelock==3.12.4 \
     --hash=sha256:08c21d87ded6e2b9da6728c3dff51baf1dcecf973b768ef35bcbc3447edb9ad4 \
     --hash=sha256:2e6f249f1f3654291606e046b09f1fd5eac39b360664c27f5aad072012f8bcbd
+filetype==1.2.0 \
+    --hash=sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb \
+    --hash=sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25
 fqdn==1.5.1 \
     --hash=sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f \
     --hash=sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014


### PR DESCRIPTION
Melhorias em https://github.com/okfn-brasil/querido-diario/pull/1045
    
    Quando a extensão do arquivo não é informada no nome dele, tentamos
    identificar ela através dos headers do response ou através de seu
    conteúdo. Porém devido a maneira como o Scrapy funciona, isso vai fazer
    com que o arquivo seja baixado novamente em novas execuções do spider.
    Para resolver esse problema seria necessários muitas mudanças na
    estrutura do Scrapy (incluindo a criação de novos FileStorage, o que
    tornaria o projeto mais complexo, com um ganho de performance
    irrelevante.
    
    Com esse modificação, identificamos a extensão, e se ela não vier por
    padrão, o arquivo será baixado novamente toda vez que reexecutarmos o
    spider (o que nunca acontece em produção para a data específica)
