### PR TITLE
Atualiza spider para Botucatu-SP

### DIFF
--- a/data_collection/gazette/spiders/sp/sp_botucatu.py
+++ b/data_collection/gazette/spiders/sp/sp_botucatu.py
@@ -1,11 +1,10 @@
 from datetime import date
 
-from gazette.spiders.base.instar import BaseInstarSpider
+from gazette.spiders.base.dosp import DospGazetteSpider
 
 
-class SpBotucatuSpider(BaseInstarSpider):
+class SpBotucatuSpider(DospGazetteSpider):
     TERRITORY_ID = "3507506"
     name = "sp_botucatu"
-    allowed_domains = ["botucatu.sp.gov.br"]
-    base_url = "https://www.botucatu.sp.gov.br/portal/diario-oficial"
+    code = 4734
     start_date = date(2000, 1, 6)


### PR DESCRIPTION
Botucatu-SP migrou o site publicador e esta PR atualiza o raspador para coletar o novo site

[intervalo_sp_botucatu.log](https://github.com/user-attachments/files/16482564/intervalo_sp_botucatu.log)
[intervalo_sp_botucatu.csv](https://github.com/user-attachments/files/16482565/intervalo_sp_botucatu.csv)
[ultima-edicao_sp_botucatu.log](https://github.com/user-attachments/files/16482566/ultima-edicao_sp_botucatu.log)
[ultima-edicao_sp_botucatu.csv](https://github.com/user-attachments/files/16482567/ultima-edicao_sp_botucatu.csv)
