### PR TITLE
Add new spider BarcoDigital

### DIFF
--- a/data_collection/gazette/spiders/base/barcodigital.py
+++ b/data_collection/gazette/spiders/base/barcodigital.py
@@ -30,8 +30,15 @@ class BarcoDigitalSpider(BaseGazetteSpider):
     def parse(self, response):
         for documents in response.json().values():
             for document in documents:
+                document_date = datetime.strptime(
+                    document.get("data"), "%Y-%m-%d"
+                ).date()
+
+                if document_date > self.end_date:
+                    continue
+
                 yield Gazette(
-                    date=datetime.strptime(document.get("data"), "%Y-%m-%d").date(),
+                    date=document_date,
                     edition_number=document.get("edicao"),
                     is_extra_edition=document.get("tipo_edicao_id")
                     != self.EDITION_TYPE_NORMAL,

--- a/data_collection/gazette/spiders/base/barcodigital.py
+++ b/data_collection/gazette/spiders/base/barcodigital.py
@@ -1,0 +1,40 @@
+from datetime import date, datetime
+
+from dateutil.rrule import MONTHLY, rrule
+from scrapy import Request
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class BarcoDigitalSpider(BaseGazetteSpider):
+    EDITION_TYPE_NORMAL = 1
+    EDITION_TYPE_EXTRA = 2
+    EDITION_TYPE_SUPPLEMENT = 3
+
+    def start_requests(self):
+        initial_date = date(self.start_date.year, self.start_date.month, 1)
+        end_date = self.end_date
+
+        periods_of_interest = [
+            (date.year, date.month)
+            for date in rrule(freq=MONTHLY, dtstart=initial_date, until=end_date)
+        ]
+
+        for year, month in periods_of_interest:
+            url = (
+                f"{self.base_url}/api/publico/diario/calendario?mes={month}&ano={year}"
+            )
+            yield Request(url)
+
+    def parse(self, response):
+        for documents in response.json().values():
+            for document in documents:
+                yield Gazette(
+                    date=datetime.strptime(document.get("data"), "%Y-%m-%d").date(),
+                    edition_number=document.get("edicao"),
+                    is_extra_edition=document.get("tipo_edicao_id")
+                    != self.EDITION_TYPE_NORMAL,
+                    file_urls=[f"{self.base_url}/arquivo/{document.get('url')}"],
+                    power="executive",
+                )

--- a/data_collection/gazette/spiders/base/barcodigital.py
+++ b/data_collection/gazette/spiders/base/barcodigital.py
@@ -36,6 +36,8 @@ class BarcoDigitalSpider(BaseGazetteSpider):
 
                 if document_date > self.end_date:
                     continue
+                elif document_date < self.start_date:
+                    return
 
                 yield Gazette(
                     date=document_date,

--- a/data_collection/gazette/spiders/to/to_lagoa_de_tocantins.py
+++ b/data_collection/gazette/spiders/to/to_lagoa_de_tocantins.py
@@ -1,0 +1,12 @@
+from datetime import date
+
+from gazette.spiders.base.barcodigital import BarcoDigitalSpider
+
+
+class ToLagoaDeTocatinsSpider(BarcoDigitalSpider):
+    name = "to_lagoa_de_tocantins"
+    TERRITORY_ID = "1711951"
+    allowed_domains = ["api-lagoadotocantins.barcodigital.com.br"]
+    base_url = "https://api-lagoadotocantins.barcodigital.com.br"
+
+    start_date = date(year=2018, month=5, day=1)

--- a/data_collection/gazette/spiders/to/to_recursolandia.py
+++ b/data_collection/gazette/spiders/to/to_recursolandia.py
@@ -1,0 +1,12 @@
+from datetime import date
+
+from gazette.spiders.base.barcodigital import BarcoDigitalSpider
+
+
+class ToRecursolandiaSpider(BarcoDigitalSpider):
+    name = "to_recursolandia"
+    TERRITORY_ID = "1718501"
+    allowed_domains = ["api-recursolandia.barcodigital.com.br"]
+    base_url = "https://api-recursolandia.barcodigital.com.br"
+
+    start_date = date(year=2019, month=11, day=11)


### PR DESCRIPTION
PR feito em colaboração com @adellylima, @r-lelis, @heitorado, @cjasm, @cacoze, @yamawakimiho 

**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [X] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição
- Issue
   - BaseSpider: https://github.com/okfn-brasil/querido-diario/issues/1016


- Cria **BarcoDigital** base spider
- Adiciona Spider da Cidade **Lagoa do Tocatins - TO** 
- Adiciona Spider da Cidade **Recursolândia - TO** 


**Erro na carga completa da cidade Recursolândia**
A Edição 40 do diário oficial não encontra-se disponível no site. Ela foi publicada em 08-06-2020.
**Nome do arquivo:** Edicao-n-040-de-08-06-2020.pdf 
**Link do aquivo pdf:** https://api-recursolandia.barcodigital.com.br/arquivo/recursolandia.to.gov.br/Diarios/040/Edicao-n-040-de-08-06-2020.pdf 
**Imagem do site:** ![image](https://github.com/okfn-brasil/querido-diario/assets/42525687/c2f5f21f-748e-4a81-97db-748bd2800fe2)


### Arquivos

| **Lagoa do Tocatins**       | File Link                                                                                                                     |
|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------|
| Ultimo diário publicado     | [to_lagoa_de_tocantins_last_edition-2024-07-01.csv](https://github.com/user-attachments/files/16087341/to_lagoa_de_tocantins_last_edition-2024-07-01.csv) |
|                             | [to_lagoa_de_tocantins_last_edition-2024-07-01.log](https://github.com/user-attachments/files/16087342/to_lagoa_de_tocantins_last_edition-2024-07-01.log) |
| Completo                    | [to_lagoa_de_tocantins_full.csv](https://github.com/user-attachments/files/16087336/to_lagoa_de_tocantins_full.csv) |
|                             | [to_lagoa_de_tocantins_full.log](https://github.com/user-attachments/files/16087338/to_lagoa_de_tocantins_full.log) |
| Intervalo                   |[to_lagoa_de_tocantins-2024-06-01_to_2024-07-01.csv](https://github.com/user-attachments/files/16088823/to_lagoa_de_tocantins-2024-06-01_to_2024-07-01.csv) |
|                             | [to_lagoa_de_tocantins-2024-06-01_to_2024-07-01.log](https://github.com/user-attachments/files/16088824/to_lagoa_de_tocantins-2024-06-01_to_2024-07-01.log) |










| **Recursolândia**           | File Link                                                                                                                     |
|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------|
| Ultimo diário publicado     | [to_recursolandia_last_edition-2024-07-01.csv](https://github.com/user-attachments/files/16087659/to_recursolandia_last_edition-2024-07-01.csv) |
|                             | [to_recursolandia_last_edition-2024-07-02.log](https://github.com/user-attachments/files/16087660/to_recursolandia_last_edition-2024-07-02.log) |
| Completo                    | [to_recursolandia_full.csv](https://github.com/user-attachments/files/16087654/to_recursolandia_full.csv) |
|                             | [to_recursolandia_full.log](https://github.com/user-attachments/files/16087656/to_recursolandia_full.log) |
| Intervalo                   | [to_recursolandia_interval_-2024-06-01_to_2024-07-01.csv](https://github.com/user-attachments/files/16088854/to_recursolandia_interval_-2024-06-01_to_2024-07-01.csv)|
|                             | [to_recursolandia_interval_-2024-06-01_to_2024-07-01.log](https://github.com/user-attachments/files/16088855/to_recursolandia_interval_-2024-06-01_to_2024-07-01.log) |









