### PR TITLE
Add the spider to get all gazette editions for the city of Batatais, SP.

### DIFF
--- a/data_collection/gazette/spiders/sp/sp_batatais.py
+++ b/data_collection/gazette/spiders/sp/sp_batatais.py
@@ -1,0 +1,67 @@
+import re
+import scrapy
+
+from datetime import datetime
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class SpBatataisSpider(BaseGazetteSpider):
+    name = "sp_batatais"
+    TERRITORY_ID = ""
+    allowed_domains = ["www.batatais.sp.gov.br"]
+    start_urls = ["https://www.batatais.sp.gov.br/diario-oficial"]
+    start_date = datetime(2021, 10, 27).date()
+
+    def start_requests(self):
+        page = 1
+
+        start_url = f"{self.start_urls[0]}?p={page}"
+
+        yield scrapy.Request(
+            start_url,
+            cb_kwargs={"page": page}
+        )
+
+    def _pagination_requests(self, response, page):
+        if page == 1:
+            pages = response.xpath("/html/body/main/section[2]/div/div/div[2]/nav/ul/li/a/text()")
+            last_page = int(pages[-1].get())
+
+            for next_page in range(2, last_page + 1):
+                next_page_url = f"{self.start_urls[0]}?p={next_page}"
+
+                yield scrapy.Request(
+                    next_page_url,
+                    cb_kwargs={"page": page}
+                )
+
+    def parse(self, response, page):
+        gazettes_xpath = "/html/body/main/section[2]/div/div/div[2]/div"
+
+        gazettes = response.xpath(gazettes_xpath)
+
+        extra_regex = re.compile(r"(?i)extra")
+        edition_number_regex = re.compile(r"\d+(-[A-Za-z])?\/\d{4}")
+
+        for gazette in gazettes:
+            is_extra_edition = False
+            edition = gazette.xpath("div/span/text()")
+            edition_description = edition[0].get()
+            if extra_regex.search(edition_description):
+                is_extra_edition = True
+
+            edition_number = edition_number_regex.search(edition_description).group()
+
+            edition_date = datetime.strptime(edition[1].get().split()[-1], "%d/%m/%Y").date()
+            edition_file = gazette.xpath("div[@class='card-buttons']/a/@href").get()
+
+            yield Gazette(
+                date=edition_date,
+                edition_number=edition_number,
+                is_extra_edition=is_extra_edition,
+                file_urls=[edition_file],
+                power="executive",
+            )
+        yield from self._pagination_requests(response, page)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [X] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [ ] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [ ] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [ ] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [ ] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [ ] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [ ] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

<Descreva o seu Pull Request informando a issue (caso exista) que está sendo solucionada ou uma descrição do código apresentado>
