### PR TITLE
Adiciona Spider para Japeri-RJ

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_japeri.py
+++ b/data_collection/gazette/spiders/rj/rj_japeri.py
@@ -1,0 +1,28 @@
+from datetime import date
+
+import dateparser
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjJaperiSpider(BaseGazetteSpider):
+    TERRITORY_ID = "3302270"
+    name = "rj_japeri"
+    allowed_domains = ["pmjaperi.geosiap.net.br"]
+    start_date = date(2019, 7, 22)
+    start_urls = [
+        "https://pmjaperi.geosiap.net.br/portal-transparencia/api/default/publicacoes/publicacoes"
+    ]
+
+    def parse(self, response):
+        for item in response.json()["publicacoes"]:
+            if item["ds_publicacao_tipo"] != "DIÁRIO OFICIAL":
+                continue
+            date = dateparser.parse(
+                item["dt_publicacao_formatado"], languages=["pt"]
+            ).date()
+            url = f"https://pmjaperi.geosiap.net.br/portal-transparencia/api/default/publicacoes/get_arquivo?id_publicacao={item['id_publicacao']}"
+            yield Gazette(
+                date=date, file_urls=[url], is_extra_edition=False, power="executive"
+            )


### PR DESCRIPTION
#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [X] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [X] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [X] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [X] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [X] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

[completo.csv](https://github.com/user-attachments/files/18325591/completo.csv)
[completo.log](https://github.com/user-attachments/files/18325593/completo.log)
[intervalo.csv](https://github.com/user-attachments/files/18325594/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/18325595/intervalo.log)
[ultima.csv](https://github.com/user-attachments/files/18325596/ultima.csv)
[ultima.log](https://github.com/user-attachments/files/18325597/ultima.log)


#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [X] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [X] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

Implementa spider para Japeri-RJ

Resolve #1218
