### PR TITLE
Atualiza ba_barreiras para voltar a coletar diários

### DIFF
--- a/data_collection/gazette/spiders/ba/ba_barreiras.py
+++ b/data_collection/gazette/spiders/ba/ba_barreiras.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import re
+from urllib.parse import urlparse, urlunparse
 
 import scrapy
 from dateutil.rrule import YEARLY, rrule
@@ -53,8 +54,13 @@ class BaBarreirasSpider(BaseGazetteSpider):
 
             yield Gazette(
                 power="executive",
-                file_urls=[link],
+                file_urls=[self._url_fix(link)],
                 date=gazette_date,
                 edition_number=edition_number,
                 is_extra_edition=is_extra_edition,
             )
+
+    def _url_fix(self, link):
+        link = urlparse(link)
+        link = link._replace(scheme="https")
+        return urlunparse(link)


### PR DESCRIPTION
O raspador para Barreiras-BA estava sem coletar diários desde 2024-07-04. O motivo foi que as URLs pros diários passaram a ser cadastradas no site no formato `<a href="//www.barreiras.ba.gov.br/diario/pdf/2024/diario4217.pdf" ... ` começando com `//` e sem o `http`/`https`. Esta PR adiciona um ajuste para tratar a string da URL.

Foi verificada uma coleta de intervalo (2024-06-01 to 2024-08-02) que contém o intervalo ausente, mas agora obtendo os diários.

[intervalo_ba_barreiras.log](https://github.com/user-attachments/files/16475916/intervalo_ba_barreiras.log)
[intervalo_ba_barreiras.csv](https://github.com/user-attachments/files/16475917/intervalo_ba_barreiras.csv)
