### PR TITLE
Fix - Spider de Caçapava-SP (Fixes #1131)

### DIFF
--- a/data_collection/gazette/spiders/sp/sp_cacapava.py
+++ b/data_collection/gazette/spiders/sp/sp_cacapava.py
@@ -31,12 +31,12 @@ class SpCacapavaSpider(BaseGazetteSpider):
             edition_number = gazette.css("h3::text").re_first(r"Edição nº (\d+)")
             gazette_raw_date = gazette.css("p::text").re_first(r"\d{2}/\d{2}/\d{4}")
             gazette_date = datetime.strptime(gazette_raw_date, "%d/%m/%Y").date()
-            gazette_url = gazette.css("a::attr(href)")
+            gazette_url = gazette.css("a::attr(href)").extract()
 
             yield Gazette(
                 date=gazette_date,
                 edition_number=edition_number,
                 is_extra_edition=False,
                 power="executive_legislative",
-                file_urls=[gazette_url],
+                file_urls=gazette_url,
             )


### PR DESCRIPTION
#### Testes
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Anexos

```shell
scrapy crawl sp_cacapava -a start_date=2024-09-01 -a end_date=2024-09-19 -s LOG_FILE=sp_cacapava.log -o sp_cacapava.csv
```

- [sp_cacapava.csv](https://github.com/user-attachments/files/17082361/sp_cacapava.csv)
- [sp_cacapava.log](https://github.com/user-attachments/files/17082362/sp_cacapava.log)

#### Descrição

Faltava apenas chamar o `.extract()` para fazer o evaluate dos hrefs.
