### PR TITLE
Habilita proxy para spider to_sampaio

### DIFF
--- a/data_collection/gazette/spiders/to/to_sampaio.py
+++ b/data_collection/gazette/spiders/to/to_sampaio.py
@@ -8,6 +8,8 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class ToSampaioSpider(BaseGazetteSpider):
+    zyte_smartproxy_enabled = True
+
     TERRITORY_ID = "1718808"
     name = "to_sampaio"
     allowed_domains = ["sampaio.to.gov.br"]


### PR DESCRIPTION
Raspador dando erro em produção, mas funcionando normalmente local 
[to_sampaio.log](https://github.com/user-attachments/files/16880626/to_sampaio.log)
