### PR TITLE
Cria base ptio e adiciona 3 municipios do RJ

### DIFF
--- a/data_collection/gazette/spiders/base/ptio.py
+++ b/data_collection/gazette/spiders/base/ptio.py
@@ -1,0 +1,44 @@
+import dateparser
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class BasePtioSpider(BaseGazetteSpider):
+    def start_requests(self):
+        yield scrapy.Request(self.BASE_URL)
+
+    def parse(self, response):
+        for gazette_div in response.xpath("//div[@class='edicoes']"):
+            raw_gazete_date = gazette_div.xpath(
+                ".//div[@class='data-caderno hidden-phone']/text()"
+            ).get()
+            gazette_date = dateparser.parse(raw_gazete_date).date()
+
+            if gazette_date > self.end_date:
+                continue
+            if gazette_date < self.start_date:
+                return
+
+            gazette_edition = gazette_div.xpath(
+                ".//span[@class='edicao']/strong/text()"
+            ).get()
+            gazette_edition_number = gazette_edition.split()[1].replace(".", "")
+
+            sub_dir = gazette_div.xpath(".//button[1]/@href").get()
+            gazette_url = response.urljoin(sub_dir[sub_dir.index("?") :])
+
+            yield Gazette(
+                date=gazette_date,
+                edition_number=gazette_edition_number,
+                is_extra_edition=False,
+                file_urls=[gazette_url],
+                power="executive",
+            )
+
+        next_page = response.xpath(
+            "//ul[@class='paginacao']//a[@class='proximo']/@href"
+        )
+        if next_page:
+            yield scrapy.Request(response.urljoin(next_page.get()))

--- a/data_collection/gazette/spiders/rj/rj_areal.py
+++ b/data_collection/gazette/spiders/rj/rj_areal.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.ptio import BasePtioSpider
+
+
+class RjArealSpider(BasePtioSpider):
+    name = "rj_areal"
+    TERRITORY_ID = "3300225"
+    allowed_domains = ["portaldatransparencia.com.br"]
+    BASE_URL = "http://rj.portaldatransparencia.com.br/prefeitura/areal/"
+    start_date = date(2006, 8, 1)

--- a/data_collection/gazette/spiders/rj/rj_comendador_levy_gasparian.py
+++ b/data_collection/gazette/spiders/rj/rj_comendador_levy_gasparian.py
@@ -1,0 +1,13 @@
+from datetime import date
+
+from gazette.spiders.base.ptio import BasePtioSpider
+
+
+class RjComendadorLevyGasparianSpider(BasePtioSpider):
+    name = "rj_comendador_levy_gasparian"
+    TERRITORY_ID = "3300951"
+    allowed_domains = ["portaldatransparencia.com.br"]
+    BASE_URL = (
+        "http://rj.portaldatransparencia.com.br/prefeitura/comendadorlevygasparian/"
+    )
+    start_date = date(2013, 11, 26)

--- a/data_collection/gazette/spiders/rj/rj_sapucaia.py
+++ b/data_collection/gazette/spiders/rj/rj_sapucaia.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.ptio import BasePtioSpider
+
+
+class RjSapucaiaSpider(BasePtioSpider):
+    name = "rj_sapucaia"
+    TERRITORY_ID = "3305406"
+    allowed_domains = ["portaldatransparencia.com.br"]
+    BASE_URL = "http://rj.portaldatransparencia.com.br/prefeitura/sapucaia/"
+    start_date = date(2019, 1, 16)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [x] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[log.zip](https://github.com/user-attachments/files/16922023/log.zip)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

resolve #1113 
Cria base ptio e spiders para os municípios do RJ que estão mapeados na #1114 : Areal, Cabo Frio, Comendador Levy Gasparian e Sapucaia.

Obs1: Há diários com mesmo número de edição e data que não são edições extras, pois cada edição pode conter cadernos publicados em arquivos diferentes.
Para os 4 municípios tratados não foi possível localizar edições extras e todos são exclusivamente do executivo. Ao adicionar novos municípios mapeados na issue #1114, talvez seja necessário adaptar o código do base para validar o poder e a edição extra.

Obs2: Cabo Frio até o fim de agosto/2024 usava o sistema PTIO, mas a partir de Setembro/2024 passou a usar base instar.

Obs3. Não foi utilizado o nome padrão parse para a base ptio (ficou ptio_parse), pois, como rj_cabo_frio tem herança múltipla, se o start_requests das duas classes mães redirecionassem para um método de mesmo nome, a requisição iria sempre para o classe mãe declarada à esquerda no "class RjCaboFrioSpider".