### PR TITLE
Cria spider para Duque de Caxias RJ no padrão atual do projeto

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_duque_de_caxias.py
+++ b/data_collection/gazette/spiders/rj/rj_duque_de_caxias.py
@@ -1,0 +1,57 @@
+import re
+from datetime import date, datetime
+
+from scrapy import Request
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+from gazette.utils.dates import yearly_sequence
+from gazette.utils.extraction import get_date_from_text
+
+
+class RjDuqueDeCaxiasSpider(BaseGazetteSpider):
+    name = "rj_duque_de_caxias"
+    TERRITORY_ID = "3301702"
+    allowed_domains = ["duquedecaxias.rj.gov.br"]
+    start_date = date(2017, 1, 2)
+
+    def start_requests(self):
+        current_year = datetime.today().year
+        for year in yearly_sequence(self.start_date, self.end_date):
+            if year == current_year:
+                yield Request(
+                    "https://duquedecaxias.rj.gov.br/portal/boletim-oficial.html"
+                )
+            else:
+                yield Request(f"https://duquedecaxias.rj.gov.br/portal/{year}.html")
+
+    def parse(self, response):
+        pdf_divs = response.xpath(
+            "//i[contains(@class, 'fa-file-pdf')]/ancestor::div[1]"
+        )
+        # use descending order to reduce iterations in the daily crawl
+        for pdf_div in pdf_divs[::-1]:
+            raw_gazette_date = pdf_div.xpath("./preceding-sibling::div[1]/text()").get()
+            gazette_date = get_date_from_text(raw_gazette_date)
+            if not gazette_date or gazette_date > self.end_date:
+                continue
+            if gazette_date < self.start_date:
+                return
+
+            raw_gazette_edtion = pdf_div.xpath("./preceding-sibling::div[2]/text()")
+            is_extra_edition = bool(
+                re.search(r"extra|esp", raw_gazette_edtion.get(), re.IGNORECASE)
+            )
+            edition_number = (
+                None if is_extra_edition else raw_gazette_edtion.re_first(r"\d+")
+            )
+
+            gazette_url = response.urljoin(pdf_div.xpath(".//a/@href").get())
+
+            yield Gazette(
+                date=gazette_date,
+                edition_number=edition_number,
+                is_extra_edition=is_extra_edition,
+                file_urls=[gazette_url],
+                power="executive_legislative",
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[completa.csv](https://github.com/user-attachments/files/18140374/completa.csv)
[completa.log](https://github.com/user-attachments/files/18140375/completa.log)
[intervalo.csv](https://github.com/user-attachments/files/18140376/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/18140377/intervalo.log)
[ultima.csv](https://github.com/user-attachments/files/18140378/ultima.csv)
[ultima.log](https://github.com/user-attachments/files/18140379/ultima.log)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

Resolve #616 

Atualiza o código do PR #705 para o padrão atual do projeto, coletando todos os atributos do gazette.

Obs. Foi utilizada a data inicial de 02/01/2017, pois as versões anteriores não disponibilizam a data da edição. Os diários anteriores a 2017 exibem apenas a data de modificação do arquivo, que não tem relação com a data de publicação do diário.

Obs2. Revisar esse PR anrtes do #1323, pois se for integrada a função extract_date no utils, eu modificarei o código do spider de Campos-RJ para usar o método do utils.

Adiciona a função extract_date no utils do projeto para fazer o parse das datas escritas por extenso, corrigindo eventuais erros de digitação no mês.

O código utiliza a biblioteca fuzzywuzzy, que usa o algoritmo de distância Levenshtein para medir a semelhança entre duas strings e, a partir da lista de meses, selecionar o mês com a grafia correta antes de fazer o dateparser.

Para usar o fuzzywuzzy, é necessário instalar 2 bibliotecas ao projeto: **fuzzywuzzy** e **python-Levenshtein**
