### PR TITLE
Adicionado raspadores dos municípios de Aratuipe, Aurelino Leal, Baia…

### DIFF
--- a/data_collection/gazette/spiders/ba/ba_aratuipe.py
+++ b/data_collection/gazette/spiders/ba/ba_aratuipe.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.sai import BaseSaiSpider
+
+
+class BaAratacaSpider(BaseSaiSpider):
+    TERRITORY_ID = "2902302"
+    name = "ba_aratuipe"
+    allowed_domains = ["aratuipe.ba.gov.br"]
+    base_url = "https://www.aratuipe.ba.gov.br"
+    start_date = date(2013, 1, 10)

--- a/data_collection/gazette/spiders/ba/ba_aurelino_leal.py
+++ b/data_collection/gazette/spiders/ba/ba_aurelino_leal.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.sai import BaseSaiSpider
+
+
+class BaAratacaSpider(BaseSaiSpider):
+    TERRITORY_ID = "2902401"
+    name = "ba_aurelino_leal"
+    allowed_domains = ["aurelinoleal.ba.gov.br"]
+    base_url = "https://www.aurelinoleal.ba.gov.br"
+    start_date = date(2008, 3, 29)

--- a/data_collection/gazette/spiders/ba/ba_baianopolis.py
+++ b/data_collection/gazette/spiders/ba/ba_baianopolis.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.sai import BaseSaiSpider
+
+
+class BaAratacaSpider(BaseSaiSpider):
+    TERRITORY_ID = "2902500"
+    name = "ba_baianopolis"
+    allowed_domains = ["sai.io.org.br"]
+    base_url = "https://sai.io.org.br/ba/baianopolis"
+    start_date = date(2017, 1, 17)

--- a/data_collection/gazette/spiders/ba/ba_baixa_grande.py
+++ b/data_collection/gazette/spiders/ba/ba_baixa_grande.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.sai import BaseSaiSpider
+
+
+class BaAratacaSpider(BaseSaiSpider):
+    TERRITORY_ID = "2902609"
+    name = "ba_baixa_grande"
+    allowed_domains = ["baixagrande.ba.gov.br"]
+    base_url = "https://www.baixagrande.ba.gov.br"
+    start_date = date(2010, 1, 15)

--- a/data_collection/gazette/spiders/ba/ba_barra_do_choca.py
+++ b/data_collection/gazette/spiders/ba/ba_barra_do_choca.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.sai import BaseSaiSpider
+
+
+class BaAratacaSpider(BaseSaiSpider):
+    TERRITORY_ID = "2902906"
+    name = "ba_barra_do_choca"
+    allowed_domains = ["sai.io.org.br"]
+    base_url = "https://sai.io.org.br/ba/barradochoca"
+    start_date = date(2009, 1, 5)


### PR DESCRIPTION
…nopolis, Baixa Grande, Barra do Choça

**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [x] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

Issue #1115

[ba_aurelino_leal_completa.csv](https://github.com/user-attachments/files/17549905/ba_aurelino_leal_completa.csv)
[ba_aurelino_leal_completa.log](https://github.com/user-attachments/files/17549906/ba_aurelino_leal_completa.log)
[ba_aurelino_leal_intervalo_coleta.csv](https://github.com/user-attachments/files/17549907/ba_aurelino_leal_intervalo_coleta.csv)
[ba_aurelino_leal_intervalo_coleta.log](https://github.com/user-attachments/files/17549908/ba_aurelino_leal_intervalo_coleta.log)
[ba_aurelino_leal_ultima_coleta.csv](https://github.com/user-attachments/files/17549909/ba_aurelino_leal_ultima_coleta.csv)
[ba_aurelino_leal_ultima_coleta.log](https://github.com/user-attachments/files/17549910/ba_aurelino_leal_ultima_coleta.log)
[ba_baianopolis_completa.csv](https://github.com/user-attachments/files/17549911/ba_baianopolis_completa.csv)
[ba_baianopolis_completa.log](https://github.com/user-attachments/files/17549912/ba_baianopolis_completa.log)
[ba_baianopolis_intervalo_coleta.csv](https://github.com/user-attachments/files/17549914/ba_baianopolis_intervalo_coleta.csv)
[ba_baianopolis_intervalo_coleta.log](https://github.com/user-attachments/files/17549915/ba_baianopolis_intervalo_coleta.log)
[ba_baianopolis_ultima_coleta.csv](https://github.com/user-attachments/files/17549916/ba_baianopolis_ultima_coleta.csv)
[ba_baianopolis_ultima_coleta.log](https://github.com/user-attachments/files/17549917/ba_baianopolis_ultima_coleta.log)
[ba_baixa_grande_completa.csv](https://github.com/user-attachments/files/17549918/ba_baixa_grande_completa.csv)
[ba_baixa_grande_completa.log](https://github.com/user-attachments/files/17549919/ba_baixa_grande_completa.log)
[ba_baixa_grande_intervalo_coleta.csv](https://github.com/user-attachments/files/17549921/ba_baixa_grande_intervalo_coleta.csv)
[ba_baixa_grande_intervalo_coleta.log](https://github.com/user-attachments/files/17549922/ba_baixa_grande_intervalo_coleta.log)
[ba_baixa_grande_ultima_coleta.csv](https://github.com/user-attachments/files/17549923/ba_baixa_grande_ultima_coleta.csv)
[ba_baixa_grande_ultima_coleta.log](https://github.com/user-attachments/files/17549924/ba_baixa_grande_ultima_coleta.log)
[ba_barra_do_choca_completa.csv](https://github.com/user-attachments/files/17549925/ba_barra_do_choca_completa.csv)
[ba_barra_do_choca_completa.log](https://github.com/user-attachments/files/17549926/ba_barra_do_choca_completa.log)
[ba_barra_do_choca_intervalo_coleta.csv](https://github.com/user-attachments/files/17549927/ba_barra_do_choca_intervalo_coleta.csv)
[ba_barra_do_choca_intervalo_coleta.log](https://github.com/user-attachments/files/17549928/ba_barra_do_choca_intervalo_coleta.log)
[ba_barra_do_choca_ultima_coleta.csv](https://github.com/user-attachments/files/17549929/ba_barra_do_choca_ultima_coleta.csv)
[ba_barra_do_choca_ultima_coleta.log](https://github.com/user-attachments/files/17549930/ba_barra_do_choca_ultima_coleta.log)
[ba_aratuipe_completa.csv](https://github.com/user-attachments/files/17549931/ba_aratuipe_completa.csv)
[ba_aratuipe_completa.log](https://github.com/user-attachments/files/17549932/ba_aratuipe_completa.log)
[ba_aratuipe_intervalo_coleta.csv](https://github.com/user-attachments/files/17549933/ba_aratuipe_intervalo_coleta.csv)
[ba_aratuipe_intervalo_coleta.log](https://github.com/user-attachments/files/17549934/ba_aratuipe_intervalo_coleta.log)
[ba_aratuipe_ultima_coleta.csv](https://github.com/user-attachments/files/17549935/ba_aratuipe_ultima_coleta.csv)
[ba_aratuipe_ultima_coleta.log](https://github.com/user-attachments/files/17549936/ba_aratuipe_ultima_coleta.log)
