### PR TITLE
Hotfix: Adapting Spider [df_brasilia] to Changes in the DODF Website/API

### DIFF
--- a/data_collection/gazette/spiders/df/df_brasilia.py
+++ b/data_collection/gazette/spiders/df/df_brasilia.py
@@ -1,10 +1,10 @@
 import datetime
 import re
+from urllib.parse import parse_qs, unquote, urlparse
 
+import dateutil.parser
 from dateparser import parse
 from dateutil.rrule import MONTHLY, rrule
-import dateutil.parser
-from urllib.parse import urlparse,parse_qs,unquote
 from scrapy import Request
 
 from gazette.items import Gazette
@@ -38,7 +38,7 @@ class DfBrasiliaSpider(BaseGazetteSpider):
     name = "df_brasilia"
     allowed_domains = ["dodf.df.gov.br"]
     start_date = datetime.date(1967, 12, 25)
-    
+
     BASE_URL = "https://dodf.df.gov.br/dodf/jornal/pastas"
 
     def start_requests(self):
@@ -61,13 +61,15 @@ class DfBrasiliaSpider(BaseGazetteSpider):
         month, year = response.meta["month"], response.meta["year"]
         gazette_days = response.css(".lista-arquivos a::attr(href)").getall()
         for url in gazette_days:
-            date = unquote(url.split('/')[-1])
+            date = unquote(url.split("/")[-1])
 
             if date is None:
                 continue
 
             try:
-                date_parsed = dateutil.parser.parse(date, dayfirst=True).date() #.strftime('%d-%m-%Y') 
+                date_parsed = dateutil.parser.parse(
+                    date, dayfirst=True
+                ).date()  # .strftime('%d-%m-%Y')
                 valid_date = True
             except dateutil.parser._parser.ParserError as ex:
                 date_parsed = ex
@@ -79,13 +81,15 @@ class DfBrasiliaSpider(BaseGazetteSpider):
                 if date < self.start_date:
                     continue
 
-                yield Request(url, meta={"date_route":date_parsed}, callback=self.parse_gazette)
+                yield Request(
+                    url, meta={"date_route": date_parsed}, callback=self.parse_gazette
+                )
 
     def parse_gazette(self, response):
         """Parses list of documents to request each one for the date."""
         DATE_REGEX = r"[0-9]{2}-[0-9]{2}[ -][0-9]{2,4}"
         PDF_URL = "https://dodf.df.gov.br/dodf/jornal/visualizar-pdf?{}"
-        
+
         gazette_editions = response.css(".lista-arquivos a::attr(href)").getall()
         if not gazette_editions:
             self.logger.warning(f"Document not found in {response.url}")
@@ -93,18 +97,19 @@ class DfBrasiliaSpider(BaseGazetteSpider):
 
         for url_edition in gazette_editions:
             query_edition = urlparse(url_edition).query
-            pdfname = parse_qs(query_edition)['arquivo'][0]
+            pdfname = parse_qs(query_edition)["arquivo"][0]
             try:
                 date_pdfname = re.search(DATE_REGEX, pdfname).group()
                 date_parsed = parse(date_pdfname, settings={"DATE_ORDER": "DMY"}).date()
             except:
                 date_parsed = response.meta["date_route"]
 
-            edition_number = [chunck for chunck in pdfname.split(' ') if chunck.isnumeric()][0]
+            edition_number = [
+                chunck for chunck in pdfname.split(" ") if chunck.isnumeric()
+            ][0]
             is_extra_edition = "EXTRA" in pdfname
             is_supplement_edition = "SUPLEMENTO" in pdfname
             file_urls = [PDF_URL.format(query_edition)]
-
 
             yield Gazette(
                 date=date_parsed,
@@ -112,5 +117,5 @@ class DfBrasiliaSpider(BaseGazetteSpider):
                 is_extra_edition=is_extra_edition,
                 s_supplement_edition=s_supplement_edition,
                 power="executive",
-                file_urls=file_urls
+                file_urls=file_urls,
             )


### PR DESCRIPTION
## Checklist

**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [ ] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

##
### Descrição

Tenho uma app que fiz em 2022 antes de conhecer o QD pra coletar a edições diárias do [DODF](https://www.dodf.df.gov.br/) em versão JSON e monitorar as publicações do meu interesse a partir de palavras chaves. Há alguns meses atrás recebi notificações do GitHub Actions de que as requisições app estavam falhando, mas como estava sem tempo naquele momento deixei pra verificar depois. Retomando agora, identifiquei qual era o problema no meu app e percebi que poderia utilizar isso pra contribuir com o QD também.

Em Outubro/2024 o site do DODF foi atualizado pra nova versão, com a alteração alteração da UX/UI resultando também na alteração das URLs (routes) e forma de consulta as edições. A alteração do DODF está fazendo a execução do spider [df_brasilia.py] resultar em falhas desde o dia 02/10/2024, deixando de fazer a coleta diária de novas edições. Em decorrência disso, os logs de `PRODUÇÃO` apontam falhas e nenhuma edição coletada desde 02/10/2024, de acordo com o bot de _monitoramento_ do Discord e consultas a API Pública do QD.

Está PR propõe entrega a correções e adaptações necessárias no código do spider `df_brasilia` pra lidar com a nova lógica do site do [DODF](https://www.dodf.df.gov.br/). , além de pequenos ajustes de melhoria para entrega dos fields `edition_number` e adequação do `power` a realidade local.

De forma geral, a lógica de coleta do spider foi mantida, sendo a principal alteração se deu na forma de descoberta das URLs dos PDFs e metadados vinculados. Anteriormente, a descoberta dava-se por requisição "direta" a rota (desativada) da API do DF. A API parece continuar existindo em rotas e lógica diferente que demandariam tempo e esforço pra descoberta, portanto, a solução apresentada trabalha com a lógica normal de "raspagem" simulado o comportamento do UX. Assim, ao invés de "tratar" o JSON da antiga API, o `parse_gazette` foi apenas adaptado pra descobrir e extrair as URLs do PDFs e os metadados dentro HTML das páginas processadas.

Os testes realizados com código do PR foram exitosos e consistentes, entretanto, em razão da longa data de existência do DODF (desde 1967) e, portanto, da quantidade de edições disponíveis não foi realizada uma coleta `COMPLETA` de todas edições. Neste caso, específico ela foi substituída por uma coleta simples a partir de SETEMBRO de 2024, apenas pra verificar se nova lógica se aplicava a edições anteriores as mudanças no site do [DODF](https://www.dodf.df.gov.br/). 

Como é possível verificar no levantamento abaixo, essa nova configuração permitiu a descoberta de 22.811 `file_urls`, que filtradas por `editions_number` aponta para 14.648 edições do DODF, ou seja, o teste de coleta `COMPLETA` iria levar umas belas.

```
2024 => (336/336) => [uniques_editions] => (321) [noextra] => 231 [isextra] => 90
2023 => (350/350) => [uniques_editions] => (331) [noextra] => 242 [isextra] => 89
2022 => (354/354) => [uniques_editions] => (341) [noextra] => 242 [isextra] => 99
2021 => (375/375) => [uniques_editions] => (355) [noextra] => 245 [isextra] => 110
2020 => (441/441) => [uniques_editions] => (397) [noextra] => 246 [isextra] => 151
2019 => (420/420) => [uniques_editions] => (343) [noextra] => 250 [isextra] => 93
2018 => (359/359) => [uniques_editions] => (341) [noextra] => 247 [isextra] => 94
2017 => (336/336) => [uniques_editions] => (302) [noextra] => 248 [isextra] => 54
2016 => (768/768) => [uniques_editions] => (288) [noextra] => 243 [isextra] => 45
2015 => (826/826) => [uniques_editions] => (300) [noextra] => 252 [isextra] => 48
2014 => (836/836) => [uniques_editions] => (274) [noextra] => 246 [isextra] => 28
2013 => (796/796) => [uniques_editions] => (280) [noextra] => 249 [isextra] => 31
2012 => (776/776) => [uniques_editions] => (263) [noextra] => 243 [isextra] => 20
2011 => (755/755) => [uniques_editions] => (253) [noextra] => 251 [isextra] => 2
2010 => (741/741) => [uniques_editions] => (250) [noextra] => 242 [isextra] => 8
2009 => (777/777) => [uniques_editions] => (253) [noextra] => 248 [isextra] => 5
2008 => (787/787) => [uniques_editions] => (259) [noextra] => 251 [isextra] => 8
2007 => (748/748) => [uniques_editions] => (249) [noextra] => 248 [isextra] => 1
2006 => (776/776) => [uniques_editions] => (257) [noextra] => 247 [isextra] => 10
2005 => (754/754) => [uniques_editions] => (253) [noextra] => 247 [isextra] => 6
2004 => (752/752) => [uniques_editions] => (249) [noextra] => 249 [isextra] => 0
2003 => (773/773) => [uniques_editions] => (251) [noextra] => 249 [isextra] => 2
2002 => (729/729) => [uniques_editions] => (244) [noextra] => 242 [isextra] => 2
2001 => (371/371) => [uniques_editions] => (250) [noextra] => 248 [isextra] => 2
2000 => (259/259) => [uniques_editions] => (252) [noextra] => 247 [isextra] => 5
1999 => (261/261) => [uniques_editions] => (259) [noextra] => 250 [isextra] => 9
1998 => (252/252) => [uniques_editions] => (252) [noextra] => 249 [isextra] => 3
1997 => (260/260) => [uniques_editions] => (258) [noextra] => 252 [isextra] => 6
1996 => (259/259) => [uniques_editions] => (256) [noextra] => 254 [isextra] => 2
1995 => (256/256) => [uniques_editions] => (250) [noextra] => 247 [isextra] => 3
1994 => (263/263) => [uniques_editions] => (252) [noextra] => 252 [isextra] => 0
1993 => (279/279) => [uniques_editions] => (262) [noextra] => 261 [isextra] => 1
1992 => (266/266) => [uniques_editions] => (263) [noextra] => 259 [isextra] => 4
1991 => (271/271) => [uniques_editions] => (261) [noextra] => 259 [isextra] => 2
1990 => (268/268) => [uniques_editions] => (253) [noextra] => 253 [isextra] => 0
1989 => (252/252) => [uniques_editions] => (246) [noextra] => 246 [isextra] => 0
1988 => (252/252) => [uniques_editions] => (246) [noextra] => 246 [isextra] => 0
1987 => (246/246) => [uniques_editions] => (246) [noextra] => 246 [isextra] => 0
1986 => (253/253) => [uniques_editions] => (249) [noextra] => 249 [isextra] => 0
1985 => (249/249) => [uniques_editions] => (249) [noextra] => 249 [isextra] => 0
1984 => (252/252) => [uniques_editions] => (250) [noextra] => 250 [isextra] => 0
1983 => (250/250) => [uniques_editions] => (248) [noextra] => 248 [isextra] => 0
1982 => (253/253) => [uniques_editions] => (247) [noextra] => 247 [isextra] => 0
1981 => (288/288) => [uniques_editions] => (246) [noextra] => 246 [isextra] => 0
1980 => (249/249) => [uniques_editions] => (247) [noextra] => 247 [isextra] => 0
1979 => (252/252) => [uniques_editions] => (247) [noextra] => 247 [isextra] => 0
1978 => (249/249) => [uniques_editions] => (246) [noextra] => 246 [isextra] => 0
1977 => (246/246) => [uniques_editions] => (240) [noextra] => 240 [isextra] => 0
1976 => (153/153) => [uniques_editions] => (152) [noextra] => 151 [isextra] => 1
1975 => (202/202) => [uniques_editions] => (190) [noextra] => 190 [isextra] => 0
1974 => (199/199) => [uniques_editions] => (198) [noextra] => 198 [isextra] => 0
1973 => (190/190) => [uniques_editions] => (189) [noextra] => 189 [isextra] => 0
1972 => (193/193) => [uniques_editions] => (192) [noextra] => 192 [isextra] => 0
1971 => (213/213) => [uniques_editions] => (201) [noextra] => 201 [isextra] => 0
1970 => (199/199) => [uniques_editions] => (195) [noextra] => 195 [isextra] => 0
1969 => (205/205) => [uniques_editions] => (198) [noextra] => 198 [isextra] => 0
1968 => (202/202) => [uniques_editions] => (200) [noextra] => 200 [isextra] => 0
1967 => (4/4) => [uniques_editions] => (4) [noextra] => 4 [isextra] => 0
====================================================================================================
 TOTAL => (22881/22881) => [uniques_editions] => (14648) [noextra] => 13614 [isextra] => 1034
```
Enfim, gostaria muito que o PR revisado, aprovado e as correções implementadas em produção, pois pretendo migrar minha aplicação para consumir o retorno servido pela API do QD.


##
### Log Files (Tests)

[df_brasilia_full_20240901_20241129.log](https://github.com/user-attachments/files/18031402/df_brasilia_full_20240901_20241129.log)
[df_brasilia_full_20240901_20241129v2.log](https://github.com/user-attachments/files/18031403/df_brasilia_full_20240901_20241129v2.log)
[df_brasilia_last_20241129.csv](https://github.com/user-attachments/files/18031405/df_brasilia_last_20241129.csv)
[df_brasilia_last_20241129.log](https://github.com/user-attachments/files/18031406/df_brasilia_last_20241129.log)
[df_brasilia_between_20240901_20241004.csv](https://github.com/user-attachments/files/18031407/df_brasilia_between_20240901_20241004.csv)
[df_brasilia_between_20240901_20241004.log](https://github.com/user-attachments/files/18031408/df_brasilia_between_20240901_20241004.log)
[df_brasilia_full_20240901_20241129.csv](https://github.com/user-attachments/files/18031409/df_brasilia_full_20240901_20241129.csv)


##
### Log Summary (Tests)

```
==============================================
 RESULT iCAL => SINGLE (df_brasilia)
==============================================
URL: https://dodf.df.gov.br/dodf/jornal/pastas
Site | Editions: 14648 | Estimate Duration: 4:04:08
Site | Start_Date: 1967-12-25 <=> 1967-12-25 [Spider] = TRUE ✅
Site | End_Date: 2024-11-29
Duration: 00:00:00 (iCAL
============================================
 RESULT TEST => LAST_20241129 (df_brasilia)
============================================
params => ['-a', 'start_date=2024-11-29']
 'item_scraped_count': 2,
 'log_count/DEBUG': 12,
 'log_count/INFO': 34,
 'log_count/WARNING': 1,
Duration: 00:00:04 (LAST)
========================================================
 RESULT TEST => BETWEEN_20240901_20241004 (df_brasilia)
========================================================
params => ['-a', 'start_date=2024-09-01', '-a', 'end_date=2024-10-04']
 'item_scraped_count': 66,
 'log_count/DEBUG': 259,
 'log_count/INFO': 34,
 'log_count/WARNING': 7,
Duration: 00:00:23 (BETWEEN)
=====================================================
 RESULT TEST => FULL_20240901_20241129 (df_brasilia)
=====================================================
params => ['-a', 'start_date=2024-09-01', '-a', 'end_date=2024-11-29']
 'item_scraped_count': 96,
 'log_count/DEBUG': 325,
 'log_count/INFO': 34,
 'log_count/WARNING': 1,
Duration: 00:00:15 (FULL)
======================
 SUM UP (df_brasilia)
======================
Collected Editions (BETWEEN) => 40 
Collected Editions (FULL) => 96
Duration: 00:00:00 (Check CSV/FULL)
```