### PR TITLE
[Manutenção] Classe base AdminLTE

### DIFF
--- a/data_collection/gazette/spiders/base/adminlte.py
+++ b/data_collection/gazette/spiders/base/adminlte.py
@@ -13,7 +13,7 @@ class AdminLTEGazetteSpider(BaseGazetteSpider):
     """
 
     def start_requests(self):
-        url = f"http://diariooficial.{self.city_domain}/pesquisa/"
+        url = f"https://diariooficial.{self.city_domain}/pesquisa/"
 
         start_date = self.start_date.strftime("%Y-%m-%d")
         end_date = self.end_date.strftime("%Y-%m-%d")


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [ ] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [ ] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [ ] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [ ] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [ ] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

Revisa raspador base AdminLTE.
Coisa simples: só permite protocolo de transferência seguro (https). `url` da base atualizada. Funcionando com todas as cidades.
Issue: #1171

#### Testes
[to_gurupi_intervalo.csv](https://github.com/user-attachments/files/17000348/to_gurupi_intervalo.csv)
[to_gurupi_completa.csv](https://github.com/user-attachments/files/17000349/to_gurupi_completa.csv)
[pa_santana_do_araguaia_intervalo.csv](https://github.com/user-attachments/files/17000350/pa_santana_do_araguaia_intervalo.csv)
[pa_santana_do_araguaia_completa.csv](https://github.com/user-attachments/files/17000351/pa_santana_do_araguaia_completa.csv)
[log_to_gurupi_ultimo.txt](https://github.com/user-attachments/files/17000353/log_to_gurupi_ultimo.txt)
[log_to_gurupi_intervalo.txt](https://github.com/user-attachments/files/17000354/log_to_gurupi_intervalo.txt)
[log_to_gurupi_completa.txt](https://github.com/user-attachments/files/17000355/log_to_gurupi_completa.txt)
[log_pa_santana_do_araguaia_ultimo.txt](https://github.com/user-attachments/files/17000356/log_pa_santana_do_araguaia_ultimo.txt)
[log_pa_santana_do_araguaia_intervalo.txt](https://github.com/user-attachments/files/17000357/log_pa_santana_do_araguaia_intervalo.txt)
[log_pa_santana_do_araguaia_completa.txt](https://github.com/user-attachments/files/17000358/log_pa_santana_do_araguaia_completa.txt)

