### PR TITLE
Spyder sao joao do triunfo

### DIFF
--- a/data_collection/gazette/spiders/pr/pr_sao_joao_do_triunfo.py
+++ b/data_collection/gazette/spiders/pr/pr_sao_joao_do_triunfo.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from gazette.spiders.base.instar import BaseInstarSpider
+
+
+class PrSaoJoaoDoTriunfoSpider(BaseInstarSpider):
+    TERRITORY_ID = "4125100"
+    name = "pr_sao_joao_do_triunfo"
+    allowed_domains = ["sjtriunfo.pr.gov.br"]
+    base_url = "https://www.sjtriunfo.pr.gov.br/portal/diario-oficial"
+    start_date = date(2013, 4, 10)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [x] É um *layout* padrão e todos os municípios adicionados usam a [BaseInstarSpider](https://github.com/okfn-brasil/querido-diario/blob/main/data_collection/gazette/spiders/base/instar.py) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
[LAST.txt](https://github.com/user-attachments/files/18085996/LAST.txt)

- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
[INTERVAL_LOG.txt](https://github.com/user-attachments/files/18085792/INTERVAL_LOG.txt)
[INTERVAL_LOG.csv](https://github.com/user-attachments/files/18085984/INTERVAL_LOG.csv)

- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[COMPLETE_LOG.txt](https://github.com/user-attachments/files/18086008/COMPLETE_LOG.txt)
[COMPLETE_LOG.csv](https://github.com/user-attachments/files/18086011/COMPLETE_LOG.csv)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição
Raspador para a cidade de São João do Triunfo - PR
