### PR TITLE
Feature/to tupirama

### DIFF
--- a/data_collection/gazette/spiders/to/to_tupirama.py
+++ b/data_collection/gazette/spiders/to/to_tupirama.py
@@ -1,0 +1,12 @@
+from datetime import date
+
+from gazette.spiders.base.barcodigital import BaseBarcoDigitalSpider
+
+
+class ToTupiramaSpider(BaseBarcoDigitalSpider):
+    name = "to_tupirama"
+    TERRITORY_ID = "1721257"
+    allowed_domains = ["api-tupirama.barcodigital.com.br"]
+    base_url = "https://api-tupirama.barcodigital.com.br"
+
+    start_date = date(year=2017, month=1, day=1)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [X] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [ X] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [X] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [X] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [X] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-coletados) não encontrando problemas.
- [X] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.
- [X] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#arquivos-auxiliares) não encontrando problemas.

#### Descrição
Esse Pull Request adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão. Neste caso, BARCO.

Resultados dos testes:
[to_tupirama_completa.csv](https://github.com/user-attachments/files/17445499/to_tupirama_completa.csv)
[to_tupirama_completa.log](https://github.com/user-attachments/files/17445500/to_tupirama_completa.log)
[to_tupirama_intervalo.csv](https://github.com/user-attachments/files/17445501/to_tupirama_intervalo.csv)
[to_tupirama_intervalo.log](https://github.com/user-attachments/files/17445502/to_tupirama_intervalo.log)
[to_tupirama_ultima_edicao.log](https://github.com/user-attachments/files/17445503/to_tupirama_ultima_edicao.log)
