### PR TITLE
Re-adiciona 2 raspadores de Minas Gerais

### DIFF
--- a/data_collection/gazette/spiders/mg/mg_carmo_do_rio_claro.py
+++ b/data_collection/gazette/spiders/mg/mg_carmo_do_rio_claro.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.instar import BaseInstarSpider
+
+
+class MgCarmoDoRioClaroSpider(BaseInstarSpider):
+    TERRITORY_ID = "3114402"
+    name = "mg_carmo_do_rio_claro"
+    allowed_domains = ["carmodorioclaro.mg.gov.br"]
+    base_url = "https://www.carmodorioclaro.mg.gov.br/portal/diario-oficial"
+    start_date = date(2021, 5, 14)

--- a/data_collection/gazette/spiders/mg/mg_juatuba.py
+++ b/data_collection/gazette/spiders/mg/mg_juatuba.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.instar import BaseInstarSpider
+
+
+class MgJuatubaSpider(BaseInstarSpider):
+    TERRITORY_ID = "3136652"
+    name = "mg_juatuba"
+    allowed_domains = ["juatuba.mg.gov.br"]
+    base_url = "https://www.juatuba.mg.gov.br/portal/diario-oficial"
+    start_date = date(2016, 1, 5)


### PR DESCRIPTION
Devido a um erro no rebase da PR #1281 -- onde foi solicitado que o código de raspadores já existentes no repositório fossem retirado **da PR**, acabei retirando do repositório por engano --, esta PR faz um cherry-pick no commit que havia originalmente adicionado os raspadores no repositório, reintegrando-os. 