### PR TITLE
sistema replicavel administracaopublica #1247

### DIFF
--- a/data_collection/gazette/spiders/base/administracaopublica.py
+++ b/data_collection/gazette/spiders/base/administracaopublica.py
@@ -1,0 +1,58 @@
+import re
+from datetime import datetime as dt
+
+from dateutil.rrule import DAILY, rrule
+from scrapy import Request
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class BaseAdministracaoPublicaSpider(BaseGazetteSpider):
+    """
+    Base spider for cities using the https://administracaopublica.com.br/diario-oficial?token= plataform.
+    Gazettes are also available in http://www.transparenciadministrativa.com.br/diario/diariov2.xhtml?token=.
+    """
+
+    allowed_domains = ["administracaopublica.com.br"]
+
+    def start_requests(self):
+        dates = list(
+            rrule(freq=DAILY, interval=7, dtstart=self.start_date, until=self.end_date)
+        )
+        dt_end_date = dt(self.end_date.year, self.end_date.month, self.end_date.day)
+        if dt_end_date not in dates:
+            dates.append(dt_end_date)
+
+        for i in range(len(dates) - 1):
+            start = dates[i].strftime("%Y-%m-%d")
+            end = dates[i + 1].strftime("%Y-%m-%d")
+            yield Request(
+                f"https://www.administracaopublica.com.br/diario-oficial?token={self.token}&de={start}&ate={end}"
+            )
+
+    def parse(self, response):
+        gazettes = response.css('[class*="diario_item_diario__"]')
+        for gazette in gazettes:
+            if "Nenhum resultado encontrado" not in response.text:
+                href = gazette.css(
+                    '[class*="generics_button_baixar__"]::attr(href)'
+                ).get()
+                pattern = gazette.css("::text").getall()
+
+                match pattern:
+                    case [edition, _, power, date, _]:
+                        pass
+                    case [edition, _, date, _]:
+                        power = ""
+                power_dict = {
+                    "EXECUTIVO": "executive",
+                    "LEGISLATIVO": "legislative",
+                }
+                yield Gazette(
+                    edition_number=re.search(r"(\d+)[-/]", edition).group(1),
+                    date=dt.strptime(date, "%d/%m/%Y").date(),
+                    file_urls=[f"https://www.administracaopublica.com.br{href}"],
+                    is_extra_edition=power == "EXTRA",
+                    power=power_dict.get(power, "executive_legislative"),
+                )

--- a/data_collection/gazette/spiders/ma/ma_nova_iorque.py
+++ b/data_collection/gazette/spiders/ma/ma_nova_iorque.py
@@ -1,0 +1,10 @@
+import datetime as dt
+
+from gazette.spiders.base.administracaopublica import BaseAdministracaoPublicaSpider
+
+
+class MaNovaIorqueSpider(BaseAdministracaoPublicaSpider):
+    TERRITORY_ID = "2107308"
+    name = "ma_nova_iorque"
+    start_date = dt.date(2017, 2, 15)
+    token = "4f1cf16edf5d73feaad4fec2a03c7c9e1cf536aa"

--- a/data_collection/gazette/spiders/ma/ma_peritoro.py
+++ b/data_collection/gazette/spiders/ma/ma_peritoro.py
@@ -1,11 +1,10 @@
 import datetime as dt
 
-from gazette.spiders.base.aplus import BaseAplusSpider
+from gazette.spiders.base.administracaopublica import BaseAdministracaoPublicaSpider
 
 
-class MaPeritoroSpider(BaseAplusSpider):
+class MaPeritoroSpider(BaseAdministracaoPublicaSpider):
     TERRITORY_ID = "2108454"
     name = "ma_peritoro"
-    start_date = dt.date(2020, 1, 4)
-    allowed_domains = ["peritoro.ma.gov.br"]
-    url_base = "https://www.peritoro.ma.gov.br/diario/"
+    start_date = dt.date(2017, 1, 2)
+    token = "9de645b503b922df799865ffcb07a6ec7b9cb53e"

--- a/data_collection/gazette/spiders/ma/ma_turilandia.py
+++ b/data_collection/gazette/spiders/ma/ma_turilandia.py
@@ -1,0 +1,10 @@
+import datetime as dt
+
+from gazette.spiders.base.administracaopublica import BaseAdministracaoPublicaSpider
+
+
+class MaTurilandiaSpider(BaseAdministracaoPublicaSpider):
+    TERRITORY_ID = "2112456"
+    name = "ma_turilandia"
+    start_date = dt.date(2021, 3, 11)
+    token = "9664abfc624b73571a05e874f98fd6d114834924"


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [X] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [X] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [X] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [X] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [X] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [X] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [X] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

[ma_nova_iorque_arbitrario.csv](https://github.com/user-attachments/files/17263858/ma_nova_iorque_arbitrario.csv)
[ma_nova_iorque_arbitrario.log](https://github.com/user-attachments/files/17263859/ma_nova_iorque_arbitrario.log)
[ma_nova_iorque_completo.csv](https://github.com/user-attachments/files/17263860/ma_nova_iorque_completo.csv)
[ma_nova_iorque_completo.log](https://github.com/user-attachments/files/17263861/ma_nova_iorque_completo.log)
[ma_nova_iorque_mais_recente.log](https://github.com/user-attachments/files/17263862/ma_nova_iorque_mais_recente.log)


#### Descrição

O sistema replicável foi feita através da consulta ao domínio _administracaopublica.com.br_. Neste domínio podemos reutilizar os tokens identificadores do domínio originalmente apresentado na Issue #1247 _transparenciadministrativa.com.br_. Vale ressaltar que o domínio utilizado é disponibilizado na primeira página dos boletins.

Neste novo domínio a consulta ao endereço do arquivo pdf pode ser feita de maneira direta enquanto percorre o site, além de que as alterações de data podem ser feitas diretamente na url consultada.

O raspador consulta os boletins em um intervalo de 20 em 20 dias, correspondendo ao número máximo de boletins a serem mostrados sem navegação em paginação de resultados. Com isso podemos evitar a interação com elementos de renderização dinâmica no site. 
