### PR TITLE
Novo Spider - Angra dos Reis/RJ

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_angra_dos_reis.py
+++ b/data_collection/gazette/spiders/rj/rj_angra_dos_reis.py
@@ -1,0 +1,48 @@
+import re
+from datetime import date, datetime as dt
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjAngraDosReisSpider(BaseGazetteSpider):
+    name = "rj_angra_dos_reis"
+    TERRITORY_ID = "3300100"
+    allowed_domains = ["angra.rj.gov.br"]
+    start_date = date(2005, 3, 11)
+
+    def start_requests(self):
+        start_year = int(self.start_date.strftime("%Y"))
+        end_year = int(self.end_date.strftime("%Y"))
+
+        for year in range(end_year, (start_year - 1), -1):
+            yield scrapy.Request(
+                f"https://angra.rj.gov.br/boletim-oficial.asp?vAno={year}"
+            )
+
+    def parse(self, response):
+        for tr in response.xpath("//tr")[1:]:
+            raw_gazette_date = tr.xpath("./td/strong/text()").get()
+            gazette_date = dt.strptime(raw_gazette_date, "%d/%m/%Y").date()
+            if gazette_date > self.end_date:
+                continue
+            if gazette_date < self.start_date:
+                return
+
+            raw_gazette_edition = tr.xpath("./td/text()")[0].get()
+            match = re.search(r"\d+", raw_gazette_edition)
+            gazette_edition_number = "" if match is None else match.group(0)
+            is_extra_edition = "EXTRA" in raw_gazette_edition.upper()
+
+            url_subdir = tr.xpath(".//a/@href").get()
+            gazette_url = response.urljoin(url_subdir)
+
+            yield Gazette(
+                date=gazette_date,
+                edition_number=gazette_edition_number,
+                is_extra_edition=is_extra_edition,
+                file_urls=[gazette_url],
+                power="executive_legislative",
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
[ultima.log](https://github.com/user-attachments/files/16570770/ultima.log)

- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
[intervalo.csv](https://github.com/user-attachments/files/16570771/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/16570772/intervalo.log)

- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[completa.csv](https://github.com/user-attachments/files/16570774/completa.csv)
[completa.log](https://github.com/user-attachments/files/16570775/completa.log)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

Cria spider para Angra dos Reis/RJ, conforme issue #1191
