### PR TITLE
Adiciona 4 novos municípios do Rio de Janeiro

### DIFF
--- a/data_collection/gazette/spiders/base/adiarios_v2.py
+++ b/data_collection/gazette/spiders/base/adiarios_v2.py
@@ -8,6 +8,11 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class BaseAdiariosV2Spider(BaseGazetteSpider):
+    """
+    This base class deals with 'Layout 2' gazette pages, usually requested
+    from https://{city_website}/jornal.php
+    """
+
     def start_requests(self):
         start_date = self.start_date.strftime("%d/%m/%Y")
         end_date = self.end_date.strftime("%d/%m/%Y")

--- a/data_collection/gazette/spiders/rj/rj_armacao_dos_buzios.py
+++ b/data_collection/gazette/spiders/rj/rj_armacao_dos_buzios.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v2 import BaseAdiariosV2Spider
+
+
+class RjArmacaoDosBuziosSpider(BaseAdiariosV2Spider):
+    TERRITORY_ID = "3300233"
+    name = "rj_armacao_dos_buzios"
+    allowed_domains = ["buzios.aexecutivo.com.br"]
+    BASE_URL = "https://buzios.aexecutivo.com.br"
+    start_date = date(2015, 9, 3)

--- a/data_collection/gazette/spiders/rj/rj_iguaba_grande.py
+++ b/data_collection/gazette/spiders/rj/rj_iguaba_grande.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v2 import BaseAdiariosV2Spider
+
+
+class RjIguabaGrandeSpider(BaseAdiariosV2Spider):
+    TERRITORY_ID = "3301876"
+    name = "rj_iguaba_grande"
+    allowed_domains = ["iguaba.rj.gov.br"]
+    BASE_URL = "https://portal.iguaba.rj.gov.br"
+    start_date = date(2013, 1, 1)

--- a/data_collection/gazette/spiders/rj/rj_quissama.py
+++ b/data_collection/gazette/spiders/rj/rj_quissama.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.adiarios_v2 import BaseAdiariosV2Spider
+
+
+class RjQuissamaSpider(BaseAdiariosV2Spider):
+    TERRITORY_ID = "3304151"
+    name = "rj_quissama"
+    allowed_domains = ["quissama.rj.gov.br"]
+    BASE_URL = "https://portal.quissama.rj.gov.br"
+    start_date = date(2017, 1, 31)

--- a/data_collection/gazette/spiders/rj/rj_sao_jose_do_vale_do_rio_preto.py
+++ b/data_collection/gazette/spiders/rj/rj_sao_jose_do_vale_do_rio_preto.py
@@ -1,0 +1,10 @@
+from datetime import date
+
+from gazette.spiders.base.dosp import DospGazetteSpider
+
+
+class RjSaoJoseDoValeDoRioPretoSpider(DospGazetteSpider):
+    TERRITORY_ID = "3305158"
+    name = "rj_sao_jose_do_vale_do_rio_preto"
+    code = 3640
+    start_date = date(2023, 5, 24)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [x] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

Adiciona 3 novos municípios de adiarios (#1082) e 1 de dosp (#1087)  

###  Logs 
- São José do Vale do Rio - RJ
[ultima-edicao_rj_sao_jose_do_vale_do_rio.csv](https://github.com/user-attachments/files/16446216/ultima-edicao_rj_sao_jose_do_vale_do_rio.csv) | [ultima-edicao_rj_sao_jose_do_vale_do_rio.log](https://github.com/user-attachments/files/16446214/ultima-edicao_rj_sao_jose_do_vale_do_rio.log)
[intervalo_rj_sao_jose_do_vale_do_rio.csv](https://github.com/user-attachments/files/16446249/intervalo_rj_sao_jose_do_vale_do_rio.csv) | [intervalo_rj_sao_jose_do_vale_do_rio.log](https://github.com/user-attachments/files/16446248/intervalo_rj_sao_jose_do_vale_do_rio.log)
[completa_rj_sao_jose_do_vale_do_rio.log](https://github.com/user-attachments/files/16446407/completa_rj_sao_jose_do_vale_do_rio.log) | [completa_rj_sao_jose_do_vale_do_rio.csv](https://github.com/user-attachments/files/16446408/completa_rj_sao_jose_do_vale_do_rio.csv)

- Armação dos Búzios - RJ 
[ultima-edicao_rj_armacao_dos_buzios.csv](https://github.com/user-attachments/files/16446220/ultima-edicao_rj_armacao_dos_buzios.csv) | [ultima-edicao_rj_armacao_dos_buzios.log](https://github.com/user-attachments/files/16446219/ultima-edicao_rj_armacao_dos_buzios.log)
[intervalo_rj_armacao_dos_buzios.log](https://github.com/user-attachments/files/16446250/intervalo_rj_armacao_dos_buzios.log) | [intervalo_rj_armacao_dos_buzios.csv](https://github.com/user-attachments/files/16446251/intervalo_rj_armacao_dos_buzios.csv)
[completa_rj_armacao_dos_buzios.log](https://github.com/user-attachments/files/16446267/completa_rj_armacao_dos_buzios.log) | [completa_rj_armacao_dos_buzios.csv](https://github.com/user-attachments/files/16446269/completa_rj_armacao_dos_buzios.csv)

- Quissamã - RJ
[ultima-edicao_rj_quissama.log](https://github.com/user-attachments/files/16446217/ultima-edicao_rj_quissama.log) | [ultima-edicao_rj_quissama.csv](https://github.com/user-attachments/files/16446218/ultima-edicao_rj_quissama.csv)
[intervalo_rj_quissama.log](https://github.com/user-attachments/files/16446253/intervalo_rj_quissama.log) | [intervalo_rj_quissama.csv](https://github.com/user-attachments/files/16446254/intervalo_rj_quissama.csv)
[completa_rj_quissama.log](https://github.com/user-attachments/files/16446409/completa_rj_quissama.log) | [completa_rj_quissama.csv](https://github.com/user-attachments/files/16446410/completa_rj_quissama.csv)

- Iguaba Grande - RJ
[ultima-edicao_rj_iguaba_grande.csv](https://github.com/user-attachments/files/16446228/ultima-edicao_rj_iguaba_grande.csv) | [ultima-edicao_rj_iguaba_grande.log](https://github.com/user-attachments/files/16446227/ultima-edicao_rj_iguaba_grande.log)
[intervalo_rj_iguaba_grande.log](https://github.com/user-attachments/files/16446255/intervalo_rj_iguaba_grande.log) | [intervalo_rj_iguaba_grande.csv](https://github.com/user-attachments/files/16446256/intervalo_rj_iguaba_grande.csv)
[completa_rj_iguaba_grande.log](https://github.com/user-attachments/files/16446273/completa_rj_iguaba_grande.log) | [completa_rj_iguaba_grande.csv](https://github.com/user-attachments/files/16446275/completa_rj_iguaba_grande.csv)


