### PR TITLE
Corrige filtro por data de DOEM

### DIFF
--- a/data_collection/gazette/spiders/base/doem.py
+++ b/data_collection/gazette/spiders/base/doem.py
@@ -46,7 +46,7 @@ class DoemGazetteSpider(BaseGazetteSpider):
             date = self.get_gazette_date(gazette_box)
             edition_number = self.get_edition_number(gazette_box)
 
-            if self.start_date < date < self.end_date:
+            if self.start_date <= date <= self.end_date:
                 yield Gazette(
                     date=date,
                     file_urls=[file_url],


### PR DESCRIPTION
A coleta diária não estava cumprindo seu propósito - nem sempre coletando diários - pois o filtro por data não funcionava corretamente. 

todas as coletas foram testadas com o atributo `-a start_date=2024-06-14` no mesmo dia. 

[ba_inhambupe-ultimo-dia.log](https://github.com/user-attachments/files/15844871/ba_inhambupe-ultimo-dia.log)
[ba_inhambupe-ultimo-dia.csv](https://github.com/user-attachments/files/15844872/ba_inhambupe-ultimo-dia.csv)

[ba_ipiau-ultimo-dia.log](https://github.com/user-attachments/files/15844873/ba_ipiau-ultimo-dia.log)
[ba_ipiau-ultimo-dia.csv](https://github.com/user-attachments/files/15844874/ba_ipiau-ultimo-dia.csv)

[ba_laje-ultimo-dia.log](https://github.com/user-attachments/files/15844875/ba_laje-ultimo-dia.log)
[ba_laje-ultimo-dia.csv](https://github.com/user-attachments/files/15844876/ba_laje-ultimo-dia.csv)

[ba_itapetinga-ultimo-dia.log](https://github.com/user-attachments/files/15844869/ba_itapetinga-ultimo-dia.log)
[ba_itapetinga-ultimo-dia.csv](https://github.com/user-attachments/files/15844870/ba_itapetinga-ultimo-dia.csv)