### PR TITLE
Adiciona novos 10 raspadores da Paraíba

### DIFF
--- a/data_collection/gazette/spiders/pb/pb_jacarau.py
+++ b/data_collection/gazette/spiders/pb/pb_jacarau.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v1 import BaseAdiariosV1Spider
+
+
+class PbJacarauSpider(BaseAdiariosV1Spider):
+    TERRITORY_ID = "2507309"
+    name = "pb_jacarau"
+    allowed_domains = ["jacarau.pb.gov.br"]
+    BASE_URL = "https://www.jacarau.pb.gov.br"
+    start_date = date(2019, 3, 7)

--- a/data_collection/gazette/spiders/pb/pb_jerico.py
+++ b/data_collection/gazette/spiders/pb/pb_jerico.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v1 import BaseAdiariosV1Spider
+
+
+class PbJericoSpider(BaseAdiariosV1Spider):
+    TERRITORY_ID = "2507408"
+    name = "pb_jerico"
+    allowed_domains = ["jerico.pb.gov.br"]
+    BASE_URL = "https://www.jerico.pb.gov.br"
+    start_date = date(2021, 6, 1)

--- a/data_collection/gazette/spiders/pb/pb_marizopolis.py
+++ b/data_collection/gazette/spiders/pb/pb_marizopolis.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v1 import BaseAdiariosV1Spider
+
+
+class PbMarizopolisSpider(BaseAdiariosV1Spider):
+    TERRITORY_ID = "2509156"
+    name = "pb_marizopolis"
+    allowed_domains = ["marizopolis.pb.gov.br"]
+    BASE_URL = "https://www.marizopolis.pb.gov.br"
+    start_date = date(2021, 1, 27)

--- a/data_collection/gazette/spiders/pb/pb_piloezinhos.py
+++ b/data_collection/gazette/spiders/pb/pb_piloezinhos.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v1 import BaseAdiariosV1Spider
+
+
+class PbPiloezinhosSpider(BaseAdiariosV1Spider):
+    TERRITORY_ID = "2511707"
+    name = "pb_piloezinhos"
+    allowed_domains = ["piloezinhos.pb.gov.br"]
+    BASE_URL = "https://www.piloezinhos.pb.gov.br"
+    start_date = date(2022, 6, 1)

--- a/data_collection/gazette/spiders/pb/pb_riachao.py
+++ b/data_collection/gazette/spiders/pb/pb_riachao.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v1 import BaseAdiariosV1Spider
+
+
+class PbRiachaoSpider(BaseAdiariosV1Spider):
+    TERRITORY_ID = "2512747"
+    name = "pb_riachao"
+    allowed_domains = ["riachao.pb.gov.br"]
+    BASE_URL = "https://www.riachao.pb.gov.br"
+    start_date = date(2024, 2, 29)

--- a/data_collection/gazette/spiders/pb/pb_sao_jose_dos_ramos.py
+++ b/data_collection/gazette/spiders/pb/pb_sao_jose_dos_ramos.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v1 import BaseAdiariosV1Spider
+
+
+class PbSaoJoseDosRamosSpider(BaseAdiariosV1Spider):
+    TERRITORY_ID = "2514453"
+    name = "pb_sao_jose_dos_ramos"
+    allowed_domains = ["saojosedosramos.pb.gov.br"]
+    BASE_URL = "https://www.saojosedosramos.pb.gov.br"
+    start_date = date(2021, 1, 4)

--- a/data_collection/gazette/spiders/pb/pb_serraria.py
+++ b/data_collection/gazette/spiders/pb/pb_serraria.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v1 import BaseAdiariosV1Spider
+
+
+class PbSerrariaSpider(BaseAdiariosV1Spider):
+    TERRITORY_ID = "2515906"
+    name = "pb_serraria"
+    allowed_domains = ["serraria.pb.gov.br"]
+    BASE_URL = "https://www.serraria.pb.gov.br"
+    start_date = date(2024, 3, 1)

--- a/data_collection/gazette/spiders/pb/pb_sertaozinho.py
+++ b/data_collection/gazette/spiders/pb/pb_sertaozinho.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v1 import BaseAdiariosV1Spider
+
+
+class PbSertaozinhoSpider(BaseAdiariosV1Spider):
+    TERRITORY_ID = "2515930"
+    name = "pb_sertaozinho"
+    allowed_domains = ["sertaozinho.pb.gov.br"]
+    BASE_URL = "https://www.sertaozinho.pb.gov.br"
+    start_date = date(2024, 2, 1)

--- a/data_collection/gazette/spiders/pb/pb_tacima.py
+++ b/data_collection/gazette/spiders/pb/pb_tacima.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v1 import BaseAdiariosV1Spider
+
+
+class PbTacimaSpider(BaseAdiariosV1Spider):
+    TERRITORY_ID = "2516409"
+    name = "pb_tacima"
+    allowed_domains = ["pmtacima.pb.gov.br"]
+    BASE_URL = "https://www.pmtacima.pb.gov.br"
+    start_date = date(2024, 1, 26)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [x] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [ ] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [ ] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [ ] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Descrição
Adiciona 10 raspadores da lista de #1082 

Testes e verificações serão realizadas por @rochamatcomp 


