### PR TITLE
Cria spider para Cabo Frio / RJ

### DIFF
--- a/data_collection/gazette/spiders/base/instar.py
+++ b/data_collection/gazette/spiders/base/instar.py
@@ -8,6 +8,8 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class BaseInstarSpider(BaseGazetteSpider):
+    power = "executive_legislative"
+
     def start_requests(self):
         page = 1
         start_date = self.start_date.strftime("%d-%m-%Y")
@@ -58,7 +60,7 @@ class BaseInstarSpider(BaseGazetteSpider):
                 date=gazette_date,
                 edition_number=edition_number,
                 is_extra_edition=False,
-                power="executive_legislative",
+                power=self.power,
             )
 
             yield scrapy.Request(

--- a/data_collection/gazette/spiders/rj/rj_cabo_frio.py
+++ b/data_collection/gazette/spiders/rj/rj_cabo_frio.py
@@ -1,0 +1,12 @@
+from datetime import date
+
+from gazette.spiders.base.instar import BaseInstarSpider
+
+
+class RjCaboFrioSpider(BaseInstarSpider):
+    name = "rj_cabo_frio"
+    TERRITORY_ID = "3300704"
+    allowed_domains = ["cabofrio.instartecnologia.com.br"]
+    base_url = "https://www.cabofrio.instartecnologia.com.br/portal/diario-oficial"
+    start_date = date(2020, 7, 29)
+    power = "executive"


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [x] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[intervalo.csv](https://github.com/user-attachments/files/17015014/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/17015016/intervalo.log)
[rj_cabo_frio_completa.csv](https://github.com/user-attachments/files/17015017/rj_cabo_frio_completa.csv)
[rj_cabo_frio_completa.log](https://github.com/user-attachments/files/17015018/rj_cabo_frio_completa.log)
[ultima.csv](https://github.com/user-attachments/files/17015019/ultima.csv)
[ultima.log](https://github.com/user-attachments/files/17015020/ultima.log)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

resolve #1267 
Cria spider para Cabo Frio, usando base Instar. Foi necessário pequeno ajusto na Base, pois nesse município são publicados, apenas, atos do poder executivo.
