### PR TITLE
Atualiza raspadores para Pau dos Ferros-RN e Paulínia-SP

### DIFF
--- a/data_collection/gazette/spiders/rn/rn_pau_dos_ferros_2017.py
+++ b/data_collection/gazette/spiders/rn/rn_pau_dos_ferros_2017.py
@@ -8,9 +8,10 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class RnPauDosFerrosSpider(BaseGazetteSpider):
-    name = "rn_pau_dos_ferros"
+    name = "rn_pau_dos_ferros_2017"
     allowed_domains = ["paudosferros.rn.gov.br"]
     start_date = datetime.date(2017, 1, 2)
+    end_date = datetime.date(2022, 9, 28)
     TERRITORY_ID = "2409407"
     start_urls = ["https://paudosferros.rn.gov.br/publicacoes.php?grupo=&cat=11"]
 

--- a/data_collection/gazette/spiders/rn/rn_pau_dos_ferros_2022.py
+++ b/data_collection/gazette/spiders/rn/rn_pau_dos_ferros_2022.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v1 import BaseAdiariosV1Spider
+
+
+class RnPauDosFerrosSpider(BaseAdiariosV1Spider):
+    TERRITORY_ID = "2409407"
+    name = "rn_pau_dos_ferros_2022"
+    allowed_domains = ["paudosferros.rn.gov.br"]
+    BASE_URL = "https://www.paudosferros.rn.gov.br"
+    start_date = date(2022, 9, 28)

--- a/data_collection/gazette/spiders/sp/sp_paulinia.py
+++ b/data_collection/gazette/spiders/sp/sp_paulinia.py
@@ -1,58 +1,11 @@
-import datetime
+from datetime import date
 
-import scrapy
-
-from gazette.items import Gazette
-from gazette.spiders.base import BaseGazetteSpider
+from gazette.spiders.base.instar import BaseInstarSpider
 
 
-class SpPauliniaSpider(BaseGazetteSpider):
-    name = "sp_paulinia"
+class SpPauliniaSpider(BaseInstarSpider):
     TERRITORY_ID = "3536505"
-    start_date = datetime.date(2012, 1, 4)
-    allowed_domains = ["www.paulinia.sp.gov.br"]
-    start_urls = ["http://www.paulinia.sp.gov.br/semanarios"]
-
-    def parse(self, response):
-        years = response.css("div.col-md-1")
-
-        for year in years:
-            year_to_scrape = int(year.xpath("./a/text()").get())
-
-            if not (self.start_date.year <= year_to_scrape <= self.end_date.year):
-                continue
-
-            event_target = year.xpath("./a/@href").re_first(r"(ctl00.*?)',")
-
-            yield scrapy.FormRequest.from_response(
-                response,
-                formdata={"__EVENTTARGET": event_target},
-                callback=self.parse_year,
-            )
-
-        yield from self.parse_year(response)
-
-    def parse_year(self, response):
-        editions = response.css("div.body-content div.row a[href*='AbreSemanario']")
-
-        for edition in editions:
-            title = edition.xpath("./text()")
-            gazette_date = datetime.datetime.strptime(
-                title.re_first(r"\d{2}/\d{2}/\d{4}"),
-                "%d/%m/%Y",
-            ).date()
-
-            if not (self.start_date <= gazette_date <= self.end_date):
-                continue
-
-            document_href = edition.xpath("./@href").get()
-            edition_number = title.re_first(r"- (\d+) -")
-            is_extra_edition = "extra" in title.get().lower()
-
-            yield Gazette(
-                date=gazette_date,
-                edition_number=edition_number,
-                file_urls=[response.urljoin(document_href)],
-                is_extra_edition=is_extra_edition,
-                power="executive",
-            )
+    name = "sp_paulinia"
+    allowed_domains = ["paulinia.sp.gov.br"]
+    base_url = "https://www.paulinia.sp.gov.br/portal/diario-oficial"
+    start_date = date(2012, 1, 4)


### PR DESCRIPTION
resolve item 3 de #1156

### Descrição 

Pau dos Ferros-RN é um município cujo código não revisado já existia no repositório (#1162), e que migrou para usar um sistema replicável. 

Paulínia-SP já tinha código integrado e em produção que parou de funcionar por ter migrado para um sistema replicável também. A migração nesse caso mantém o `start_date` igual, parecendo não haver perda de série histórica na transição. 

Esta PR endereça ambos casos.  

### Logs

Pau dos Ferros - RN
[rn_pau_dos_ferros_2022-intervalo.log](https://github.com/user-attachments/files/15810810/rn_pau_dos_ferros_2022-intervalo.log) | [rn_pau_dos_ferros_2022-intervalo.csv](https://github.com/user-attachments/files/15810811/rn_pau_dos_ferros_2022-intervalo.csv)
[rn_pau_dos_ferros_2022-completa.csv](https://github.com/user-attachments/files/15810809/rn_pau_dos_ferros_2022-completa.csv) | [rn_pau_dos_ferros_2022-completa.log](https://github.com/user-attachments/files/15810808/rn_pau_dos_ferros_2022-completa.log)

Paulínia - SP 
[sp_paulinia-intervalo.csv](https://github.com/user-attachments/files/15810817/sp_paulinia-intervalo.csv) | [sp_paulinia-intervalo.log](https://github.com/user-attachments/files/15810815/sp_paulinia-intervalo.log)
[sp_paulinia-completa.csv](https://github.com/user-attachments/files/15810921/sp_paulinia-completa.csv) | [sp_paulinia-completa.log](https://github.com/user-attachments/files/15810920/sp_paulinia-completa.log) 

