### PR TITLE
Cria spider para Maricá RJ

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_marica.py
+++ b/data_collection/gazette/spiders/rj/rj_marica.py
@@ -1,0 +1,74 @@
+import re
+from datetime import date, datetime as dt
+
+import scrapy
+from dateutil.rrule import MONTHLY, rrule, rruleset
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjMaricaSpider(BaseGazetteSpider):
+    TERRITORY_ID = "3302700"
+    name = "rj_marica"
+    allowed_domains = ["marica.rj.gov.br"]
+    start_date = date(2006, 7, 17)
+    BASE_URL = "https://www.marica.rj.gov.br/wp-admin/admin-ajax.php"
+
+    def start_requests(self):
+        monthly_dates = rruleset()
+        monthly_dates.rrule(
+            rrule(MONTHLY, dtstart=self.start_date, until=self.end_date, bymonthday=[1])
+        )
+        monthly_dates.rdate(dt(self.start_date.year, self.start_date.month, 1))
+        for monthly_date in monthly_dates:
+            year = monthly_date.strftime("%Y")
+            month = monthly_date.strftime("%m")
+            for gazette_type in ["jom", "jom-especial"]:
+                yield scrapy.FormRequest(
+                    method="GET",
+                    url=self.BASE_URL,
+                    formdata={
+                        "post_type": gazette_type,
+                        "year": year,
+                        "month": month,
+                        "action": "alm_get_posts",
+                        "posts_per_page": "31",
+                    },
+                )
+
+    def parse(self, response):
+        html = response.json()["html"]
+        if html:
+            gazette_list = html.split("\n\n\n")
+            for gazette_data in gazette_list[:-1]:
+                raw_gazette_date = re.search(r"\d+\/\d+\/\d+", gazette_data).group()
+                gazette_date = dt.strptime(raw_gazette_date, "%d/%m/%Y").date()
+                if not self.start_date <= gazette_date <= self.end_date:
+                    continue
+
+                gazette_edition_number = re.search(
+                    r'title=".*?(\d+)"', gazette_data
+                ).group(1)
+
+                gazette_item = {
+                    "date": gazette_date,
+                    "edition_number": gazette_edition_number,
+                }
+
+                gazette_url = re.search(r'href="(.*?)"', gazette_data).group(1)
+                yield scrapy.Request(
+                    gazette_url,
+                    callback=self.parse_gazette,
+                    cb_kwargs={"gazette_item": gazette_item},
+                )
+
+    def parse_gazette(self, response, gazette_item):
+        gazette_url = response.xpath('//*[@class="vc_btn3-container"]//a/@href').get()
+        if gazette_url is not None:
+            yield Gazette(
+                **gazette_item,
+                file_urls=[gazette_url],
+                power="executive_legislative",
+                is_extra_edition="jom-especial" in response.url
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[completa.csv](https://github.com/user-attachments/files/17195523/completa.csv)
[completa.log](https://github.com/user-attachments/files/17195525/completa.log)
[intervalo.csv](https://github.com/user-attachments/files/17195526/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/17195528/intervalo.log)
[ultima.csv](https://github.com/user-attachments/files/17195529/ultima.csv)
[ultima.log](https://github.com/user-attachments/files/17195530/ultima.log)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição
resolve #1201 
Cria Spider para Maricá já implementado as sugestões da PR #1252 
Um novo PR foi necessário pois não tenho permissão para alterar o repositório da Janaína, que não está mais atuando no projeto.
