### PR TITLE
Habilita smartproxy para Campinas-SP

### DIFF
--- a/data_collection/gazette/spiders/sp/sp_campinas.py
+++ b/data_collection/gazette/spiders/sp/sp_campinas.py
@@ -8,6 +8,8 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class SpCampinasSpider(BaseGazetteSpider):
+    zyte_smartproxy_enabled = True
+
     TERRITORY_ID = "3509502"
     name = "sp_campinas"
     allowed_domains = ["campinas.sp.gov.br"]


### PR DESCRIPTION
O site não mudou, mas o raspador estava sem coletar edições desde 6/dez/24, sem fazer nenhuma requisição em produção. 