### PR TITLE
Feature - Novo spider para Arraial do Cabo - RJ [Fixes #1261]

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_arraial_do_cabo.py
+++ b/data_collection/gazette/spiders/rj/rj_arraial_do_cabo.py
@@ -1,11 +1,34 @@
-import datetime
+from datetime import date, datetime
 
-from gazette.spiders.base.instar import BaseInstarSpider
+from scrapy import Request
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class RjArraialdoCabopider(BaseInstarSpider):
+class RjArraialdoCaboSpider(BaseGazetteSpider):
     TERRITORY_ID = "3300258"
     name = "rj_arraial_do_cabo"
-    allowed_domains = ["arraial.rj.gov.br"]
-    base_url = "https://www.arraial.rj.gov.br/portal/diario-oficial"
-    start_date = datetime.date(2019, 2, 7)
+    allowed_domains = ["portal.arraial.rj.gov.br"]
+    start_urls = ["https://portal.arraial.rj.gov.br/diarios_oficiais_web"]
+    start_date = date(2019, 4, 11)
+
+    def parse(self, response):
+        for entry in response.css(".row .card.card-margin"):
+            edition = entry.css("h5.card-title").re_first(r"(\d*) \/ \d{4}")
+            file_url = entry.css(".widget-49-meeting-action.mt-2 a::attr(href)").get()
+            publish_date = entry.css(".widget-49-date-day::text").get()
+            publish_date = datetime.strptime(publish_date, "%d %b %Y").date()
+
+            if self.start_date <= publish_date <= self.end_date:
+                yield Gazette(
+                    date=publish_date,
+                    file_urls=[file_url],
+                    edition_number=edition,
+                    is_extra_edition=False,
+                    power="executive",
+                )
+
+        next_page = response.xpath('//a[contains(@rel, "next")]/@href')[-1]
+        if next_page and publish_date > self.start_date:
+            yield Request(next_page.get())


### PR DESCRIPTION
#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

Novo spider customizado para Arraial do Cabo, conforme #1261. Eu mudei a data de início pois o registro mais antigo que eu consegui encontrar manualmente no site foi em `07/05/2019`.

## Anexos

#### Coleta última edição

```
scrapy crawl rj_arraial_do_cabo -a start_date=2024-09-20 -s LOG_FILE=rj_arraial_do_cabo.log -o rj_arraial_do_cabo.csv
```

- [rj_arraial_do_cabo.csv](https://github.com/user-attachments/files/17082584/rj_arraial_do_cabo.csv)
- [rj_arraial_do_cabo.log](https://github.com/user-attachments/files/17082585/rj_arraial_do_cabo.log)

#### Coleta intervalo

```
scrapy crawl rj_arraial_do_cabo -a start_date=2024-09-01 -a end_date=2024-09-20 -s LOG_FILE=rj_arraial_do_cabo.log -o rj_arraial_do_cabo.csv
```

- [rj_arraial_do_cabo.csv](https://github.com/user-attachments/files/17082599/rj_arraial_do_cabo.csv)
- [rj_arraial_do_cabo.log](https://github.com/user-attachments/files/17082600/rj_arraial_do_cabo.log)

#### Coleta completa

```
scrapy crawl rj_arraial_do_cabo -s LOG_FILE=rj_arraial_do_cabo.log -o rj_arraial_do_cabo.csv
```

- [rj_arraial_do_cabo.csv](https://github.com/user-attachments/files/17082562/rj_arraial_do_cabo.csv)
- [rj_arraial_do_cabo.log](https://github.com/user-attachments/files/17082563/rj_arraial_do_cabo.log)
