### PR TITLE
Adiciona spider para adiarios com outro layout de página

### DIFF
--- a/data_collection/gazette/spiders/base/adiarios_v2.py
+++ b/data_collection/gazette/spiders/base/adiarios_v2.py
@@ -1,0 +1,86 @@
+import re
+from datetime import datetime
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class BaseAdiariosV2Spider(BaseGazetteSpider):
+    def start_requests(self):
+        start_date = self.start_date.strftime("%d/%m/%Y")
+        end_date = self.end_date.strftime("%d/%m/%Y")
+
+        yield scrapy.Request(
+            f"{self.BASE_URL}/jornal.php?dtini={start_date}&dtfim={end_date}",
+            callback=self.parse_pagination,
+        )
+
+    def parse_pagination(self, response):
+        last_page_number = self.get_last_page_number(response)
+
+        for page_number in range(1, last_page_number):
+            yield scrapy.Request(
+                f"{response.url}&pagina={page_number}", callback=self.parse_page
+            )
+
+        yield from self.parse_page(response)
+
+    def parse_page(self, response):
+        # [1:] => first element is table header
+        elements = response.css("table tr")[1:]
+
+        for element in elements:
+            raw_date = element.css("td[data-title='Publicação']::text").get()
+            gazette_date = datetime.strptime(raw_date, "%d/%m/%Y").date()
+
+            edition_number, is_extra_edition = self.get_edition_info(element)
+
+            gazette_id = re.search(
+                r"id=(\d+)", element.css("td a").attrib["href"]
+            ).group(1)
+
+            gazette_item = {
+                "date": gazette_date,
+                "edition_number": edition_number,
+                "is_extra_edition": is_extra_edition,
+                "power": "executive",
+            }
+
+            yield scrapy.Request(
+                url=f"{self.BASE_URL}/jornal.php?id={gazette_id}",
+                callback=self.intermediary_page,
+                cb_kwargs={"gazette_item": gazette_item},
+            )
+
+    def get_last_page_number(self, response):
+        page_pagination = response.css(".pagination li a span::text").getall()
+        last_page_index = max([int(i) for i in page_pagination])
+        return last_page_index
+
+    def intermediary_page(self, response, gazette_item):
+        gazette_path = response.css("div.public_paginas > div.titulo > a").attrib[
+            "href"
+        ]
+        gazette_url = f"{self.BASE_URL}/{gazette_path}"
+
+        yield Gazette(
+            **gazette_item,
+            file_urls=[gazette_url],
+        )
+
+    def get_edition_info(self, element):
+        edition_number = element.css("td[data-title='Número']::text").get()
+
+        if edition_number is None:
+            return "", False
+
+        is_extra_edition = bool(
+            re.search(
+                r"complementar|suplement|extra|especial|anexo",
+                edition_number.lower(),
+                re.IGNORECASE,
+            )
+        )
+        return edition_number.strip(), is_extra_edition

--- a/data_collection/gazette/spiders/rj/rj_casimiro_de_abreu.py
+++ b/data_collection/gazette/spiders/rj/rj_casimiro_de_abreu.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v2 import BaseAdiariosV2Spider
+
+
+class RjCasimiroDeAbreuSpider(BaseAdiariosV2Spider):
+    name = "rj_casimiro_de_abreu"
+    TERRITORY_ID = "3301306"
+    start_date = date(2017, 1, 4)
+    allowed_domains = ["casimirodeabreu.rj.gov.br"]
+    BASE_URL = "https://transparencia.casimirodeabreu.rj.gov.br"

--- a/data_collection/gazette/spiders/rj/rj_cordeiro.py
+++ b/data_collection/gazette/spiders/rj/rj_cordeiro.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v2 import BaseAdiariosV2Spider
+
+
+class RjCordeiroSpider(BaseAdiariosV2Spider):
+    name = "rj_cordeiro"
+    TERRITORY_ID = "3301504"
+    start_date = date(2017, 10, 5)
+    allowed_domains = ["cordeiro.rj.gov.br"]
+    BASE_URL = "https://transparencia.cordeiro.rj.gov.br"


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [x] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

Adiciona a base para adiarios com um segundo layout de pagina (o primeiro foi adicionado por #885) com os dois únicos casos conhecidos até o momento




