### PR TITLE
Atualiza import em 3 arquivos

### DIFF
--- a/data_collection/gazette/spiders/rs/rs_candelaria.py
+++ b/data_collection/gazette/spiders/rs/rs_candelaria.py
@@ -1,10 +1,10 @@
 from datetime import date
 
-from gazette.spiders.base.atende_layoutdois import BaseAtendeL2Spider
+from gazette.spiders.base.atende_v2 import BaseAtendeV2Spider
 
 
-class RsCandelariaSpider(BaseAtendeL2Spider):
+class RsCandelariaSpider(BaseAtendeV2Spider):
     TERRITORY_ID = "4304200"
     name = "rs_candelaria"
-    start_date = date(2023, 5, 7)  # Edição 1
     city_subdomain = "candelaria"
+    start_date = date(2023, 5, 7)

--- a/data_collection/gazette/spiders/rs/rs_horizontina.py
+++ b/data_collection/gazette/spiders/rs/rs_horizontina.py
@@ -1,10 +1,10 @@
 from datetime import date
 
-from gazette.spiders.base.atende_layoutdois import BaseAtendeL2Spider
+from gazette.spiders.base.atende_v2 import BaseAtendeV2Spider
 
 
-class RsHorizontinaSpider(BaseAtendeL2Spider):
+class RsHorizontinaSpider(BaseAtendeV2Spider):
     TERRITORY_ID = "4309605"
     name = "rs_horizontina"
-    start_date = date(2016, 6, 15)  # Edição 1
     city_subdomain = "horizontina"
+    start_date = date(2016, 6, 15)

--- a/data_collection/gazette/spiders/rs/rs_santa_rosa.py
+++ b/data_collection/gazette/spiders/rs/rs_santa_rosa.py
@@ -1,10 +1,10 @@
 from datetime import date
 
-from gazette.spiders.base.atende_layoutdois import BaseAtendeL2Spider
+from gazette.spiders.base.atende_v2 import BaseAtendeV2Spider
 
 
-class RsSantaRosaSpider(BaseAtendeL2Spider):
+class RsSantaRosaSpider(BaseAtendeV2Spider):
     TERRITORY_ID = "4317202"
     name = "rs_santa_rosa"
-    start_date = date(2022, 8, 23)  # Edição 1
     city_subdomain = "santarosa"
+    start_date = date(2022, 8, 23)


### PR DESCRIPTION
Para padronizar o nome das bases, nos casos em que há um segundo layout, o arquivo `atende_layoutdois.py` foi renomeado para `atende_v2.py`, assim como `adiarios_v1.py` e `adiarios_v2.py` 

A modificação foi feita em https://github.com/okfn-brasil/querido-diario/pull/1157/commits/ae8ce8e91d89a888c16cf7b21c66ddc1714fe948, porém ficou faltando refletir o ajuste em outros 3 raspadores replicados de `atende_v2`. Esta PR os corrigem. 