### PR TITLE
Adiciona novo spider para Caxias-MA e atualiza o anterior

### DIFF
--- a/data_collection/gazette/spiders/base/aplus.py
+++ b/data_collection/gazette/spiders/base/aplus.py
@@ -25,7 +25,8 @@ class BaseAplusSpider(BaseGazetteSpider):
                 gazette.xpath("./td[2]/text()").get(), "%d/%m/%Y"
             ).date()
             gazette_url = gazette.css("td a::attr(href)").get()
-            edition_number = gazette.xpath("./td[1]/text()").get()
+            edition_number = self._get_edition_number(gazette)
+
             is_extra_edition = re.search(r"-\d+$", edition_number) is not None
 
             yield Gazette(
@@ -35,3 +36,12 @@ class BaseAplusSpider(BaseGazetteSpider):
                 is_extra_edition=is_extra_edition,
                 power="executive",
             )
+
+    def _get_edition_number(self, gazette):
+        raw = gazette.xpath("./td[1]/text()").get()
+        edition_number_match = re.search(r"(\d+)/", raw)
+
+        if edition_number_match is None:
+            return ""
+        else:
+            return edition_number_match.group(1)

--- a/data_collection/gazette/spiders/ma/ma_caxias_2017.py
+++ b/data_collection/gazette/spiders/ma/ma_caxias_2017.py
@@ -15,9 +15,10 @@ class MaCaxiasSpider(BaseGazetteSpider):
     Por exemplo, no dia 25/05/2017 os dois documentos publicados têm checksum igual.
     """
 
-    name = "ma_caxias"
+    name = "ma_caxias_2017"
     allowed_domains = ["caxias.ma.gov.br"]
     start_date = date(2017, 3, 6)
+    end_date = date(2024, 6, 21)
     TERRITORY_ID = "2103000"
     BASE_URL = "https://caxias.ma.gov.br/diario-oficial-do-municipio"
     DATE_FORMAT = "%d/%m/%Y"

--- a/data_collection/gazette/spiders/ma/ma_caxias_2021.py
+++ b/data_collection/gazette/spiders/ma/ma_caxias_2021.py
@@ -1,0 +1,11 @@
+import datetime as dt
+
+from gazette.spiders.base.aplus import BaseAplusSpider
+
+
+class MaCaxiasSpider(BaseAplusSpider):
+    TERRITORY_ID = "2103000"
+    name = "ma_caxias_2021"
+    start_date = dt.date(2021, 8, 6)
+    allowed_domains = ["caxias.ma.gov.br"]
+    url_base = "https://dom.caxias.ma.gov.br/diario/"


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [x] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

Caxias-MA estava quebrando em produção desde Junho/2024. O município migrou a publicação para outro caminho, usando o padrão aplus já integrado ao projeto. Esta PR adiciona o novo spider e atualiza o anterior.

[completa_ma_caxias_2021.csv](https://github.com/user-attachments/files/16475448/completa_ma_caxias_2021.csv) | [completa_ma_caxias_2021.log](https://github.com/user-attachments/files/16475447/completa_ma_caxias_2021.log)
[intervalo_ma_caxias_2021.log](https://github.com/user-attachments/files/16475449/intervalo_ma_caxias_2021.log) | [intervalo_ma_caxias_2021.csv](https://github.com/user-attachments/files/16475450/intervalo_ma_caxias_2021.csv)
[ultima-edicao_ma_caxias_2021.log](https://github.com/user-attachments/files/16475451/ultima-edicao_ma_caxias_2021.log) | [ultima-edicao_ma_caxias_2021.csv](https://github.com/user-attachments/files/16475452/ultima-edicao_ma_caxias_2021.csv)

A PR também adiciona uma melhoria para a coleta de `edition_number` para o padrão aplus. Visto que essa modificação reflete em todos os raspadores do padrão em produção, eles também foram verificados.
[intervalo_ma_santo_antonio_dos_lopes.log](https://github.com/user-attachments/files/16475485/intervalo_ma_santo_antonio_dos_lopes.log) | [intervalo_ma_santo_antonio_dos_lopes.csv](https://github.com/user-attachments/files/16475486/intervalo_ma_santo_antonio_dos_lopes.csv)
[intervalo_ma_codo.log](https://github.com/user-attachments/files/16475487/intervalo_ma_codo.log) | [intervalo_ma_codo.csv](https://github.com/user-attachments/files/16475488/intervalo_ma_codo.csv)
[intervalo_ma_bacabal.log](https://github.com/user-attachments/files/16475489/intervalo_ma_bacabal.log) | [intervalo_ma_bacabal.csv](https://github.com/user-attachments/files/16475490/intervalo_ma_bacabal.csv)



