### PR TITLE
Adiciona verificação de presenta de allowed_domains em BaseGazetteSpider

### DIFF
--- a/data_collection/gazette/spiders/base/__init__.py
+++ b/data_collection/gazette/spiders/base/__init__.py
@@ -19,7 +19,10 @@ class BaseGazetteSpider(scrapy.Spider):
 
         if not hasattr(self, "TERRITORY_ID"):
             raise NotConfigured("Please set a value for `TERRITORY_ID`")
-
+        
+        if not hasattr(self, "allowed_domains"):
+            raise NotConfigured("Please set a value for `allowed_domains`)
+        
         if start_date:
             try:
                 self.start_date = datetime.strptime(start_date, "%Y-%m-%d").date()


### PR DESCRIPTION
A issue #1314 me fez perceber que estamos deixando passar a verificação da presença desse atributo nas verificações de BaseGazetteSpider. Esta PR incrementa isso na base.

Além disso, estou verificando quais raspadores serão impactados. Estou executando a coleta dos ultimos 3 dias para todos os raspadores do repositório (`scrapy list`) a partir do incremento da branch, e os raspadores que precisam ser corrigidos são: 

- [ ] Please set a value for `allowed_domains` in al_associacao_municipios
- [ ] Please set a value for `allowed_domains` in al_maceio
- [ ] Please set a value for `allowed_domains` in am_associacao_municipios
- [ ] Please set a value for `allowed_domains` in ba_associacao_municipios
- [ ] Please set a value for `allowed_domains` in ce_associacao_municipios
- [ ] Please set a value for `allowed_domains` in ce_sobral
- [ ] Please set a value for `allowed_domains` in df_brasilia
- [ ] Please set a value for `allowed_domains` in es_cariacica
- [ ] Please set a value for `allowed_domains` in go_associacao_municipios
- [ ] Please set a value for `allowed_domains` in go_federacao_municipios
- [ ] Please set a value for `allowed_domains` in mg_associacao_municipios
- [ ] Please set a value for `allowed_domains` in mg_uberaba_2003
- [ ] Please set a value for `allowed_domains` in ms_associacao_municipios
- [ ] Please set a value for `allowed_domains` in mt_associacao_municipios
- [ ] Please set a value for `allowed_domains` in pa_federacao_municipios
- [ ] Please set a value for `allowed_domains` in pb_federacao_municipios
- [ ] Please set a value for `allowed_domains` in pb_joao_pessoa
- [ ] Please set a value for `allowed_domains` in pe_associacao_municipios
- [ ] Please set a value for `allowed_domains` in pi_associacao_municipios
- [ ] Please set a value for `allowed_domains` in pr_associacao_municipios
- [ ] Please set a value for `allowed_domains` in pr_curitiba
- demais em breve