### PR TITLE
#1207 Cria spider para Petrópolis RJ

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_petropolis.py
+++ b/data_collection/gazette/spiders/rj/rj_petropolis.py
@@ -1,0 +1,86 @@
+import re
+from datetime import date
+
+import dateparser
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjPetropolis(BaseGazetteSpider):
+    name = "rj_petropolis"
+    TERRITORY_ID = "3303906"
+    allowed_domains = ["petropolis.rj.gov.br"]
+    start_urls = [
+        "https://www.petropolis.rj.gov.br/pmp/index.php/servicos-cidadao/diario-oficial"
+    ]
+    start_date = date(2001, 10, 2)
+
+    def parse(self, response):
+        for a in response.xpath("//div[@class='col-2 text-center']//p/a"):
+            year = int(a.xpath("./text()").get())
+            if self.start_date.year <= year <= self.end_date.year:
+                url = a.xpath("./@href").get()
+                base_url = response.urljoin(url)
+                yield scrapy.Request(
+                    url=base_url,
+                    callback=self.parse_year_month,
+                    cb_kwargs={"year": year},
+                )
+
+    def parse_year_month(self, response, year):
+        for a in response.xpath("//div[@class='col-2 text-center']//p/a"):
+            url = a.xpath("./@href").get()
+            gazette_month_name = a.xpath("./text()").get()
+            gazette_month = dateparser.parse(gazette_month_name).month
+            month_start = self.start_date.replace(day=1)
+            month_end = self.end_date.replace(day=1)
+            month = date(year, gazette_month, 1)
+            if month_start <= month <= month_end:
+                base_url = response.urljoin(url)
+                yield scrapy.Request(
+                    url=base_url,
+                    callback=self.parse_gazette,
+                    cb_kwargs={"year": year, "month": gazette_month},
+                )
+
+    def parse_gazette(self, response, month, year):
+        tr_xpath = "//table[contains(@class, 'tabela-do')]/tbody/tr"
+        for gazette_data in response.xpath(tr_xpath):
+            raw_gazette_name = (
+                gazette_data.xpath("./th/a/text()")
+                .get()
+                .replace("º", "")
+                .replace("°", "")
+            )
+
+            raw_gazette_date = re.search(
+                r"\s(\d{1,2}\s)(.*?\d{4}|/\d{1,2}/\d{2,4})", raw_gazette_name
+            )
+            if raw_gazette_date is None or not raw_gazette_date.group(1):
+                continue
+
+            day = int(raw_gazette_date.group(1))
+            gazette_date = date(year, month, day)
+            if not self.start_date <= gazette_date <= self.end_date:
+                continue
+
+            url_subdir = gazette_data.xpath("./th/a/@href").get()
+            gazette_url = response.urljoin(url_subdir)
+
+            gazette_edition_number = (
+                gazette_data.xpath("./td[1]/p").re_first(r"\d+") or ""
+            )
+
+            is_extra_edition = bool(
+                re.search(r"supl|extra", raw_gazette_name, re.IGNORECASE)
+            )
+
+            yield Gazette(
+                date=gazette_date,
+                edition_number=gazette_edition_number,
+                is_extra_edition=is_extra_edition,
+                file_urls=[gazette_url],
+                power="executive",
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[completa.csv](https://github.com/user-attachments/files/17171363/completa.csv)
[completa.log](https://github.com/user-attachments/files/17171365/completa.log)
[intervalo.csv](https://github.com/user-attachments/files/17171366/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/17171367/intervalo.log)
[ultima.log](https://github.com/user-attachments/files/17171368/ultima.log)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

Resolve https://github.com/okfn-brasil/querido-diario/issues/478
Na raspagem completa, ocorre um erro esperado devido a existência de um diário oficial de 31/01/23 na página de fevereiro do mesmo ano. Como o mesmo também se encontra na página de janeiro, optei por ignorar esse erro.
