### PR TITLE
Adiciona 6 raspadores de #1090

### DIFF
--- a/data_collection/gazette/spiders/to/to_caseara.py
+++ b/data_collection/gazette/spiders/to/to_caseara.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.diariooficialbr import BaseDiarioOficialBRSpider
+
+
+class ToCasearaSpider(BaseDiarioOficialBRSpider):
+    TERRITORY_ID = "1703909"
+    name = "to_caseara"
+    allowed_domains = ["caseara.diariooficial.com.br"]
+    BASE_URL = "https://caseara.diariooficialbr.com.br"
+    start_date = date(2019, 6, 26)

--- a/data_collection/gazette/spiders/to/to_caseara.py
+++ b/data_collection/gazette/spiders/to/to_caseara.py
@@ -6,6 +6,6 @@ from gazette.spiders.base.diariooficialbr import BaseDiarioOficialBRSpider
 class ToCasearaSpider(BaseDiarioOficialBRSpider):
     TERRITORY_ID = "1703909"
     name = "to_caseara"
-    allowed_domains = ["caseara.diariooficial.com.br"]
+    allowed_domains = ["caseara.diariooficialbr.com.br"]
     BASE_URL = "https://caseara.diariooficialbr.com.br"
     start_date = date(2019, 6, 26)

--- a/data_collection/gazette/spiders/to/to_itapiratins.py
+++ b/data_collection/gazette/spiders/to/to_itapiratins.py
@@ -1,0 +1,14 @@
+from datetime import date
+
+from gazette.spiders.base.diariooficialbr import BaseDiarioOficialBRSpider
+
+
+class ToItapiratinsSpider(BaseDiarioOficialBRSpider):
+    TERRITORY_ID = "1710904"
+    name = "to_itapiratins"
+    allowed_domains = ["itapiratins.diariooficialbr.com.br"]
+    BASE_URL = "https://itapiratins.diariooficialbr.com.br"
+    start_date = date(2017, 4, 3)
+    end_date = date(
+        2024, 1, 10
+    )  # Alert: Discontinued this date! (Verified in 2024-09-24)

--- a/data_collection/gazette/spiders/to/to_itapiratins_2017.py
+++ b/data_collection/gazette/spiders/to/to_itapiratins_2017.py
@@ -5,7 +5,7 @@ from gazette.spiders.base.diariooficialbr import BaseDiarioOficialBRSpider
 
 class ToItapiratinsSpider(BaseDiarioOficialBRSpider):
     TERRITORY_ID = "1710904"
-    name = "to_itapiratins"
+    name = "to_itapiratins_2017"
     allowed_domains = ["itapiratins.diariooficialbr.com.br"]
     BASE_URL = "https://itapiratins.diariooficialbr.com.br"
     start_date = date(2017, 4, 3)

--- a/data_collection/gazette/spiders/to/to_miracema.py
+++ b/data_collection/gazette/spiders/to/to_miracema.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.diariooficialbr import BaseDiarioOficialBRSpider
+
+
+class ToMiracemaSpider(BaseDiarioOficialBRSpider):
+    TERRITORY_ID = "1713205"
+    name = "to_miracema"
+    allowed_domains = ["miracema.diariooficialbr.com.br"]
+    BASE_URL = "https://miracema.diariooficialbr.com.br"
+    start_date = date(2023, 1, 16)

--- a/data_collection/gazette/spiders/to/to_muricilandia.py
+++ b/data_collection/gazette/spiders/to/to_muricilandia.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.diariooficialbr import BaseDiarioOficialBRSpider
+
+
+class ToMuricilandiaSpider(BaseDiarioOficialBRSpider):
+    TERRITORY_ID = "1713957"
+    name = "to_muricilandia"
+    allowed_domains = ["muricilandia.diariooficialbr.com.br"]
+    BASE_URL = "https://muricilandia.diariooficialbr.com.br"
+    start_date = date(2019, 7, 2)

--- a/data_collection/gazette/spiders/to/to_santa_fe_do_araguaia.py
+++ b/data_collection/gazette/spiders/to/to_santa_fe_do_araguaia.py
@@ -1,0 +1,15 @@
+from datetime import date
+
+from gazette.spiders.base.diariooficialbr import BaseDiarioOficialBRSpider
+
+
+class ToSantaFedoAraguaiaSpider(
+    BaseDiarioOficialBRSpider
+):  # <= Fix: Remove "/uf" from folder name "uf/uf_city"
+    TERRITORY_ID = "1718865"
+    name = (
+        "to_santa_fe_do_araguaia"  # <= Fix: Remove "/uf" from folder name "uf/uf_city"
+    )
+    allowed_domains = ["santafedoaraguaia.diariooficialbr.com.br"]
+    BASE_URL = "https://santafedoaraguaia.diariooficialbr.com.br"
+    start_date = date(2021, 2, 5)

--- a/data_collection/gazette/spiders/to/to_santa_fe_do_araguaia.py
+++ b/data_collection/gazette/spiders/to/to_santa_fe_do_araguaia.py
@@ -3,13 +3,9 @@ from datetime import date
 from gazette.spiders.base.diariooficialbr import BaseDiarioOficialBRSpider
 
 
-class ToSantaFedoAraguaiaSpider(
-    BaseDiarioOficialBRSpider
-):  # <= Fix: Remove "/uf" from folder name "uf/uf_city"
+class ToSantaFedoAraguaiaSpider(BaseDiarioOficialBRSpider):
     TERRITORY_ID = "1718865"
-    name = (
-        "to_santa_fe_do_araguaia"  # <= Fix: Remove "/uf" from folder name "uf/uf_city"
-    )
+    name = "to_santa_fe_do_araguaia"
     allowed_domains = ["santafedoaraguaia.diariooficialbr.com.br"]
     BASE_URL = "https://santafedoaraguaia.diariooficialbr.com.br"
     start_date = date(2021, 2, 5)

--- a/data_collection/gazette/spiders/to/to_talisma.py
+++ b/data_collection/gazette/spiders/to/to_talisma.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.diariooficialbr import BaseDiarioOficialBRSpider
+
+
+class ToTalismaSpider(BaseDiarioOficialBRSpider):
+    TERRITORY_ID = "1720978"
+    name = "to_talisma"
+    allowed_domains = ["talisma.diariooficialbr.com.br"]
+    BASE_URL = "https://talisma.diariooficialbr.com.br"
+    start_date = date(2020, 1, 2)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [x] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [ ] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário. (Obs.: Apenas to_itapiratins.py fugiu a esse padrão)
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

Adiciona 6 raspadores de municípios replicados a partir do padrão BaseDOBR mencionado na https://github.com/okfn-brasil/querido-diario/issues/1090#issuecomment-2372690577:

Code | City 
-- | -- 
1703909 | Caseara	-	TO 
1710904 | Itapiratins	-	TO 
1713205 | Miracema	-	TO | 
1713957 | Muricilândia	-	TO | 
1718865 | Santa Fé do Araguaia	-	TO | 
1720978 | Talismã	-	TO | 



