### PR TITLE
Cria spider para Maricá/RJ

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_marica.py
+++ b/data_collection/gazette/spiders/rj/rj_marica.py
@@ -1,0 +1,70 @@
+import re
+from datetime import date, datetime as dt
+
+import scrapy
+from dateutil.relativedelta import relativedelta
+from dateutil.rrule import MONTHLY, rrule
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjMaricaSpider(BaseGazetteSpider):
+    TERRITORY_ID = "3302700"
+    name = "rj_marica"
+    allowed_domains = ["marica.rj.gov.br"]
+    start_date = date(2006, 7, 17)
+    BASE_URL = "https://www.marica.rj.gov.br/wp-admin/admin-ajax.php?slug={GAZETTE_TYPE}&post_type={GAZETTE_TYPE}&year={YEAR}&month={MONTH}&action=alm_get_posts&order=DESC&orderby=date&posts_per_page=31"
+
+    def start_requests(self):
+        end_date = self.end_date + relativedelta(months=1)
+        for monthly_date in rrule(
+            freq=MONTHLY, dtstart=self.start_date, until=end_date
+        ):
+            year = monthly_date.strftime("%Y")
+            month = monthly_date.strftime("%m")
+            for gazette_type in ["jom", "jom-especial"]:
+                base_url = self.BASE_URL.format(
+                    GAZETTE_TYPE=gazette_type, YEAR=year, MONTH=month
+                )
+                yield scrapy.FormRequest(
+                    method="GET",
+                    url=base_url,
+                )
+
+    def parse(self, response):
+        html = response.json()["html"]
+        if html:
+            gazette_list = html.split("\n\n\n")
+            for gazette_data in gazette_list[0:-1]:
+                raw_gazette_date = re.search(r"\d+\/\d+\/\d+", gazette_data).group(0)
+                gazette_date = dt.strptime(raw_gazette_date, "%d/%m/%Y").date()
+                if not self.start_date <= gazette_date <= self.end_date:
+                    continue
+
+                gazette_edition_number = re.search(
+                    r'title=".*?(\d+)"', gazette_data
+                ).group(1)
+
+                gazette_item = {
+                    "date": gazette_date,
+                    "edition_number": gazette_edition_number,
+                }
+
+                gazette_url = re.search(r'href="(.*?)"', gazette_data).group(1)
+                yield scrapy.Request(
+                    gazette_url,
+                    method="GET",
+                    callback=self.parse_gazette,
+                    cb_kwargs={"gazette_item": gazette_item},
+                )
+
+    def parse_gazette(self, response, gazette_item):
+        gazette_url = response.xpath('//*[@class="vc_btn3-container"]//a/@href').get()
+        if gazette_url is not None:
+            yield Gazette(
+                **gazette_item,
+                file_urls=[gazette_url],
+                power="executive_legislative",
+                is_extra_edition="jom-especial" in response.url
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
[rj_marica_ult.log](https://github.com/user-attachments/files/16588747/rj_marica_ult.log)

- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
[rj_marica_interv.csv](https://github.com/user-attachments/files/16588750/rj_marica_interv.csv)
[rj_marica_interv.log](https://github.com/user-attachments/files/16588751/rj_marica_interv.log)

- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[completa.csv](https://github.com/user-attachments/files/16588754/completa.csv)
[completa.log](https://github.com/user-attachments/files/16588755/completa.log)


#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

Criado spider para Maricá/RJ, conforme issues #1201 
