### PR TITLE
Ajustar regex de coleta de metadado #1187

### DIFF
--- a/data_collection/gazette/spiders/base/adiarios_v1.py
+++ b/data_collection/gazette/spiders/base/adiarios_v1.py
@@ -38,12 +38,19 @@ class BaseAdiariosV1Spider(BaseGazetteSpider):
             date = datetime.strptime(date, "%d/%m/%Y").date()
 
             text = element.css("span strong::text").get()
-            edition_number = re.search(r":\s*(\d+).*/", text).group(1)
+
+            try:
+                edition_number = re.search(r":\s*(\d+).*/", text).group(1)
+            except AttributeError:
+                edition_number = ""
 
             title = element.css("span::text").getall()[1]
             is_extra_edition = bool(
                 re.search(
                     r"complementar|suplementar|extra|especial", title, re.IGNORECASE
+                )
+                or re.search(
+                    r"complementar|suplementar|extra|especial", text, re.IGNORECASE
                 )
             )
             power = self.get_power(title)


### PR DESCRIPTION
#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição
Resolve a issue #1187. Atualizar o código de [adiarios_v1.py](https://github.com/okfn-brasil/querido-diario/blob/main/data_collection/gazette/spiders/base/adiarios_v1.py) para que o fluxo de coleta dos metadados.

Classe base Adiarios V1:
- `edition_number` com valor padrão como string vazia;
- `is_extra_edition` verificada no título e também no texto.

#### Coletas
Foram feitas as coletas para os municípios com problemas encontrados na Validação #1185:
- pb_jacarau
- pb_marizopolis
- pb_piloezinhos
- pb_sertaozinho

> :white_check_mark: Depois da correção esses municípios passaram sem error.

##### Coleta última edição
[coleta_ultima_edicao_pb_sertaozinho.csv](https://github.com/user-attachments/files/16194261/coleta_ultima_edicao_pb_sertaozinho.csv)
[coleta_ultima_edicao_pb_sertaozinho.log](https://github.com/user-attachments/files/16194264/coleta_ultima_edicao_pb_sertaozinho.log)
[coleta_ultima_edicao_pb_piloezinhos.csv](https://github.com/user-attachments/files/16194265/coleta_ultima_edicao_pb_piloezinhos.csv)
[coleta_ultima_edicao_pb_piloezinhos.log](https://github.com/user-attachments/files/16194266/coleta_ultima_edicao_pb_piloezinhos.log)
[coleta_ultima_edicao_pb_marizopolis.csv](https://github.com/user-attachments/files/16194267/coleta_ultima_edicao_pb_marizopolis.csv)
[coleta_ultima_edicao_pb_marizopolis.log](https://github.com/user-attachments/files/16194268/coleta_ultima_edicao_pb_marizopolis.log)
[coleta_ultima_edicao_pb_jacarau.log](https://github.com/user-attachments/files/16194270/coleta_ultima_edicao_pb_jacarau.log)
[coleta_ultima_edicao_pb_jacarau.csv](https://github.com/user-attachments/files/16194271/coleta_ultima_edicao_pb_jacarau.csv)

##### Coleta intervalo
[coleta_intervalo_pb_sertaozinho.csv](https://github.com/user-attachments/files/16194291/coleta_intervalo_pb_sertaozinho.csv)
[coleta_intervalo_pb_sertaozinho.log](https://github.com/user-attachments/files/16194292/coleta_intervalo_pb_sertaozinho.log)
[coleta_intervalo_pb_piloezinhos.csv](https://github.com/user-attachments/files/16194293/coleta_intervalo_pb_piloezinhos.csv)
[coleta_intervalo_pb_piloezinhos.log](https://github.com/user-attachments/files/16194294/coleta_intervalo_pb_piloezinhos.log)
[coleta_intervalo_pb_marizopolis.csv](https://github.com/user-attachments/files/16194295/coleta_intervalo_pb_marizopolis.csv)
[coleta_intervalo_pb_marizopolis.log](https://github.com/user-attachments/files/16194296/coleta_intervalo_pb_marizopolis.log)
[coleta_intervalo_pb_jacarau.csv](https://github.com/user-attachments/files/16194297/coleta_intervalo_pb_jacarau.csv)
[coleta_intervalo_pb_jacarau.log](https://github.com/user-attachments/files/16194298/coleta_intervalo_pb_jacarau.log)

##### Coleta completa
[coleta_completa_pb_sertaozinho.csv](https://github.com/user-attachments/files/16194564/coleta_completa_pb_sertaozinho.csv)
[coleta_completa_pb_sertaozinho.log](https://github.com/user-attachments/files/16194565/coleta_completa_pb_sertaozinho.log)
[coleta_completa_pb_piloezinhos.csv](https://github.com/user-attachments/files/16194566/coleta_completa_pb_piloezinhos.csv)
[coleta_completa_pb_piloezinhos.log](https://github.com/user-attachments/files/16194567/coleta_completa_pb_piloezinhos.log)
[coleta_completa_pb_marizopolis.csv](https://github.com/user-attachments/files/16194568/coleta_completa_pb_marizopolis.csv)
[coleta_completa_pb_marizopolis.log](https://github.com/user-attachments/files/16194569/coleta_completa_pb_marizopolis.log)
[coleta_completa_pb_jacarau.csv](https://github.com/user-attachments/files/16194570/coleta_completa_pb_jacarau.csv)
[coleta_completa_pb_jacarau.log](https://github.com/user-attachments/files/16194571/coleta_completa_pb_jacarau.log)
