### PR TITLE
Al maragogi

### DIFF
--- a/data_collection/gazette/spiders/al/al_maragogi.py
+++ b/data_collection/gazette/spiders/al/al_maragogi.py
@@ -1,0 +1,72 @@
+import re
+from datetime import date, datetime
+
+import scrapy
+from dateutil.rrule import YEARLY, rrule
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class AlMaragogiSpider(BaseGazetteSpider):
+    name = "al_maragogi"
+    TERRITORY_ID = "2704500"
+    allowed_domains = ["maragogi.al.gov.br"]
+    base_url = "https://maragogi.al.gov.br/diarios-oficiais/diario-oficial-"
+    start_urls = ["https://maragogi.al.gov.br/diarios-oficiais/"]
+    start_date = date(2020, 1, 1)
+    end_date = date.today()
+    stop_crawling = False
+
+    def extrair_numero(self, arquivo):
+        match = re.search(r"no-(\d+)-", arquivo)
+        if match:
+            return match.group(1)
+        return None
+
+    def start_requests(self):
+        for date_of_interest in rrule(
+            freq=YEARLY, dtstart=self.start_date, until=self.end_date
+        ):
+            base_url = f"{self.base_url}{date_of_interest.year}/"
+            yield scrapy.Request(url=base_url, callback=self.parse)
+
+    def parse(self, response):
+        if self.stop_crawling:
+            return
+
+        titles = response.css(".arq-list-item-content h1::text").getall()
+        dates = response.css(".data::text").getall()
+
+        for title, data_str in zip(titles, dates):
+            edition_number = self.extrair_numero(title)
+            data_str = data_str.strip()
+
+            try:
+                item_date = datetime.strptime(data_str, "%d/%m/%Y").date()
+            except ValueError:
+                continue
+
+            if item_date < self.start_date:
+                self.stop_crawling = True
+                return
+
+            if title.endswith("."):
+                title = title[:-1]
+
+            if not title.endswith(".pdf"):
+                title += ".pdf"
+
+            file_url = f"https://maragogi.al.gov.br/wp-content/uploads/{item_date.year}/{item_date.month:02d}/{title}"
+
+            yield Gazette(
+                date=item_date,
+                edition_number=edition_number,
+                is_extra_edition=False,
+                file_urls=[file_url],
+                power="executive",
+            )
+
+        next_page = response.css("a.next.page-numbers::attr(href)").get()
+        if next_page:
+            yield scrapy.Request(url=next_page, callback=self.parse)


### PR DESCRIPTION
#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição

Reimplementação do raspador do município de Maragogi AL , anteriormente citado nesta issue https://github.com/okfn-brasil/querido-diario/issues/1176 e feito parcialmente nesta PR https://github.com/okfn-brasil/querido-diario/pull/1186, porém o mesmo ficou muito tempo esperando retorno do desenvolvedor, visto que houve mudanças drásticas no site dos diários oficiais em questão, decidi abrir esta nova PR para facilitar o fluxo de revisão


- Logs e outputs de uma extração completa:
[output-all.log](https://github.com/user-attachments/files/17197804/output-all.log)
[output-all.csv](https://github.com/user-attachments/files/17197805/output-all.csv)

- Logs e outputs de uma extração com data aleatória (2024-05-10 até 2024-08-23):
[output-date.csv](https://github.com/user-attachments/files/17197810/output-date.csv)
[output-date.log](https://github.com/user-attachments/files/17197809/output-date.log)


