### PR TITLE
Atualiza Santa Luzia-BA e Dirce Reis-SP

### DIFF
--- a/data_collection/gazette/spiders/ba/ba_santa_luzia_2021.py
+++ b/data_collection/gazette/spiders/ba/ba_santa_luzia_2021.py
@@ -5,6 +5,7 @@ from gazette.spiders.base.doem import DoemGazetteSpider
 
 class BaSantaLuziaSpider(DoemGazetteSpider):
     TERRITORY_ID = "2928059"
-    name = "ba_santa_luzia"
-    start_date = date(2021, 1, 4)
+    name = "ba_santa_luzia_2021"
     state_city_url_part = "ba/santaluzia"
+    start_date = date(2021, 1, 4)
+    end_date = date(2024, 1, 29)

--- a/data_collection/gazette/spiders/ba/ba_santa_luzia_2024.py
+++ b/data_collection/gazette/spiders/ba/ba_santa_luzia_2024.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.sai import SaiGazetteSpider
+
+
+class BaSantaLuziaSpider(SaiGazetteSpider):
+    TERRITORY_ID = "2928059"
+    name = "ba_santa_luzia_2024"
+    allowed_domains = ["santaluzia.ba.gov.br"]
+    base_url = "https://www.santaluzia.ba.gov.br"
+    start_date = date(2024, 1, 5)

--- a/data_collection/gazette/spiders/sp/sp_dirce_reis.py
+++ b/data_collection/gazette/spiders/sp/sp_dirce_reis.py
@@ -1,11 +1,10 @@
 from datetime import date
 
-from gazette.spiders.base.instar import BaseInstarSpider
+from gazette.spiders.base.dosp import DospGazetteSpider
 
 
-class SpDirceReisSpider(BaseInstarSpider):
+class SpDirceReisSpider(DospGazetteSpider):
     TERRITORY_ID = "3513850"
     name = "sp_dirce_reis"
-    allowed_domains = ["dircereis.sp.gov.br"]
-    base_url = "https://www.dircereis.sp.gov.br/portal/diario-oficial"
-    start_date = date(2019, 10, 7)
+    code = 4803
+    start_date = date(2019, 4, 4)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [x] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [ ] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

- Santa Luzia-BA 
Dando erro em produção desde 2024-01-29, pois o município mudou de DOEM para SAI.

[ba_santa_luzia_2024-ultimo-dia.log](https://github.com/user-attachments/files/15904920/ba_santa_luzia_2024-ultimo-dia.log) | [ba_santa_luzia_2024-ultimo-dia.csv](https://github.com/user-attachments/files/15904921/ba_santa_luzia_2024-ultimo-dia.csv)
[ba_santa_luzia_2024-intervalo.log](https://github.com/user-attachments/files/15904950/ba_santa_luzia_2024-intervalo.log) | [ba_santa_luzia_2024-intervalo.csv](https://github.com/user-attachments/files/15904951/ba_santa_luzia_2024-intervalo.csv)
[ba_santa_luzia_2024-completa.log](https://github.com/user-attachments/files/15904916/ba_santa_luzia_2024-completa.log) | [ba_santa_luzia_2024-completa.csv](https://github.com/user-attachments/files/15904917/ba_santa_luzia_2024-completa.csv)

O raspador apresenta apenas os erros conhecidos de SAI (#1175), de resto está tudo certo.

- Dirce Reis-SP
Dando erro em produção desde 2024-05-09, pois o município mudou de INSTAR para DOSP

[sp_dirce_reis-ultimo-dia.log](https://github.com/user-attachments/files/15904995/sp_dirce_reis-ultimo-dia.log) | [sp_dirce_reis-ultimo-dia.csv](https://github.com/user-attachments/files/15904996/sp_dirce_reis-ultimo-dia.csv)
[sp_dirce_reis-intervalo.log](https://github.com/user-attachments/files/15904993/sp_dirce_reis-intervalo.log) | [sp_dirce_reis-intervalo.csv](https://github.com/user-attachments/files/15904994/sp_dirce_reis-intervalo.csv)
[sp_dirce_reis-completa.log](https://github.com/user-attachments/files/15904990/sp_dirce_reis-completa.log) | [sp_dirce_reis-completa.csv](https://github.com/user-attachments/files/15904991/sp_dirce_reis-completa.csv)

Tudo ok com Dirce Reis.
