### PR TITLE
Cria spider para Rio das Ostras/RJ

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_rio_das_ostras.py
+++ b/data_collection/gazette/spiders/rj/rj_rio_das_ostras.py
@@ -1,0 +1,49 @@
+import re
+from datetime import date, datetime as dt
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjRioDasOstrasSpider(BaseGazetteSpider):
+    name = "rj_rio_das_ostras"
+    TERRITORY_ID = "3304524"
+    allowed_domains = ["riodasostras.rj.gov.br"]
+    start_date = date(2001, 7, 13)
+
+    def start_requests(self):
+        for year in range(self.start_date.year, self.end_date.year + 1):
+            base_url = f"https://appro.riodasostras.rj.gov.br/riodasostrasapp_server/api/jornais/search/site?&limit=600&offset=0&orderBy=data&orderDir=desc&ano={year}"
+            yield scrapy.Request(base_url)
+
+    def parse(self, response):
+        for gazette_data in response.json():
+            raw_gazette_date = gazette_data["data"][:10]
+            gazette_date = dt.strptime(raw_gazette_date, "%Y-%m-%d").date()
+
+            if gazette_date > self.end_date:
+                continue
+
+            if gazette_date < self.start_date:
+                return
+
+            match = re.search(r"Edição.*?(\d+)", gazette_data["edicao"])
+            gazette_edition_number = "" if match is None else match.group(1)
+            is_extra_edition = bool(
+                re.search(
+                    r"anex|encar|loa|ppa|ldo|conc",
+                    gazette_data["edicao"],
+                    re.IGNORECASE,
+                )
+            )
+            gazette_url = gazette_data["link"]
+
+            yield Gazette(
+                date=gazette_date,
+                edition_number=gazette_edition_number,
+                is_extra_edition=is_extra_edition,
+                file_urls=[gazette_url],
+                power="executive_legislative",
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [X] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [X] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [X] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [X] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [X] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

[completa.csv](https://github.com/user-attachments/files/16839039/completa.csv)
[completa.log](https://github.com/user-attachments/files/16839040/completa.log)
[intervalo.csv](https://github.com/user-attachments/files/16839042/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/16839044/intervalo.log)
[ultima.log](https://github.com/user-attachments/files/16839045/ultima.log)

#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [X] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [X] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

Criado Spider para o município de Rio das Ostras/RJ conforme issue #1207