### PR TITLE
Atualiza raspador para Sumaré-SP

### DIFF
--- a/data_collection/gazette/spiders/sp/sp_sumare.py
+++ b/data_collection/gazette/spiders/sp/sp_sumare.py
@@ -16,16 +16,16 @@ class SpSumareSpider(BaseGazetteSpider):
         gazettes = response.css("li.umDO")
 
         for gazette in gazettes:
-            title = gazette.css("a::attr(title)").get()
+            title = gazette.css(".file-title::text").get()
             url = gazette.css("a::attr(href)").get()
-            str_date = gazette.css(".areaData::text").get()
+            str_date = gazette.css(".areaMetade::text").get()
             date = datetime.strptime(str_date, "%d/%m/%Y").date()
 
             if not (self.start_date <= date <= self.end_date):
                 continue
 
             yield Gazette(
-                edition_number=re.search(r"\d+", title).group(0),
+                edition_number=re.search(r"\d+", title.strip()).group(0),
                 date=date,
                 file_urls=[response.urljoin(url)],
                 is_extra_edition="extra" in title.lower(),


### PR DESCRIPTION
O site de Sumaré-SP aparentemente mudou, fazendo o raspador dar o seguinte erro em produção: 
![image](https://github.com/okfn-brasil/querido-diario/assets/44185775/f536d117-9fb2-4330-bf83-90d4f4d5cfc8)

Esta PR atualiza o raspador. 

## Logs: 
[sp_sumare_periodo.log](https://github.com/user-attachments/files/15844901/sp_sumare_periodo.log)
[sp_sumare_periodo.csv](https://github.com/user-attachments/files/15844902/sp_sumare_periodo.csv)

[sp_sumare.log](https://github.com/user-attachments/files/15845031/sp_sumare.log)
[sp_sumare.csv](https://github.com/user-attachments/files/15845030/sp_sumare.csv)