### PR TITLE
Padroniza nomenclatura para as classes de spiders base

### DIFF
--- a/data_collection/gazette/spiders/al/al_associacao_municipios.py
+++ b/data_collection/gazette/spiders/al/al_associacao_municipios.py
@@ -1,9 +1,9 @@
 import datetime
 
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class AlAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class AlAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "al_associacao_municipios"
     TERRITORY_ID = "2700000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/ama/"

--- a/data_collection/gazette/spiders/al/al_igaci.py
+++ b/data_collection/gazette/spiders/al/al_igaci.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class AlIgaciSpider(SaiGazetteSpider):
+class AlIgaciSpider(BaseSaiSpider):
     TERRITORY_ID = "2703106"
     name = "al_igaci"
     allowed_domains = ["igaci.al.gov.br"]

--- a/data_collection/gazette/spiders/al/al_maceio.py
+++ b/data_collection/gazette/spiders/al/al_maceio.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class AlMaceioSpider(SigpubGazetteSpider):
+class AlMaceioSpider(BaseSigpubSpider):
     name = "al_maceio"
     TERRITORY_ID = "2704302"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/maceio"

--- a/data_collection/gazette/spiders/am/am_associacao_municipios.py
+++ b/data_collection/gazette/spiders/am/am_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class AmAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class AmAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "am_associacao_municipios"
     TERRITORY_ID = "1300000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/aam"

--- a/data_collection/gazette/spiders/ba/ba_abare.py
+++ b/data_collection/gazette/spiders/ba/ba_abare.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaAbareSpider(SaiGazetteSpider):
+class BaAbareSpider(BaseSaiSpider):
     TERRITORY_ID = "2900207"
     name = "ba_abare"
     allowed_domains = ["sai.io.org.br"]

--- a/data_collection/gazette/spiders/ba/ba_acajutiba.py
+++ b/data_collection/gazette/spiders/ba/ba_acajutiba.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaAcajutibaSpider(DoemGazetteSpider):
+class BaAcajutibaSpider(BaseDoemSpider):
     TERRITORY_ID = "2900306"
     name = "ba_acajutiba"
     state_city_url_part = "ba/acajutiba"

--- a/data_collection/gazette/spiders/ba/ba_adustina.py
+++ b/data_collection/gazette/spiders/ba/ba_adustina.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaAdustinaSpider(SaiGazetteSpider):
+class BaAdustinaSpider(BaseSaiSpider):
     TERRITORY_ID = "2900355"
     name = "ba_adustina"
     allowed_domains = ["adustina.ba.gov.br"]

--- a/data_collection/gazette/spiders/ba/ba_alagoinhas.py
+++ b/data_collection/gazette/spiders/ba/ba_alagoinhas.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaAlagoinhasSpider(DoemGazetteSpider):
+class BaAlagoinhasSpider(BaseDoemSpider):
     TERRITORY_ID = "2900702"
     name = "ba_alagoinhas"
     state_city_url_part = "ba/alagoinhas"

--- a/data_collection/gazette/spiders/ba/ba_alcobaca.py
+++ b/data_collection/gazette/spiders/ba/ba_alcobaca.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaAlcobacaSpider(DoemGazetteSpider):
+class BaAlcobacaSpider(BaseDoemSpider):
     TERRITORY_ID = "2900801"
     name = "ba_alcobaca"
     state_city_url_part = "ba/alcobaca"

--- a/data_collection/gazette/spiders/ba/ba_almadina.py
+++ b/data_collection/gazette/spiders/ba/ba_almadina.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaAlmadinaSpider(SaiGazetteSpider):
+class BaAlmadinaSpider(BaseSaiSpider):
     TERRITORY_ID = "2900900"
     name = "ba_almadina"
     allowed_domains = ["almadina.ba.gov.br"]

--- a/data_collection/gazette/spiders/ba/ba_amelia_rodrigues.py
+++ b/data_collection/gazette/spiders/ba/ba_amelia_rodrigues.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaAmeliaRodriguesSpider(ImprensaOficialSpider):
+class BaAmeliaRodriguesSpider(BaseImprensaOficialSpider):
     name = "ba_amelia_rodrigues"
     allowed_domains = ["pmameliarodriguesba.imprensaoficial.org"]
     start_date = date(2015, 1, 1)

--- a/data_collection/gazette/spiders/ba/ba_anage.py
+++ b/data_collection/gazette/spiders/ba/ba_anage.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaAnageSpider(SaiGazetteSpider):
+class BaAnageSpider(BaseSaiSpider):
     TERRITORY_ID = "2901205"
     name = "ba_anage"
     allowed_domains = ["anage.ba.gov.br"]

--- a/data_collection/gazette/spiders/ba/ba_andorinha.py
+++ b/data_collection/gazette/spiders/ba/ba_andorinha.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaAndorinhaSpider(SaiGazetteSpider):
+class BaAndorinhaSpider(BaseSaiSpider):
     TERRITORY_ID = "2901353"
     name = "ba_andorinha"
     allowed_domains = ["andorinha.ba.gov.br"]

--- a/data_collection/gazette/spiders/ba/ba_angical.py
+++ b/data_collection/gazette/spiders/ba/ba_angical.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaAngicalSpider(DoemGazetteSpider):
+class BaAngicalSpider(BaseDoemSpider):
     TERRITORY_ID = "2901403"
     name = "ba_angical"
     state_city_url_part = "ba/angical"

--- a/data_collection/gazette/spiders/ba/ba_antonio_cardoso_2017.py
+++ b/data_collection/gazette/spiders/ba/ba_antonio_cardoso_2017.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaAntonioCardosoSpider(DoemGazetteSpider):
+class BaAntonioCardosoSpider(BaseDoemSpider):
     TERRITORY_ID = "2901700"
     name = "ba_antonio_cardoso_2017"
     state_city_url_part = "ba/antoniocardoso"

--- a/data_collection/gazette/spiders/ba/ba_associacao_municipios.py
+++ b/data_collection/gazette/spiders/ba/ba_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class BaAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class BaAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "ba_associacao_municipios"
     TERRITORY_ID = "2900000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/amurc"

--- a/data_collection/gazette/spiders/ba/ba_banzae.py
+++ b/data_collection/gazette/spiders/ba/ba_banzae.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaBanzaeSpider(DoemGazetteSpider):
+class BaBanzaeSpider(BaseDoemSpider):
     TERRITORY_ID = "2902658"
     name = "ba_banzae"
     state_city_url_part = "ba/banzae"

--- a/data_collection/gazette/spiders/ba/ba_barra_do_choca_2017.py
+++ b/data_collection/gazette/spiders/ba/ba_barra_do_choca_2017.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaBarraDoChocaSpider(DoemGazetteSpider):
+class BaBarraDoChocaSpider(BaseDoemSpider):
     TERRITORY_ID = "2902906"
     name = "ba_barra_do_choca_2017"
     state_city_url_part = "ba/barradochoca"

--- a/data_collection/gazette/spiders/ba/ba_barrocas_2017.py
+++ b/data_collection/gazette/spiders/ba/ba_barrocas_2017.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaBarrocasSpider(DoemGazetteSpider):
+class BaBarrocasSpider(BaseDoemSpider):
     TERRITORY_ID = "2903276"
     name = "ba_barrocas_2017"
     state_city_url_part = "ba/barrocas"

--- a/data_collection/gazette/spiders/ba/ba_brotas_de_macaubas.py
+++ b/data_collection/gazette/spiders/ba/ba_brotas_de_macaubas.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaBrotasDeMacaubasSpider(DoemGazetteSpider):
+class BaBrotasDeMacaubasSpider(BaseDoemSpider):
     TERRITORY_ID = "2904506"
     name = "ba_brotas_de_macaubas"
     state_city_url_part = "ba/brotasdemacaubas"

--- a/data_collection/gazette/spiders/ba/ba_cachoeira_2017.py
+++ b/data_collection/gazette/spiders/ba/ba_cachoeira_2017.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCachoeiraSpider(DoemGazetteSpider):
+class BaCachoeiraSpider(BaseDoemSpider):
     TERRITORY_ID = "2904902"
     name = "ba_cachoeira_2017"
     state_city_url_part = "ba/cachoeira"

--- a/data_collection/gazette/spiders/ba/ba_cacule_2014.py
+++ b/data_collection/gazette/spiders/ba/ba_cacule_2014.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCaculeSpider(DoemGazetteSpider):
+class BaCaculeSpider(BaseDoemSpider):
     TERRITORY_ID = "2905008"
     name = "ba_cacule_2014"
     state_city_url_part = "ba/cacule"

--- a/data_collection/gazette/spiders/ba/ba_caetite.py
+++ b/data_collection/gazette/spiders/ba/ba_caetite.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCaetiteSpider(DoemGazetteSpider):
+class BaCaetiteSpider(BaseDoemSpider):
     TERRITORY_ID = "2905206"
     name = "ba_caetite"
     state_city_url_part = "ba/caetite"

--- a/data_collection/gazette/spiders/ba/ba_camamu_2017.py
+++ b/data_collection/gazette/spiders/ba/ba_camamu_2017.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCamamuSpider(DoemGazetteSpider):
+class BaCamamuSpider(BaseDoemSpider):
     TERRITORY_ID = "2905800"
     name = "ba_camamu_2017"
     state_city_url_part = "ba/camamu"

--- a/data_collection/gazette/spiders/ba/ba_campo_alegre_de_lourdes.py
+++ b/data_collection/gazette/spiders/ba/ba_campo_alegre_de_lourdes.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCampoAlegreDeLourdesSpider(DoemGazetteSpider):
+class BaCampoAlegreDeLourdesSpider(BaseDoemSpider):
     TERRITORY_ID = "2905909"
     name = "ba_campo_alegre_de_lourdes"
     state_city_url_part = "ba/campoalegredelourdes"

--- a/data_collection/gazette/spiders/ba/ba_campo_formoso.py
+++ b/data_collection/gazette/spiders/ba/ba_campo_formoso.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCampoFormosoSpider(DoemGazetteSpider):
+class BaCampoFormosoSpider(BaseDoemSpider):
     TERRITORY_ID = "2906006"
     name = "ba_campo_formoso"
     state_city_url_part = "ba/campoformoso"

--- a/data_collection/gazette/spiders/ba/ba_canudos.py
+++ b/data_collection/gazette/spiders/ba/ba_canudos.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCanudosSpider(DoemGazetteSpider):
+class BaCanudosSpider(BaseDoemSpider):
     TERRITORY_ID = "2906824"
     name = "ba_canudos"
     state_city_url_part = "ba/canudos"

--- a/data_collection/gazette/spiders/ba/ba_catolandia_2015.py
+++ b/data_collection/gazette/spiders/ba/ba_catolandia_2015.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCatolandiaSpider(DoemGazetteSpider):
+class BaCatolandiaSpider(BaseDoemSpider):
     TERRITORY_ID = "2907400"
     name = "ba_catolandia_2015"
     state_city_url_part = "ba/catolandia"

--- a/data_collection/gazette/spiders/ba/ba_catu_2014.py
+++ b/data_collection/gazette/spiders/ba/ba_catu_2014.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCatuSpider(DoemGazetteSpider):
+class BaCatuSpider(BaseDoemSpider):
     TERRITORY_ID = "2907509"
     name = "ba_catu_2014"
     state_city_url_part = "ba/catu"

--- a/data_collection/gazette/spiders/ba/ba_cicero_dantas.py
+++ b/data_collection/gazette/spiders/ba/ba_cicero_dantas.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCiceroDantasSpider(DoemGazetteSpider):
+class BaCiceroDantasSpider(BaseDoemSpider):
     TERRITORY_ID = "2907806"
     name = "ba_cicero_dantas"
     state_city_url_part = "ba/cicerodantas"

--- a/data_collection/gazette/spiders/ba/ba_cipo.py
+++ b/data_collection/gazette/spiders/ba/ba_cipo.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCipoSpider(DoemGazetteSpider):
+class BaCipoSpider(BaseDoemSpider):
     TERRITORY_ID = "2907905"
     name = "ba_cipo"
     state_city_url_part = "ba/cipo"

--- a/data_collection/gazette/spiders/ba/ba_conceicao_do_almeida.py
+++ b/data_collection/gazette/spiders/ba/ba_conceicao_do_almeida.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaConceicaoDoAlmeidaSpider(ImprensaOficialSpider):
+class BaConceicaoDoAlmeidaSpider(BaseImprensaOficialSpider):
     name = "ba_conceicao_do_almeida"
     allowed_domains = [
         "pmconceicaodoalmeidaba.imprensaoficial.org",

--- a/data_collection/gazette/spiders/ba/ba_correntina.py
+++ b/data_collection/gazette/spiders/ba/ba_correntina.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaCorrentinaSpider(SaiGazetteSpider):
+class BaCorrentinaSpider(BaseSaiSpider):
     TERRITORY_ID = "2909307"
     name = "ba_correntina"
     allowed_domains = ["sai.io.org.br"]

--- a/data_collection/gazette/spiders/ba/ba_cotegipe.py
+++ b/data_collection/gazette/spiders/ba/ba_cotegipe.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCotegipeSpider(DoemGazetteSpider):
+class BaCotegipeSpider(BaseDoemSpider):
     TERRITORY_ID = "2909406"
     name = "ba_cotegipe"
     state_city_url_part = "ba/cotegipe"

--- a/data_collection/gazette/spiders/ba/ba_cristopolis.py
+++ b/data_collection/gazette/spiders/ba/ba_cristopolis.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCristopolisSpider(DoemGazetteSpider):
+class BaCristopolisSpider(BaseDoemSpider):
     TERRITORY_ID = "2909703"
     name = "ba_cristopolis"
     state_city_url_part = "ba/cristopolis"

--- a/data_collection/gazette/spiders/ba/ba_cruz_das_almas.py
+++ b/data_collection/gazette/spiders/ba/ba_cruz_das_almas.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaCruzDasAlmasSpider(DoemGazetteSpider):
+class BaCruzDasAlmasSpider(BaseDoemSpider):
     TERRITORY_ID = "2909802"
     name = "ba_cruz_das_almas"
     state_city_url_part = "ba/cruzdasalmas"

--- a/data_collection/gazette/spiders/ba/ba_esplanada.py
+++ b/data_collection/gazette/spiders/ba/ba_esplanada.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaEsplanadaSpider(DoemGazetteSpider):
+class BaEsplanadaSpider(BaseDoemSpider):
     TERRITORY_ID = "2910602"
     name = "ba_esplanada"
     state_city_url_part = "ba/esplanada"

--- a/data_collection/gazette/spiders/ba/ba_floresta_azul_2017.py
+++ b/data_collection/gazette/spiders/ba/ba_floresta_azul_2017.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaFlorestaAzulSpider(DoemGazetteSpider):
+class BaFlorestaAzulSpider(BaseDoemSpider):
     TERRITORY_ID = "2911006"
     name = "ba_floresta_azul_2017"
     state_city_url_part = "ba/florestaazul"

--- a/data_collection/gazette/spiders/ba/ba_formosa_do_rio_preto.py
+++ b/data_collection/gazette/spiders/ba/ba_formosa_do_rio_preto.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaFormosaDoRioPretoSpider(DoemGazetteSpider):
+class BaFormosaDoRioPretoSpider(BaseDoemSpider):
     TERRITORY_ID = "2911105"
     name = "ba_formosa_do_rio_preto"
     state_city_url_part = "ba/formosadoriopreto"

--- a/data_collection/gazette/spiders/ba/ba_gentio_do_ouro.py
+++ b/data_collection/gazette/spiders/ba/ba_gentio_do_ouro.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaGentioDoOuroSpider(ImprensaOficialSpider):
+class BaGentioDoOuroSpider(BaseImprensaOficialSpider):
     name = "ba_gentio_do_ouro"
     allowed_domains = ["pmgentiodoouroba.imprensaoficial.org"]
     start_date = date(2017, 2, 1)

--- a/data_collection/gazette/spiders/ba/ba_gongogi.py
+++ b/data_collection/gazette/spiders/ba/ba_gongogi.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaGongogiSpider(ImprensaOficialSpider):
+class BaGongogiSpider(BaseImprensaOficialSpider):
     name = "ba_gongogi"
     allowed_domains = ["pmgongogiba.imprensaoficial.org"]
     start_date = date(2020, 2, 1)

--- a/data_collection/gazette/spiders/ba/ba_governador_mangabeira.py
+++ b/data_collection/gazette/spiders/ba/ba_governador_mangabeira.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaGovernadorMangabeiraSpider(ImprensaOficialSpider):
+class BaGovernadorMangabeiraSpider(BaseImprensaOficialSpider):
     name = "ba_governador_mangabeira"
     allowed_domains = ["pmGOVERNADORMANGABEIRABA.imprensaoficial.org"]
     start_date = date(2018, 1, 1)

--- a/data_collection/gazette/spiders/ba/ba_inhambupe.py
+++ b/data_collection/gazette/spiders/ba/ba_inhambupe.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaInhambupeSpider(DoemGazetteSpider):
+class BaInhambupeSpider(BaseDoemSpider):
     TERRITORY_ID = "2913705"
     name = "ba_inhambupe"
     state_city_url_part = "ba/inhambupe"

--- a/data_collection/gazette/spiders/ba/ba_ipiau.py
+++ b/data_collection/gazette/spiders/ba/ba_ipiau.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaIpiauSpider(DoemGazetteSpider):
+class BaIpiauSpider(BaseDoemSpider):
     TERRITORY_ID = "2913903"
     name = "ba_ipiau"
     state_city_url_part = "ba/ipiau"

--- a/data_collection/gazette/spiders/ba/ba_irara.py
+++ b/data_collection/gazette/spiders/ba/ba_irara.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaIraraSpider(DoemGazetteSpider):
+class BaIraraSpider(BaseDoemSpider):
     TERRITORY_ID = "2914505"
     name = "ba_irara"
     state_city_url_part = "ba/irara"

--- a/data_collection/gazette/spiders/ba/ba_itaberaba.py
+++ b/data_collection/gazette/spiders/ba/ba_itaberaba.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaItaberabaSpider(DoemGazetteSpider):
+class BaItaberabaSpider(BaseDoemSpider):
     TERRITORY_ID = "2914703"
     name = "ba_itaberaba"
     state_city_url_part = "ba/itaberaba"

--- a/data_collection/gazette/spiders/ba/ba_itamaraju.py
+++ b/data_collection/gazette/spiders/ba/ba_itamaraju.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaItamarajuSpider(DoemGazetteSpider):
+class BaItamarajuSpider(BaseDoemSpider):
     TERRITORY_ID = "2915601"
     name = "ba_itamaraju"
     state_city_url_part = "ba/itamaraju"

--- a/data_collection/gazette/spiders/ba/ba_itapetinga.py
+++ b/data_collection/gazette/spiders/ba/ba_itapetinga.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaItapetingaSpider(DoemGazetteSpider):
+class BaItapetingaSpider(BaseDoemSpider):
     TERRITORY_ID = "2916401"
     name = "ba_itapetinga"
     state_city_url_part = "ba/itapetinga"

--- a/data_collection/gazette/spiders/ba/ba_itapicuru.py
+++ b/data_collection/gazette/spiders/ba/ba_itapicuru.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaItapicuruSpider(DoemGazetteSpider):
+class BaItapicuruSpider(BaseDoemSpider):
     TERRITORY_ID = "2916500"
     name = "ba_itapicuru"
     state_city_url_part = "ba/itapicuru"

--- a/data_collection/gazette/spiders/ba/ba_itaquara.py
+++ b/data_collection/gazette/spiders/ba/ba_itaquara.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaItaquaraSpider(ImprensaOficialSpider):
+class BaItaquaraSpider(BaseImprensaOficialSpider):
     name = "ba_itaquara"
     allowed_domains = ["pmitaquaraba.imprensaoficial.org", "itaquara.ba.gov.br"]
     start_date = date(2019, 1, 1)

--- a/data_collection/gazette/spiders/ba/ba_itatim.py
+++ b/data_collection/gazette/spiders/ba/ba_itatim.py
@@ -1,9 +1,9 @@
 import datetime as dt
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaMaragogipeSpider(SaiGazetteSpider):
+class BaMaragogipeSpider(BaseSaiSpider):
     TERRITORY_ID = "2916856"
     name = "ba_itatim"
     start_date = dt.date(2009, 1, 1)

--- a/data_collection/gazette/spiders/ba/ba_ituacu.py
+++ b/data_collection/gazette/spiders/ba/ba_ituacu.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaItuacuSpider(DoemGazetteSpider):
+class BaItuacuSpider(BaseDoemSpider):
     TERRITORY_ID = "2917201"
     name = "ba_ituacu"
     state_city_url_part = "ba/ituacu"

--- a/data_collection/gazette/spiders/ba/ba_jaborandi.py
+++ b/data_collection/gazette/spiders/ba/ba_jaborandi.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaJaborandiSpider(SaiGazetteSpider):
+class BaJaborandiSpider(BaseSaiSpider):
     TERRITORY_ID = "2917359"
     name = "ba_jaborandi"
     allowed_domains = ["sai.io.org.br"]

--- a/data_collection/gazette/spiders/ba/ba_jaguaquara.py
+++ b/data_collection/gazette/spiders/ba/ba_jaguaquara.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaJaguaquaraSpider(DoemGazetteSpider):
+class BaJaguaquaraSpider(BaseDoemSpider):
     TERRITORY_ID = "2917607"
     name = "ba_jaguaquara"
     state_city_url_part = "ba/jaguaquara"

--- a/data_collection/gazette/spiders/ba/ba_jaguarari.py
+++ b/data_collection/gazette/spiders/ba/ba_jaguarari.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaJaguarariSpider(ImprensaOficialSpider):
+class BaJaguarariSpider(BaseImprensaOficialSpider):
     name = "ba_jaguarari"
     allowed_domains = ["pmjaguarariba.imprensaoficial.org"]
     start_date = date(2019, 10, 1)

--- a/data_collection/gazette/spiders/ba/ba_jeremoabo.py
+++ b/data_collection/gazette/spiders/ba/ba_jeremoabo.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaJeremoaboSpider(SaiGazetteSpider):
+class BaJeremoaboSpider(BaseSaiSpider):
     TERRITORY_ID = "2918100"
     name = "ba_jeremoabo"
     allowed_domains = ["jeremoabo.ba.gov.br"]

--- a/data_collection/gazette/spiders/ba/ba_juazeiro.py
+++ b/data_collection/gazette/spiders/ba/ba_juazeiro.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaJuazeiroSpider(DoemGazetteSpider):
+class BaJuazeiroSpider(BaseDoemSpider):
     TERRITORY_ID = "2918407"
     name = "ba_juazeiro"
     state_city_url_part = "ba/juazeiro"

--- a/data_collection/gazette/spiders/ba/ba_laje.py
+++ b/data_collection/gazette/spiders/ba/ba_laje.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaLajeSpider(DoemGazetteSpider):
+class BaLajeSpider(BaseDoemSpider):
     TERRITORY_ID = "2918803"
     name = "ba_laje"
     state_city_url_part = "ba/laje"

--- a/data_collection/gazette/spiders/ba/ba_lajedao.py
+++ b/data_collection/gazette/spiders/ba/ba_lajedao.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaLajedaoSpider(DoemGazetteSpider):
+class BaLajedaoSpider(BaseDoemSpider):
     TERRITORY_ID = "2918902"
     name = "ba_lajedao"
     state_city_url_part = "ba/lajedao"

--- a/data_collection/gazette/spiders/ba/ba_lauro_de_freitas.py
+++ b/data_collection/gazette/spiders/ba/ba_lauro_de_freitas.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaLauroDeFreitasSpider(SaiGazetteSpider):
+class BaLauroDeFreitasSpider(BaseSaiSpider):
     TERRITORY_ID = "2919207"
     name = "ba_lauro_de_freitas"
     allowed_domains = ["sai.io.org.br"]

--- a/data_collection/gazette/spiders/ba/ba_luis_eduardo_magalhaes.py
+++ b/data_collection/gazette/spiders/ba/ba_luis_eduardo_magalhaes.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaLuisEduardoMagalhaesSpider(SaiGazetteSpider):
+class BaLuisEduardoMagalhaesSpider(BaseSaiSpider):
     TERRITORY_ID = "2919553"
     name = "ba_luis_eduardo_magalhaes"
     allowed_domains = ["sai.io.org.br"]

--- a/data_collection/gazette/spiders/ba/ba_macajuba.py
+++ b/data_collection/gazette/spiders/ba/ba_macajuba.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaMacajubaSpider(DoemGazetteSpider):
+class BaMacajubaSpider(BaseDoemSpider):
     TERRITORY_ID = "2919603"
     name = "ba_macajuba"
     state_city_url_part = "ba/macajuba"

--- a/data_collection/gazette/spiders/ba/ba_maragogipe.py
+++ b/data_collection/gazette/spiders/ba/ba_maragogipe.py
@@ -1,9 +1,9 @@
 import datetime as dt
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaMaragogipeSpider(SaiGazetteSpider):
+class BaMaragogipeSpider(BaseSaiSpider):
     TERRITORY_ID = "2920601"
     name = "ba_maragogipe"
     start_date = dt.date(2011, 2, 2)

--- a/data_collection/gazette/spiders/ba/ba_mascote.py
+++ b/data_collection/gazette/spiders/ba/ba_mascote.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaMascoteSpider(DoemGazetteSpider):
+class BaMascoteSpider(BaseDoemSpider):
     TERRITORY_ID = "2920908"
     name = "ba_mascote"
     state_city_url_part = "ba/mascote"

--- a/data_collection/gazette/spiders/ba/ba_medeiros_neto_2018.py
+++ b/data_collection/gazette/spiders/ba/ba_medeiros_neto_2018.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaMedeirosNetoSpider(DoemGazetteSpider):
+class BaMedeirosNetoSpider(BaseDoemSpider):
     TERRITORY_ID = "2921104"
     name = "ba_medeiros_neto_2018"
     start_date = date(2018, 1, 9)

--- a/data_collection/gazette/spiders/ba/ba_monte_santo.py
+++ b/data_collection/gazette/spiders/ba/ba_monte_santo.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaMonteSantoSpider(DoemGazetteSpider):
+class BaMonteSantoSpider(BaseDoemSpider):
     TERRITORY_ID = "2921500"
     name = "ba_monte_santo"
     state_city_url_part = "ba/montesanto"

--- a/data_collection/gazette/spiders/ba/ba_morro_do_chapeu.py
+++ b/data_collection/gazette/spiders/ba/ba_morro_do_chapeu.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaMorroDoChapeuSpider(DoemGazetteSpider):
+class BaMorroDoChapeuSpider(BaseDoemSpider):
     TERRITORY_ID = "2921708"
     name = "ba_morro_do_chapeu"
     state_city_url_part = "ba/morrodochapeu"

--- a/data_collection/gazette/spiders/ba/ba_mucuri.py
+++ b/data_collection/gazette/spiders/ba/ba_mucuri.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaMucuriSpider(DoemGazetteSpider):
+class BaMucuriSpider(BaseDoemSpider):
     TERRITORY_ID = "2922003"
     name = "ba_mucuri"
     state_city_url_part = "ba/mucuri"

--- a/data_collection/gazette/spiders/ba/ba_muniz_ferreira.py
+++ b/data_collection/gazette/spiders/ba/ba_muniz_ferreira.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaMunizFerreiraSpider(ImprensaOficialSpider):
+class BaMunizFerreiraSpider(BaseImprensaOficialSpider):
     name = "ba_muniz_ferreira"
     allowed_domains = ["pmmunizferreiraba.imprensaoficial.org"]
     start_date = date(2014, 12, 1)

--- a/data_collection/gazette/spiders/ba/ba_paratinga.py
+++ b/data_collection/gazette/spiders/ba/ba_paratinga.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaParatingaSpider(ImprensaOficialSpider):
+class BaParatingaSpider(BaseImprensaOficialSpider):
     name = "ba_paratinga"
     allowed_domains = ["pmparatingaba.imprensaoficial.org"]
     start_date = date(2018, 4, 1)

--- a/data_collection/gazette/spiders/ba/ba_pe_de_serra.py
+++ b/data_collection/gazette/spiders/ba/ba_pe_de_serra.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaPeDeSerraSpider(ImprensaOficialSpider):
+class BaPeDeSerraSpider(BaseImprensaOficialSpider):
     name = "ba_pe_de_serra"
     allowed_domains = ["pmpedeserraba.imprensaoficial.org"]
     start_date = date(2017, 1, 1)

--- a/data_collection/gazette/spiders/ba/ba_prado.py
+++ b/data_collection/gazette/spiders/ba/ba_prado.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaPradoSpider(DoemGazetteSpider):
+class BaPradoSpider(BaseDoemSpider):
     TERRITORY_ID = "2925501"
     name = "ba_prado"
     state_city_url_part = "ba/prado"

--- a/data_collection/gazette/spiders/ba/ba_riachao_das_neves.py
+++ b/data_collection/gazette/spiders/ba/ba_riachao_das_neves.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaRiachaoDasNevesSpider(SaiGazetteSpider):
+class BaRiachaoDasNevesSpider(BaseSaiSpider):
     TERRITORY_ID = "2926202"
     name = "ba_riachao_das_neves"
     allowed_domains = ["sai.io.org.br"]

--- a/data_collection/gazette/spiders/ba/ba_ribeira_do_pombal_2014.py
+++ b/data_collection/gazette/spiders/ba/ba_ribeira_do_pombal_2014.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaRibeiraDoPombalSpider(DoemGazetteSpider):
+class BaRibeiraDoPombalSpider(BaseDoemSpider):
     TERRITORY_ID = "2926608"
     name = "ba_ribeira_do_pombal_2014"
     state_city_url_part = "ba/ribeiradopombal"

--- a/data_collection/gazette/spiders/ba/ba_santa_cruz_cabralia.py
+++ b/data_collection/gazette/spiders/ba/ba_santa_cruz_cabralia.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaSantaCruzCabraliaSpider(DoemGazetteSpider):
+class BaSantaCruzCabraliaSpider(BaseDoemSpider):
     TERRITORY_ID = "2927705"
     name = "ba_santa_cruz_cabralia"
     state_city_url_part = "ba/santacruzcabralia"

--- a/data_collection/gazette/spiders/ba/ba_santa_luzia_2021.py
+++ b/data_collection/gazette/spiders/ba/ba_santa_luzia_2021.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaSantaLuziaSpider(DoemGazetteSpider):
+class BaSantaLuziaSpider(BaseDoemSpider):
     TERRITORY_ID = "2928059"
     name = "ba_santa_luzia_2021"
     state_city_url_part = "ba/santaluzia"

--- a/data_collection/gazette/spiders/ba/ba_santa_luzia_2024.py
+++ b/data_collection/gazette/spiders/ba/ba_santa_luzia_2024.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class BaSantaLuziaSpider(SaiGazetteSpider):
+class BaSantaLuziaSpider(BaseSaiSpider):
     TERRITORY_ID = "2928059"
     name = "ba_santa_luzia_2024"
     allowed_domains = ["santaluzia.ba.gov.br"]

--- a/data_collection/gazette/spiders/ba/ba_santa_rita_de_cassia.py
+++ b/data_collection/gazette/spiders/ba/ba_santa_rita_de_cassia.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaSantaRitaDeCassiaSpider(DoemGazetteSpider):
+class BaSantaRitaDeCassiaSpider(BaseDoemSpider):
     TERRITORY_ID = "2928406"
     name = "ba_santa_rita_de_cassia"
     state_city_url_part = "ba/santaritadecassia"

--- a/data_collection/gazette/spiders/ba/ba_santo_amaro_2012.py
+++ b/data_collection/gazette/spiders/ba/ba_santo_amaro_2012.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaSantoAmaroSpider(DoemGazetteSpider):
+class BaSantoAmaroSpider(BaseDoemSpider):
     TERRITORY_ID = "2928604"
     name = "ba_santo_amaro_2012"
     state_city_url_part = "ba/santoamaro"

--- a/data_collection/gazette/spiders/ba/ba_santo_estevao.py
+++ b/data_collection/gazette/spiders/ba/ba_santo_estevao.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaSantoEstevaoSpider(DoemGazetteSpider):
+class BaSantoEstevaoSpider(BaseDoemSpider):
     TERRITORY_ID = "2928802"
     name = "ba_santo_estevao"
     state_city_url_part = "ba/santoestevao"

--- a/data_collection/gazette/spiders/ba/ba_sao_felipe.py
+++ b/data_collection/gazette/spiders/ba/ba_sao_felipe.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaSaoFelipeSpider(ImprensaOficialSpider):
+class BaSaoFelipeSpider(BaseImprensaOficialSpider):
     name = "ba_sao_felipe"
     allowed_domains = ["pmsaofelipeba.imprensaoficial.org"]
     start_date = date(2020, 1, 1)

--- a/data_collection/gazette/spiders/ba/ba_sao_felix.py
+++ b/data_collection/gazette/spiders/ba/ba_sao_felix.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaSaoFelixSpider(ImprensaOficialSpider):
+class BaSaoFelixSpider(BaseImprensaOficialSpider):
     name = "ba_sao_felix"
     allowed_domains = ["pmsaofelixba.imprensaoficial.org"]
     start_date = date(2017, 1, 1)

--- a/data_collection/gazette/spiders/ba/ba_sao_francisco_do_conde.py
+++ b/data_collection/gazette/spiders/ba/ba_sao_francisco_do_conde.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaSaoFranciscoDoCondeSpider(ImprensaOficialSpider):
+class BaSaoFranciscoDoCondeSpider(BaseImprensaOficialSpider):
     name = "ba_sao_francisco_do_conde"
     allowed_domains = ["pmsaofranciscodocondeba.imprensaoficial.org"]
     start_date = date(2019, 3, 1)

--- a/data_collection/gazette/spiders/ba/ba_sao_miguel_das_matas.py
+++ b/data_collection/gazette/spiders/ba/ba_sao_miguel_das_matas.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaSaoMiguelDasMatasSpider(ImprensaOficialSpider):
+class BaSaoMiguelDasMatasSpider(BaseImprensaOficialSpider):
     name = "ba_sao_miguel_das_matas"
     allowed_domains = [
         "pmsaomigueldasmatasba.imprensaoficial.org",

--- a/data_collection/gazette/spiders/ba/ba_sapeacu.py
+++ b/data_collection/gazette/spiders/ba/ba_sapeacu.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaSapeacuSpider(ImprensaOficialSpider):
+class BaSapeacuSpider(BaseImprensaOficialSpider):
     name = "ba_sapeacu"
     allowed_domains = ["pmsapeacuba.imprensaoficial.org", "sapeacu.ba.gov.br"]
     start_date = date(2017, 1, 1)

--- a/data_collection/gazette/spiders/ba/ba_satiro_dias.py
+++ b/data_collection/gazette/spiders/ba/ba_satiro_dias.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaSatiroDiasSpider(DoemGazetteSpider):
+class BaSatiroDiasSpider(BaseDoemSpider):
     TERRITORY_ID = "2929701"
     name = "ba_satiro_dias"
     state_city_url_part = "ba/satirodias"

--- a/data_collection/gazette/spiders/ba/ba_saude.py
+++ b/data_collection/gazette/spiders/ba/ba_saude.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaSaudeSpider(ImprensaOficialSpider):
+class BaSaudeSpider(BaseImprensaOficialSpider):
     name = "ba_saude"
     allowed_domains = ["pmsaudeba.imprensaoficial.org"]
     start_date = date(2018, 2, 1)

--- a/data_collection/gazette/spiders/ba/ba_senhor_do_bonfim.py
+++ b/data_collection/gazette/spiders/ba/ba_senhor_do_bonfim.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaSenhorDoBonfimSpider(DoemGazetteSpider):
+class BaSenhorDoBonfimSpider(BaseDoemSpider):
     TERRITORY_ID = "2930105"
     name = "ba_senhor_do_bonfim"
     state_city_url_part = "ba/senhordobonfim"

--- a/data_collection/gazette/spiders/ba/ba_sento_se.py
+++ b/data_collection/gazette/spiders/ba/ba_sento_se.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaSentoSeSpider(DoemGazetteSpider):
+class BaSentoSeSpider(BaseDoemSpider):
     TERRITORY_ID = "2930204"
     name = "ba_sento_se"
     state_city_url_part = "ba/sentose"

--- a/data_collection/gazette/spiders/ba/ba_serrinha.py
+++ b/data_collection/gazette/spiders/ba/ba_serrinha.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaSerrinhaSpider(ImprensaOficialSpider):
+class BaSerrinhaSpider(BaseImprensaOficialSpider):
     name = "ba_serrinha"
     allowed_domains = ["pmserrinhaba.imprensaoficial.org"]
     start_date = date(2020, 1, 1)

--- a/data_collection/gazette/spiders/ba/ba_tabocas_do_brejo_velho_2013.py
+++ b/data_collection/gazette/spiders/ba/ba_tabocas_do_brejo_velho_2013.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaTabocasDoBrejoVelhoSpider(DoemGazetteSpider):
+class BaTabocasDoBrejoVelhoSpider(BaseDoemSpider):
     TERRITORY_ID = "2930907"
     name = "ba_tabocas_do_brejo_velho_2013"
     state_city_url_part = "ba/tabocasdobrejovelho"

--- a/data_collection/gazette/spiders/ba/ba_tapiramuta.py
+++ b/data_collection/gazette/spiders/ba/ba_tapiramuta.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaTapiramutaSpider(DoemGazetteSpider):
+class BaTapiramutaSpider(BaseDoemSpider):
     TERRITORY_ID = "2931301"
     name = "ba_tapiramuta"
     state_city_url_part = "ba/tapiramuta"

--- a/data_collection/gazette/spiders/ba/ba_teixeira_de_freitas_2021.py
+++ b/data_collection/gazette/spiders/ba/ba_teixeira_de_freitas_2021.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaTeixeiraDeFreitasSpider(DoemGazetteSpider):
+class BaTeixeiraDeFreitasSpider(BaseDoemSpider):
     TERRITORY_ID = "2931350"
     name = "ba_teixeira_de_freitas_2021"
     state_city_url_part = "ba/teixeiradefreitas"

--- a/data_collection/gazette/spiders/ba/ba_teolandia.py
+++ b/data_collection/gazette/spiders/ba/ba_teolandia.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaTeolandiaSpider(DoemGazetteSpider):
+class BaTeolandiaSpider(BaseDoemSpider):
     TERRITORY_ID = "2931608"
     name = "ba_teolandia"
     state_city_url_part = "ba/teolandia"

--- a/data_collection/gazette/spiders/ba/ba_tucano.py
+++ b/data_collection/gazette/spiders/ba/ba_tucano.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class BaTucanoSpider(DoemGazetteSpider):
+class BaTucanoSpider(BaseDoemSpider):
     TERRITORY_ID = "2931905"
     name = "ba_tucano"
     state_city_url_part = "ba/tucano"

--- a/data_collection/gazette/spiders/ba/ba_vera_cruz.py
+++ b/data_collection/gazette/spiders/ba/ba_vera_cruz.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaVeraCruzSpider(ImprensaOficialSpider):
+class BaVeraCruzSpider(BaseImprensaOficialSpider):
     name = "ba_vera_cruz"
     allowed_domains = ["pmveracruzba.imprensaoficial.org"]
     start_date = date(2017, 4, 1)

--- a/data_collection/gazette/spiders/ba/ba_wenceslau_guimaraes.py
+++ b/data_collection/gazette/spiders/ba/ba_wenceslau_guimaraes.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaWenceslauGuimaraesSpider(ImprensaOficialSpider):
+class BaWenceslauGuimaraesSpider(BaseImprensaOficialSpider):
     name = "ba_wenceslau_guimaraes"
     allowed_domains = ["pmwenceslauguimaraesba.imprensaoficial.org"]
     start_date = date(2017, 1, 1)

--- a/data_collection/gazette/spiders/ba/ba_xique_xique.py
+++ b/data_collection/gazette/spiders/ba/ba_xique_xique.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.imprensa_oficial import ImprensaOficialSpider
+from gazette.spiders.base.imprensa_oficial import BaseImprensaOficialSpider
 
 
-class BaXiqueXiqueSpider(ImprensaOficialSpider):
+class BaXiqueXiqueSpider(BaseImprensaOficialSpider):
     name = "ba_xique_xique"
     allowed_domains = ["pmxiquexiqueba.imprensaoficial.org"]
     start_date = date(2017, 1, 1)

--- a/data_collection/gazette/spiders/base/adminlte.py
+++ b/data_collection/gazette/spiders/base/adminlte.py
@@ -7,7 +7,7 @@ from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
 
-class AdminLTEGazetteSpider(BaseGazetteSpider):
+class BaseAdminLteSpider(BaseGazetteSpider):
     """
     Base spider for cities using the Framework AdminLTE as design system.
     """

--- a/data_collection/gazette/spiders/base/barcodigital.py
+++ b/data_collection/gazette/spiders/base/barcodigital.py
@@ -7,7 +7,7 @@ from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
 
-class BarcoDigitalSpider(BaseGazetteSpider):
+class BaseBarcoDigitalSpider(BaseGazetteSpider):
     EDITION_TYPE_NORMAL = 1
     EDITION_TYPE_EXTRA = 2
     EDITION_TYPE_SUPPLEMENT = 3

--- a/data_collection/gazette/spiders/base/dioenet.py
+++ b/data_collection/gazette/spiders/base/dioenet.py
@@ -10,7 +10,7 @@ from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
 
-class DioenetGazetteSpider(BaseGazetteSpider):
+class BaseDioenetSpider(BaseGazetteSpider):
     """
     Base spider for all cities listed on https://plenussistemas.dioenet.com.br
     """

--- a/data_collection/gazette/spiders/base/dionet.py
+++ b/data_collection/gazette/spiders/base/dionet.py
@@ -5,7 +5,7 @@ from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
 
-class DionetGazetteSpider(BaseGazetteSpider):
+class BaseDionetSpider(BaseGazetteSpider):
     """
     Base Spider for all cities using IONEWS' DIONET product
 

--- a/data_collection/gazette/spiders/base/doem.py
+++ b/data_collection/gazette/spiders/base/doem.py
@@ -6,7 +6,7 @@ from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
 
-class DoemGazetteSpider(BaseGazetteSpider):
+class BaseDoemSpider(BaseGazetteSpider):
     """
     Base spider for all cities listed on https://doem.org.br
     """

--- a/data_collection/gazette/spiders/base/dosp.py
+++ b/data_collection/gazette/spiders/base/dosp.py
@@ -8,7 +8,7 @@ from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
 
-class DospGazetteSpider(BaseGazetteSpider):
+class BaseDospSpider(BaseGazetteSpider):
     # Must be defined into child classes
     code = None
     start_date = None

--- a/data_collection/gazette/spiders/base/imprensa_oficial.py
+++ b/data_collection/gazette/spiders/base/imprensa_oficial.py
@@ -8,7 +8,7 @@ from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
 
-class ImprensaOficialSpider(BaseGazetteSpider):
+class BaseImprensaOficialSpider(BaseGazetteSpider):
     def start_requests(self):
         initial_date = date(self.start_date.year, self.start_date.month, 1)
 

--- a/data_collection/gazette/spiders/base/sai.py
+++ b/data_collection/gazette/spiders/base/sai.py
@@ -5,7 +5,7 @@ from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
 
-class SaiGazetteSpider(BaseGazetteSpider):
+class BaseSaiSpider(BaseGazetteSpider):
     """
     Base Spider for all cases with use SAI (Serviço de Acesso a Informação)
     Read more in https://imap.org.br/sistemas/sai/

--- a/data_collection/gazette/spiders/base/sigpub.py
+++ b/data_collection/gazette/spiders/base/sigpub.py
@@ -8,7 +8,7 @@ from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
 
-class SigpubGazetteSpider(BaseGazetteSpider):
+class BaseSigpubSpider(BaseGazetteSpider):
     """www.diariomunicipal.com.br (Sigpub) base spider
 
     Documents obtained by this kind of spider are text-PDFs with many cities in it.

--- a/data_collection/gazette/spiders/ce/ce_associacao_municipios.py
+++ b/data_collection/gazette/spiders/ce/ce_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class CeAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class CeAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "ce_associacao_municipios"
     TERRITORY_ID = "2300000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/aprece"

--- a/data_collection/gazette/spiders/ce/ce_horizonte.py
+++ b/data_collection/gazette/spiders/ce/ce_horizonte.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class CeHorizonteSpider(DospGazetteSpider):
+class CeHorizonteSpider(BaseDospSpider):
     TERRITORY_ID = "2305233"
     name = "ce_horizonte"
     code = 687

--- a/data_collection/gazette/spiders/es/es_associacao_municipios.py
+++ b/data_collection/gazette/spiders/es/es_associacao_municipios.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dionet import DionetGazetteSpider
+from gazette.spiders.base.dionet import BaseDionetSpider
 
 
-class EsAssociacaoMunicipiosSpider(DionetGazetteSpider):
+class EsAssociacaoMunicipiosSpider(BaseDionetSpider):
     TERRITORY_ID = "3200000"
     name = "es_associacao_municipios"
     allowed_domains = ["ioes.dio.es.gov.br"]

--- a/data_collection/gazette/spiders/es/es_serra.py
+++ b/data_collection/gazette/spiders/es/es_serra.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dionet import DionetGazetteSpider
+from gazette.spiders.base.dionet import BaseDionetSpider
 
 
-class EsSerraSpider(DionetGazetteSpider):
+class EsSerraSpider(BaseDionetSpider):
     TERRITORY_ID = "3205002"
     name = "es_serra"
     allowed_domains = ["ioes.dio.es.gov.br"]

--- a/data_collection/gazette/spiders/go/go_associacao_municipios_agm.py
+++ b/data_collection/gazette/spiders/go/go_associacao_municipios_agm.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class GoAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class GoAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "go_associacao_municipios_agm"
     TERRITORY_ID = "5200000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/agm"

--- a/data_collection/gazette/spiders/go/go_associacao_municipios_fgm.py
+++ b/data_collection/gazette/spiders/go/go_associacao_municipios_fgm.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class GoAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class GoAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "go_associacao_municipios_fgm"
     TERRITORY_ID = "5200000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/fgm"

--- a/data_collection/gazette/spiders/mg/mg_associacao_municipios.py
+++ b/data_collection/gazette/spiders/mg/mg_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class MgAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class MgAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "mg_associacao_municipios"
     TERRITORY_ID = "3100000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/amm-mg"

--- a/data_collection/gazette/spiders/mg/mg_itajuba.py
+++ b/data_collection/gazette/spiders/mg/mg_itajuba.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class MgItajubaSpider(DospGazetteSpider):
+class MgItajubaSpider(BaseDospSpider):
     TERRITORY_ID = "3132404"
     name = "mg_itajuba"
     code = 1908

--- a/data_collection/gazette/spiders/mg/mg_uberaba_2021.py
+++ b/data_collection/gazette/spiders/mg/mg_uberaba_2021.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class MgUberabaSpider(DospGazetteSpider):
+class MgUberabaSpider(BaseDospSpider):
     TERRITORY_ID = "3170107"
     name = "mg_uberaba_2021"
     code = 2364

--- a/data_collection/gazette/spiders/ms/ms_associacao_municipios.py
+++ b/data_collection/gazette/spiders/ms/ms_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class MsAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class MsAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "ms_associacao_municipios"
     TERRITORY_ID = "5000000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/ms"

--- a/data_collection/gazette/spiders/ms/ms_corumba.py
+++ b/data_collection/gazette/spiders/ms/ms_corumba.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dionet import DionetGazetteSpider
+from gazette.spiders.base.dionet import BaseDionetSpider
 
 
-class MsCorumba(DionetGazetteSpider):
+class MsCorumba(BaseDionetSpider):
     TERRITORY_ID = "5003207"
     name = "ms_corumba"
     allowed_domains = ["do.corumba.ms.gov.br"]

--- a/data_collection/gazette/spiders/mt/mt_associacao_municipios.py
+++ b/data_collection/gazette/spiders/mt/mt_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class MtAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class MtAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "mt_associacao_municipios"
     TERRITORY_ID = "5100000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/amm-mt"

--- a/data_collection/gazette/spiders/pa/pa_associacao_municipios.py
+++ b/data_collection/gazette/spiders/pa/pa_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class PaAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class PaAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "pa_associacao_municipios"
     TERRITORY_ID = "1500000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/famep"

--- a/data_collection/gazette/spiders/pa/pa_santana_do_araguaia.py
+++ b/data_collection/gazette/spiders/pa/pa_santana_do_araguaia.py
@@ -1,9 +1,9 @@
 import datetime
 
-from gazette.spiders.base.adminlte import AdminLTEGazetteSpider
+from gazette.spiders.base.adminlte import BaseAdminLteSpider
 
 
-class PaSantanaDoAraguaiaSpider(AdminLTEGazetteSpider):
+class PaSantanaDoAraguaiaSpider(BaseAdminLteSpider):
     TERRITORY_ID = "1506708"
     name = "pa_santana_do_araguaia"
     allowed_domains = ["diariooficial.pmsaraguaia.pa.gov.br"]

--- a/data_collection/gazette/spiders/pb/pb_associacao_municipios.py
+++ b/data_collection/gazette/spiders/pb/pb_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class PbAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class PbAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "pb_associacao_municipios"
     TERRITORY_ID = "2500000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/famup"

--- a/data_collection/gazette/spiders/pe/pe_associacao_municipios.py
+++ b/data_collection/gazette/spiders/pe/pe_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class PeAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class PeAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "pe_associacao_municipios"
     TERRITORY_ID = "2600000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/amupe"

--- a/data_collection/gazette/spiders/pe/pe_cabrobo.py
+++ b/data_collection/gazette/spiders/pe/pe_cabrobo.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class PeCabroboSpider(DospGazetteSpider):
+class PeCabroboSpider(BaseDospSpider):
     TERRITORY_ID = "2603009"
     name = "pe_cabrobo"
     code = 3190

--- a/data_collection/gazette/spiders/pe/pe_petrolina.py
+++ b/data_collection/gazette/spiders/pe/pe_petrolina.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class PePetrolinaSpider(DoemGazetteSpider):
+class PePetrolinaSpider(BaseDoemSpider):
     TERRITORY_ID = "2611101"
     name = "pe_petrolina"
     state_city_url_part = "pe/petrolina"

--- a/data_collection/gazette/spiders/pi/pi_associacao_municipios.py
+++ b/data_collection/gazette/spiders/pi/pi_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class PiAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class PiAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "pi_associacao_municipios"
     TERRITORY_ID = "2200000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/appm"

--- a/data_collection/gazette/spiders/pr/pr_associacao_municipios.py
+++ b/data_collection/gazette/spiders/pr/pr_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class PrAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class PrAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "pr_associacao_municipios"
     TERRITORY_ID = "4100000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/amp"

--- a/data_collection/gazette/spiders/pr/pr_cafelandia.py
+++ b/data_collection/gazette/spiders/pr/pr_cafelandia.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class PrCafelandiaSpider(DospGazetteSpider):
+class PrCafelandiaSpider(BaseDospSpider):
     TERRITORY_ID = "4103453"
     name = "pr_cafelandia"
     code = 4748

--- a/data_collection/gazette/spiders/pr/pr_ipiranga.py
+++ b/data_collection/gazette/spiders/pr/pr_ipiranga.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class PrIpirangaSpider(DoemGazetteSpider):
+class PrIpirangaSpider(BaseDoemSpider):
     TERRITORY_ID = "4110508"
     name = "pr_ipiranga"
     state_city_url_part = "pr/ipiranga"

--- a/data_collection/gazette/spiders/pr/pr_marilandia_do_sul.py
+++ b/data_collection/gazette/spiders/pr/pr_marilandia_do_sul.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dioenet import DioenetGazetteSpider
+from gazette.spiders.base.dioenet import BaseDioenetSpider
 
 
-class PrMarilandiaDoSulSpider(DioenetGazetteSpider):
+class PrMarilandiaDoSulSpider(BaseDioenetSpider):
     TERRITORY_ID = "4114906"
     name = "pr_marilandia_do_sul"
     start_date = date(2019, 12, 17)

--- a/data_collection/gazette/spiders/pr/pr_tamboara.py
+++ b/data_collection/gazette/spiders/pr/pr_tamboara.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class PrTamboaraSpider(DoemGazetteSpider):
+class PrTamboaraSpider(BaseDoemSpider):
     TERRITORY_ID = "4126702"
     name = "pr_tamboara"
     state_city_url_part = "pr/tamboara"

--- a/data_collection/gazette/spiders/rj/rj_associacao_municipios.py
+++ b/data_collection/gazette/spiders/rj/rj_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class RjAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class RjAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "rj_associacao_municipios"
     TERRITORY_ID = "3300000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/aemerj"

--- a/data_collection/gazette/spiders/rj/rj_nova_friburgo.py
+++ b/data_collection/gazette/spiders/rj/rj_nova_friburgo.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dioenet import DioenetGazetteSpider
+from gazette.spiders.base.dioenet import BaseDioenetSpider
 
 
-class RjNovaFriburgoSpider(DioenetGazetteSpider):
+class RjNovaFriburgoSpider(BaseDioenetSpider):
     TERRITORY_ID = "3303401"
     name = "rj_nova_friburgo"
     start_date = date(2019, 10, 17)

--- a/data_collection/gazette/spiders/rj/rj_rio_de_janeiro.py
+++ b/data_collection/gazette/spiders/rj/rj_rio_de_janeiro.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dionet import DionetGazetteSpider
+from gazette.spiders.base.dionet import BaseDionetSpider
 
 
-class RjRioDeJaneiroSpider(DionetGazetteSpider):
+class RjRioDeJaneiroSpider(BaseDionetSpider):
     TERRITORY_ID = "3304557"
     name = "rj_rio_de_janeiro"
     allowed_domains = ["doweb.rio.rj.gov.br"]

--- a/data_collection/gazette/spiders/rj/rj_sao_jose_do_vale_do_rio_preto.py
+++ b/data_collection/gazette/spiders/rj/rj_sao_jose_do_vale_do_rio_preto.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class RjSaoJoseDoValeDoRioPretoSpider(DospGazetteSpider):
+class RjSaoJoseDoValeDoRioPretoSpider(BaseDospSpider):
     TERRITORY_ID = "3305158"
     name = "rj_sao_jose_do_vale_do_rio_preto"
     code = 3640

--- a/data_collection/gazette/spiders/rj/rj_sumidouro.py
+++ b/data_collection/gazette/spiders/rj/rj_sumidouro.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dioenet import DioenetGazetteSpider
+from gazette.spiders.base.dioenet import BaseDioenetSpider
 
 
-class RjSumidouroSpider(DioenetGazetteSpider):
+class RjSumidouroSpider(BaseDioenetSpider):
     TERRITORY_ID = "3305703"
     name = "rj_sumidouro"
     start_date = date(2021, 7, 26)

--- a/data_collection/gazette/spiders/rn/rn_associacao_municipios.py
+++ b/data_collection/gazette/spiders/rn/rn_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class RnAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class RnAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "rn_associacao_municipios"
     TERRITORY_ID = "2400000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/femurn"

--- a/data_collection/gazette/spiders/ro/ro_associacao_municipios.py
+++ b/data_collection/gazette/spiders/ro/ro_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class RoAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class RoAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "ro_associacao_municipios"
     TERRITORY_ID = "1100000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/arom"

--- a/data_collection/gazette/spiders/ro/ro_jaru.py
+++ b/data_collection/gazette/spiders/ro/ro_jaru.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dionet import DionetGazetteSpider
+from gazette.spiders.base.dionet import BaseDionetSpider
 
 
-class RoJaruSpider(DionetGazetteSpider):
+class RoJaruSpider(BaseDionetSpider):
     zyte_smartproxy_enabled = True
 
     TERRITORY_ID = "1100114"

--- a/data_collection/gazette/spiders/rr/rr_associacao_municipios.py
+++ b/data_collection/gazette/spiders/rr/rr_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class RrAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class RrAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "rr_associacao_municipios"
     TERRITORY_ID = "1400000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/amr"

--- a/data_collection/gazette/spiders/rs/rs_associacao_municipios.py
+++ b/data_collection/gazette/spiders/rs/rs_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class RsAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class RsAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "rs_associacao_municipios"
     TERRITORY_ID = "4300000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/famurs"

--- a/data_collection/gazette/spiders/rs/rs_marau.py
+++ b/data_collection/gazette/spiders/rs/rs_marau.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class RsMarauSpider(DospGazetteSpider):
+class RsMarauSpider(BaseDospSpider):
     TERRITORY_ID = "4311809"
     name = "rs_marau"
     code = 4049

--- a/data_collection/gazette/spiders/rs/rs_santa_clara_do_sul.py
+++ b/data_collection/gazette/spiders/rs/rs_santa_clara_do_sul.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class RsSantaClaraDoSulSpider(DospGazetteSpider):
+class RsSantaClaraDoSulSpider(BaseDospSpider):
     TERRITORY_ID = "4316758"
     name = "rs_santa_clara_do_sul"
     code = 4159

--- a/data_collection/gazette/spiders/rs/rs_tres_arroios.py
+++ b/data_collection/gazette/spiders/rs/rs_tres_arroios.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class RsTresArroiosSpider(DospGazetteSpider):
+class RsTresArroiosSpider(BaseDospSpider):
     TERRITORY_ID = "4321634"
     name = "rs_tres_arroios"
     code = 4247

--- a/data_collection/gazette/spiders/se/se_associacao_municipios.py
+++ b/data_collection/gazette/spiders/se/se_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class SeAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class SeAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "se_associacao_municipios"
     TERRITORY_ID = "2800000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/sergipe"

--- a/data_collection/gazette/spiders/se/se_estancia.py
+++ b/data_collection/gazette/spiders/se/se_estancia.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.sai import SaiGazetteSpider
+from gazette.spiders.base.sai import BaseSaiSpider
 
 
-class SeEstanciaSpider(SaiGazetteSpider):
+class SeEstanciaSpider(BaseSaiSpider):
     TERRITORY_ID = "2802106"
     name = "se_estancia"
     allowed_domains = ["estancia.se.gov.br"]

--- a/data_collection/gazette/spiders/se/se_nossa_senhora_do_socorro.py
+++ b/data_collection/gazette/spiders/se/se_nossa_senhora_do_socorro.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.doem import DoemGazetteSpider
+from gazette.spiders.base.doem import BaseDoemSpider
 
 
-class SeNossaSenhoraDoSocorroSpider(DoemGazetteSpider):
+class SeNossaSenhoraDoSocorroSpider(BaseDoemSpider):
     TERRITORY_ID = "2804805"
     name = "se_nossa_senhora_do_socorro"
     state_city_url_part = "se/nossasenhoradosocorro"

--- a/data_collection/gazette/spiders/sp/sp_adolfo.py
+++ b/data_collection/gazette/spiders/sp/sp_adolfo.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpAdolfoSpider(DospGazetteSpider):
+class SpAdolfoSpider(BaseDospSpider):
     TERRITORY_ID = "3500204"
     name = "sp_adolfo"
     code = 4650

--- a/data_collection/gazette/spiders/sp/sp_aracatuba.py
+++ b/data_collection/gazette/spiders/sp/sp_aracatuba.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpAracatubaSpider(DospGazetteSpider):
+class SpAracatubaSpider(BaseDospSpider):
     TERRITORY_ID = "3502804"
     name = "sp_aracatuba"
     code = 4680

--- a/data_collection/gazette/spiders/sp/sp_associacao_municipios.py
+++ b/data_collection/gazette/spiders/sp/sp_associacao_municipios.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class SpAssociacaoMunicipiosSpider(SigpubGazetteSpider):
+class SpAssociacaoMunicipiosSpider(BaseSigpubSpider):
     name = "sp_associacao_municipios"
     TERRITORY_ID = "3500000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/apm"

--- a/data_collection/gazette/spiders/sp/sp_avare.py
+++ b/data_collection/gazette/spiders/sp/sp_avare.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpAvareSpider(DospGazetteSpider):
+class SpAvareSpider(BaseDospSpider):
     TERRITORY_ID = "3504503"
     name = "sp_avare"
     code = 4700

--- a/data_collection/gazette/spiders/sp/sp_birigui.py
+++ b/data_collection/gazette/spiders/sp/sp_birigui.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpBiriguiSpider(DospGazetteSpider):
+class SpBiriguiSpider(BaseDospSpider):
     TERRITORY_ID = "3506508"
     name = "sp_birigui"
     code = 4722

--- a/data_collection/gazette/spiders/sp/sp_botucatu.py
+++ b/data_collection/gazette/spiders/sp/sp_botucatu.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpBotucatuSpider(DospGazetteSpider):
+class SpBotucatuSpider(BaseDospSpider):
     TERRITORY_ID = "3507506"
     name = "sp_botucatu"
     code = 4734

--- a/data_collection/gazette/spiders/sp/sp_braganca_paulista.py
+++ b/data_collection/gazette/spiders/sp/sp_braganca_paulista.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpBragancaPaulistaSpider(DospGazetteSpider):
+class SpBragancaPaulistaSpider(BaseDospSpider):
     TERRITORY_ID = "3507605"
     name = "sp_braganca_paulista"
     code = 4735

--- a/data_collection/gazette/spiders/sp/sp_campo_limpo_paulista.py
+++ b/data_collection/gazette/spiders/sp/sp_campo_limpo_paulista.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpCampoLimpoPaulistaSpider(DospGazetteSpider):
+class SpCampoLimpoPaulistaSpider(BaseDospSpider):
     TERRITORY_ID = "3509601"
     name = "sp_campo_limpo_paulista"
     code = 4758

--- a/data_collection/gazette/spiders/sp/sp_catanduva.py
+++ b/data_collection/gazette/spiders/sp/sp_catanduva.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpCatanduvaSpider(DospGazetteSpider):
+class SpCatanduvaSpider(BaseDospSpider):
     TERRITORY_ID = "3511102"
     name = "sp_catanduva"
     code = 4775

--- a/data_collection/gazette/spiders/sp/sp_cunha.py
+++ b/data_collection/gazette/spiders/sp/sp_cunha.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpCunhaSpider(DospGazetteSpider):
+class SpCunhaSpider(BaseDospSpider):
     TERRITORY_ID = "3513603"
     name = "sp_cunha"
     code = 4800

--- a/data_collection/gazette/spiders/sp/sp_dirce_reis.py
+++ b/data_collection/gazette/spiders/sp/sp_dirce_reis.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpDirceReisSpider(DospGazetteSpider):
+class SpDirceReisSpider(BaseDospSpider):
     TERRITORY_ID = "3513850"
     name = "sp_dirce_reis"
     code = 4803

--- a/data_collection/gazette/spiders/sp/sp_guaracai.py
+++ b/data_collection/gazette/spiders/sp/sp_guaracai.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpGuaracaiSpider(DospGazetteSpider):
+class SpGuaracaiSpider(BaseDospSpider):
     TERRITORY_ID = "3517802"
     name = "sp_guaracai"
     code = 4853

--- a/data_collection/gazette/spiders/sp/sp_itapeva.py
+++ b/data_collection/gazette/spiders/sp/sp_itapeva.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpItapevaSpider(DospGazetteSpider):
+class SpItapevaSpider(BaseDospSpider):
     TERRITORY_ID = "3522406"
     name = "sp_itapeva"
     code = 4907

--- a/data_collection/gazette/spiders/sp/sp_itapevi.py
+++ b/data_collection/gazette/spiders/sp/sp_itapevi.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpItapeviSpider(DospGazetteSpider):
+class SpItapeviSpider(BaseDospSpider):
     TERRITORY_ID = "3522505"
     name = "sp_itapevi"
     code = 4908

--- a/data_collection/gazette/spiders/sp/sp_itu.py
+++ b/data_collection/gazette/spiders/sp/sp_itu.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpItuSpider(DospGazetteSpider):
+class SpItuSpider(BaseDospSpider):
     TERRITORY_ID = "3523909"
     name = "sp_itu"
     code = 4923

--- a/data_collection/gazette/spiders/sp/sp_jandira.py
+++ b/data_collection/gazette/spiders/sp/sp_jandira.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpJandiraSpider(DospGazetteSpider):
+class SpJandiraSpider(BaseDospSpider):
     TERRITORY_ID = "3525003"
     name = "sp_jandira"
     code = 4934

--- a/data_collection/gazette/spiders/sp/sp_jau_2023.py
+++ b/data_collection/gazette/spiders/sp/sp_jau_2023.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpJauSpider_2023(DospGazetteSpider):
+class SpJauSpider_2023(BaseDospSpider):
     TERRITORY_ID = "3525300"
     name = "sp_jau_2023"
     code = 4937

--- a/data_collection/gazette/spiders/sp/sp_macatuba.py
+++ b/data_collection/gazette/spiders/sp/sp_macatuba.py
@@ -1,9 +1,9 @@
 import datetime
 
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class SpMacatubaSpider(SigpubGazetteSpider):
+class SpMacatubaSpider(BaseSigpubSpider):
     name = "sp_macatuba"
     TERRITORY_ID = "3528007"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/macatuba/"

--- a/data_collection/gazette/spiders/sp/sp_mogi_guacu.py
+++ b/data_collection/gazette/spiders/sp/sp_mogi_guacu.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpMogiGuacuSpider(DospGazetteSpider):
+class SpMogiGuacuSpider(BaseDospSpider):
     TERRITORY_ID = "3530706"
     name = "sp_mogi_guacu"
     code = 4995

--- a/data_collection/gazette/spiders/sp/sp_monte_alto.py
+++ b/data_collection/gazette/spiders/sp/sp_monte_alto.py
@@ -1,7 +1,7 @@
-from gazette.spiders.base.sigpub import SigpubGazetteSpider
+from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class SpMonteAltoSigpubSpider(SigpubGazetteSpider):
+class SpMonteAltoSigpubSpider(BaseSigpubSpider):
     name = "sp_monte_alto_sigpub"
     TERRITORY_ID = "3531308"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/pmmasp"

--- a/data_collection/gazette/spiders/sp/sp_monteiro_lobato.py
+++ b/data_collection/gazette/spiders/sp/sp_monteiro_lobato.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpMonteiroLobatoSpider(DospGazetteSpider):
+class SpMonteiroLobatoSpider(BaseDospSpider):
     TERRITORY_ID = "3531704"
     name = "sp_monteiro_lobato"
     code = 5006

--- a/data_collection/gazette/spiders/sp/sp_rio_claro.py
+++ b/data_collection/gazette/spiders/sp/sp_rio_claro.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpRioClaroSpider(DospGazetteSpider):
+class SpRioClaroSpider(BaseDospSpider):
     TERRITORY_ID = "3543907"
     name = "sp_rio_claro"
     code = 5142

--- a/data_collection/gazette/spiders/sp/sp_salto.py
+++ b/data_collection/gazette/spiders/sp/sp_salto.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpSaltoSpider(DospGazetteSpider):
+class SpSaltoSpider(BaseDospSpider):
     TERRITORY_ID = "3545209"
     name = "sp_salto"
     code = 5158

--- a/data_collection/gazette/spiders/sp/sp_sao_bernardo_do_campo.py
+++ b/data_collection/gazette/spiders/sp/sp_sao_bernardo_do_campo.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpSaoBernardoDoCampoSpider(DospGazetteSpider):
+class SpSaoBernardoDoCampoSpider(BaseDospSpider):
     TERRITORY_ID = "3548708"
     name = "sp_sao_bernardo_do_campo"
     code = 5195

--- a/data_collection/gazette/spiders/sp/sp_sao_jose_dos_campos.py
+++ b/data_collection/gazette/spiders/sp/sp_sao_jose_dos_campos.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dionet import DionetGazetteSpider
+from gazette.spiders.base.dionet import BaseDionetSpider
 
 
-class SpSaoJoseDosCamposSpider(DionetGazetteSpider):
+class SpSaoJoseDosCamposSpider(BaseDionetSpider):
     TERRITORY_ID = "3549904"
     name = "sp_sao_jose_dos_campos"
     allowed_domains = ["diariodomunicipio.sjc.sp.gov.br"]

--- a/data_collection/gazette/spiders/sp/sp_sertaozinho.py
+++ b/data_collection/gazette/spiders/sp/sp_sertaozinho.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpSertaozinhoSpider(DospGazetteSpider):
+class SpSertaozinhoSpider(BaseDospSpider):
     TERRITORY_ID = "3551702"
     name = "sp_sertaozinho"
     code = 5227

--- a/data_collection/gazette/spiders/sp/sp_taubate.py
+++ b/data_collection/gazette/spiders/sp/sp_taubate.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dioenet import DioenetGazetteSpider
+from gazette.spiders.base.dioenet import BaseDioenetSpider
 
 
-class SpTaubateSpider(DioenetGazetteSpider):
+class SpTaubateSpider(BaseDioenetSpider):
     TERRITORY_ID = "3554102"
     name = "sp_taubate"
     start_date = date(2022, 12, 8)

--- a/data_collection/gazette/spiders/sp/sp_tremembe.py
+++ b/data_collection/gazette/spiders/sp/sp_tremembe.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpTremembeSpider(DospGazetteSpider):
+class SpTremembeSpider(BaseDospSpider):
     TERRITORY_ID = "3554805"
     name = "sp_tremembe"
     code = 5264

--- a/data_collection/gazette/spiders/sp/sp_votuporanga.py
+++ b/data_collection/gazette/spiders/sp/sp_votuporanga.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.dosp import DospGazetteSpider
+from gazette.spiders.base.dosp import BaseDospSpider
 
 
-class SpVotuporangaSpider(DospGazetteSpider):
+class SpVotuporangaSpider(BaseDospSpider):
     TERRITORY_ID = "3557105"
     name = "sp_votuporanga"
     code = 5292

--- a/data_collection/gazette/spiders/to/to_araguaina.py
+++ b/data_collection/gazette/spiders/to/to_araguaina.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.barcodigital import BarcoDigitalSpider
+from gazette.spiders.base.barcodigital import BaseBarcoDigitalSpider
 
 
-class ToAraguainaSpider(BarcoDigitalSpider):
+class ToAraguainaSpider(BaseBarcoDigitalSpider):
     name = "to_araguaina"
     TERRITORY_ID = "1702109"
     allowed_domains = ["api-araguaina.barcodigital.com.br"]

--- a/data_collection/gazette/spiders/to/to_gurupi.py
+++ b/data_collection/gazette/spiders/to/to_gurupi.py
@@ -1,9 +1,9 @@
 import datetime
 
-from gazette.spiders.base.adminlte import AdminLTEGazetteSpider
+from gazette.spiders.base.adminlte import BaseAdminLteSpider
 
 
-class ToGurupiSpider(AdminLTEGazetteSpider):
+class ToGurupiSpider(BaseAdminLteSpider):
     TERRITORY_ID = "1709500"
     name = "to_gurupi"
     allowed_domains = ["diariooficial.gurupi.to.gov.br"]

--- a/data_collection/gazette/spiders/to/to_lagoa_de_tocantins.py
+++ b/data_collection/gazette/spiders/to/to_lagoa_de_tocantins.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.barcodigital import BarcoDigitalSpider
+from gazette.spiders.base.barcodigital import BaseBarcoDigitalSpider
 
 
-class ToLagoaDeTocatinsSpider(BarcoDigitalSpider):
+class ToLagoaDeTocatinsSpider(BaseBarcoDigitalSpider):
     name = "to_lagoa_de_tocantins"
     TERRITORY_ID = "1711951"
     allowed_domains = ["api-lagoadotocantins.barcodigital.com.br"]

--- a/data_collection/gazette/spiders/to/to_recursolandia.py
+++ b/data_collection/gazette/spiders/to/to_recursolandia.py
@@ -1,9 +1,9 @@
 from datetime import date
 
-from gazette.spiders.base.barcodigital import BarcoDigitalSpider
+from gazette.spiders.base.barcodigital import BaseBarcoDigitalSpider
 
 
-class ToRecursolandiaSpider(BarcoDigitalSpider):
+class ToRecursolandiaSpider(BaseBarcoDigitalSpider):
     name = "to_recursolandia"
     TERRITORY_ID = "1718501"
     allowed_domains = ["api-recursolandia.barcodigital.com.br"]


### PR DESCRIPTION
Não havia um padrão para se nomear classes base no repositório, por isso foi sendo adotado 2 versões
- `Base<NOME>Spider`
- `<NOME>GazetteSpider`

Sendo o diretório onde elas ficam chamado `bases/` e a [documentação foi atualizada](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#as-classes-basesistemaspider) oficializando o padrão `BaseSistemaSpider`, esta PR propaga a padronização no código do repositório