### PR TITLE
Atualiza formato de url para base Instar

### DIFF
--- a/data_collection/gazette/spiders/base/instar.py
+++ b/data_collection/gazette/spiders/base/instar.py
@@ -13,14 +13,8 @@ class BaseInstarSpider(BaseGazetteSpider):
         start_date = self.start_date.strftime("%d-%m-%Y")
         end_date = self.end_date.strftime("%d-%m-%Y")
 
-        start_url = "{base_url}/{page}/{start_date}/{end_date}/0/0/0".format(
-            **{
-                "base_url": self.base_url,
-                "page": page,
-                "start_date": start_date,
-                "end_date": end_date,
-            }
-        )
+        start_url = f"{self.base_url}/{page}/{start_date}/{end_date}/0/0/"
+
         yield scrapy.Request(
             start_url,
             cb_kwargs={"page": page, "start_date": start_date, "end_date": end_date},
@@ -34,15 +28,9 @@ class BaseInstarSpider(BaseGazetteSpider):
 
             for next_page in range(2, total_pages + 1):
                 next_page_url = (
-                    "{base_url}/{page}/{start_date}/{end_date}/0/0/0".format(
-                        **{
-                            "base_url": self.base_url,
-                            "page": next_page,
-                            "start_date": start_date,
-                            "end_date": end_date,
-                        }
-                    )
+                    f"{self.base_url}/{next_page}/{start_date}/{end_date}/0/0/"
                 )
+
                 yield scrapy.Request(
                     next_page_url,
                     cb_kwargs={


### PR DESCRIPTION
Alguns raspadores que usam a classe base Instar começaram a enviar muita requisição, em produção, levando horas para coletar apenas uma edição. 

Logs da Zyte com os problemas:
[log_mg_carmo_da_cachoeira_342.txt](https://github.com/user-attachments/files/15809464/log_mg_carmo_da_cachoeira_342.txt)
[log_mg_candeias_351.txt](https://github.com/user-attachments/files/15809466/log_mg_candeias_351.txt)
[log_mg_campo_belo_851.txt](https://github.com/user-attachments/files/15809467/log_mg_campo_belo_851.txt)
[log_mg_contagem_851.txt](https://github.com/user-attachments/files/15809463/log_mg_contagem_851.txt)


![unnamed](https://github.com/okfn-brasil/querido-diario/assets/44185775/8337fc1a-53b7-41ff-8aee-a36384dd84dc)

O motivo é que o padrão da URL mudou (deixou de terminar com `/0/0/0` e passou a terminar com `/0/0/` ) e por isso o filtro por data não estava mais funcionando. A PR atualiza a spider base. 

Logs após a modificação:
[mg_campo_belo-intervalo.csv](https://github.com/user-attachments/files/15809502/mg_campo_belo-intervalo.csv) | [mg_campo_belo-intervalo.log](https://github.com/user-attachments/files/15809503/mg_campo_belo-intervalo.log)
[mg_candeias-intervalo.csv](https://github.com/user-attachments/files/15809504/mg_candeias-intervalo.csv) | [mg_candeias-intervalo.log](https://github.com/user-attachments/files/15809505/mg_candeias-intervalo.log)
[mg_carmo_da_cachoeira-intervalo.csv](https://github.com/user-attachments/files/15809506/mg_carmo_da_cachoeira-intervalo.csv) | [mg_carmo_da_cachoeira-intervalo.log](https://github.com/user-attachments/files/15809507/mg_carmo_da_cachoeira-intervalo.log)
[mg_contagem-intervalo.csv](https://github.com/user-attachments/files/15809508/mg_contagem-intervalo.csv) | [mg_contagem-intervalo.log](https://github.com/user-attachments/files/15809509/mg_contagem-intervalo.log)
