### PR TITLE
Realiza atualizações relacionadas aos casos de agregações

### DIFF
--- a/data_collection/gazette/resources/territories.csv
+++ b/data_collection/gazette/resources/territories.csv
@@ -5569,4 +5569,25 @@ id,name,state_code,state
 3557154,Zacarias,SP,São Paulo
 2114007,Zé Doca,MA,Maranhão
 4219853,Zortéa,SC,Santa Catarina
+1100000,Associação Rondoniense de Municípios,RO,Rondônia
+1300000,Associação Amazonense de Municípios,AM,Amazonas
+1400000,Associação dos Municípios de Roraima,RR,Roraima
+1500000,Federação das Associações de Municípios do Estado do Pará,PA,Pará
+2200000,Associação Piauinense de Municípios,PI,Piauí
+2300000,Associação dos Municípios do Estado do Ceará,CE,Ceará
+2400000,Federação dos Municípios do Rio Grande do Norte,RN,Rio Grande do Norte
+2500000,Federação das Associações de Municípios da Paraíba,PB,Paraíba
+2600000,Associação Municipalista de Pernambuco,PE,Pernambuco
 2700000,Associação dos Municípios Alagoanos,AL,Alagoas
+2800000,Associação dos Municípios da Região Centro Sul,SE,Sergipe
+2900000,Associação dos Municípios do Sul, Extremo Sul e Sudoeste da Bahia,BA,Bahia
+3100000,Associação Mineira de Municípios,MG,Minas Gerais
+3200000,Associação dos Municípios do Espírito Santo,ES,Espírito Santo
+3300000,Associação Estadual de Municípios do Rio de Janeiro,RJ,Rio de Janeiro
+3500000,Associação Paulista de Municípios,SP,São Paulo
+4100000,Associação dos Municípios do Paraná,PR,Paraná
+4300000,Federação das Associações de Municípios do Rio Grande do Sul,RS,Rio Grande do Sul
+5000000,Associação dos Municípios de Mato Grosso do Sul,MS,Mato Grosso do Sul
+5100000,Associação Mato-grossense dos Municípios,MT,Mato Grosso
+5200000,Associação Goiana de Municípios,GO,Goiás
+5200001,Federação Goiana de Municípios,GO,Goiás

--- a/data_collection/gazette/spiders/go/go_associacao_municipios.py
+++ b/data_collection/gazette/spiders/go/go_associacao_municipios.py
@@ -2,6 +2,6 @@ from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
 class GoAssociacaoMunicipiosSpider(BaseSigpubSpider):
-    name = "go_associacao_municipios_agm"
+    name = "go_associacao_municipios"
     TERRITORY_ID = "5200000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/agm"

--- a/data_collection/gazette/spiders/go/go_associacao_municipios_fgm.py
+++ b/data_collection/gazette/spiders/go/go_associacao_municipios_fgm.py
@@ -1,7 +1,0 @@
-from gazette.spiders.base.sigpub import BaseSigpubSpider
-
-
-class GoAssociacaoMunicipiosSpider(BaseSigpubSpider):
-    name = "go_associacao_municipios_fgm"
-    TERRITORY_ID = "5200000"
-    CALENDAR_URL = "https://www.diariomunicipal.com.br/fgm"

--- a/data_collection/gazette/spiders/go/go_federacao_municipios.py
+++ b/data_collection/gazette/spiders/go/go_federacao_municipios.py
@@ -1,0 +1,7 @@
+from gazette.spiders.base.sigpub import BaseSigpubSpider
+
+
+class GoFederacaoMunicipiosSpider(BaseSigpubSpider):
+    name = "go_federacao_municipios"
+    TERRITORY_ID = "5200001"
+    CALENDAR_URL = "https://www.diariomunicipal.com.br/fgm"

--- a/data_collection/gazette/spiders/pa/pa_federacao_municipios.py
+++ b/data_collection/gazette/spiders/pa/pa_federacao_municipios.py
@@ -1,7 +1,7 @@
 from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class PaAssociacaoMunicipiosSpider(BaseSigpubSpider):
-    name = "pa_associacao_municipios"
+class PaFederacaoMunicipiosSpider(BaseSigpubSpider):
+    name = "pa_federacao_municipios"
     TERRITORY_ID = "1500000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/famep"

--- a/data_collection/gazette/spiders/pb/pb_federacao_municipios.py
+++ b/data_collection/gazette/spiders/pb/pb_federacao_municipios.py
@@ -1,7 +1,7 @@
 from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class PbAssociacaoMunicipiosSpider(BaseSigpubSpider):
-    name = "pb_associacao_municipios"
+class PbFederacaoMunicipiosSpider(BaseSigpubSpider):
+    name = "pb_federacao_municipios"
     TERRITORY_ID = "2500000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/famup"

--- a/data_collection/gazette/spiders/rn/rn_federacao_municipios.py
+++ b/data_collection/gazette/spiders/rn/rn_federacao_municipios.py
@@ -1,7 +1,7 @@
 from gazette.spiders.base.sigpub import BaseSigpubSpider
 
 
-class RnAssociacaoMunicipiosSpider(BaseSigpubSpider):
-    name = "rn_associacao_municipios"
+class RnFederacaoMunicipiosSpider(BaseSigpubSpider):
+    name = "rn_federacao_municipios"
     TERRITORY_ID = "2400000"
     CALENDAR_URL = "https://www.diariomunicipal.com.br/femurn"


### PR DESCRIPTION
Esta PR... 
- atualiza territories.csv com as IDs para Agregações usados pelos raspadores
- renomeia alguns arquivos para desfazer ambiguidade entre "associação" e "federação" de municípios, visto que um estado pode ter ambos
- No caso dos dois arquivos para Goiás, uma associação e uma federação, troca o Territory_ID de um deles para um novo valor visto que era o mesmo duas vezes