### PR TITLE
Atualiza base modernização para dar manutenção no raspador de Belford Roxo-RJ

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_belford_roxo.py
+++ b/data_collection/gazette/spiders/rj/rj_belford_roxo.py
@@ -9,3 +9,5 @@ class RjBelfordRoxoSpider(BaseModernizacaoSpider):
     allowed_domains = ["transparencia.prefeituradebelfordroxo.rj.gov.br"]
     start_date = date(2019, 1, 2)
     power = "executive"
+    edition_endpoint = "WEB-ObterAnexomaior.rule"
+    filter_endpoint = "diario_oficial_getmaior"


### PR DESCRIPTION
O serviço modernização parece permitir que as prefeituras escolham entre algumas opções de seção do site onde adicionar os diários oficiais

No geral, os municipios dos raspadores derivados de BaseModernizacao que estão no repositório usam a aba "Diário Oficial do Município" para publicar diários - é o caso de Mesquita-RJ: https://transparencia.mesquita.rj.gov.br/
![image](https://github.com/user-attachments/assets/90079ab7-1e4e-4f24-828c-a201019f2f46)

Já Belford Roxo-RJ passou a usar a seção "Diário Oficial Grande Circulação" - https://transparencia.prefeituradebelfordroxo.rj.gov.br/
![image](https://github.com/user-attachments/assets/5abbeec4-59f4-44c7-8431-135fdbcb4289)

Como layout da página e os campos de acesso oferecidos continuam iguais (ou seja, o parse() segue relevante para ambos os casos) a base foi atualizada para permitir acesso ao outro endpoint, não demandando uma base nova e independente apenas para Belford Roxo-RJ 

Esta PR resolve o problema de manutenção de #1346, testando a alteração para Belford Roxo e Mesquita-RJ, ambos funcionais:

[rj_mesquita.log](https://github.com/user-attachments/files/18354580/rj_mesquita.log)
[rj_mesquita.csv](https://github.com/user-attachments/files/18354581/rj_mesquita.csv)
[rj_belford_roxo.log](https://github.com/user-attachments/files/18354582/rj_belford_roxo.log)
[rj_belford_roxo.csv](https://github.com/user-attachments/files/18354583/rj_belford_roxo.csv)

closes #1346