### PR TITLE
Adiciona novo raspador para Florianópolis-SC e atualiza antigo

### DIFF
--- a/data_collection/gazette/spiders/sc/sc_florianopolis_2009.py
+++ b/data_collection/gazette/spiders/sc/sc_florianopolis_2009.py
@@ -10,7 +10,7 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class ScFlorianopolisSpider(BaseGazetteSpider):
-    name = "sc_florianopolis"
+    name = "sc_florianopolis_2009"
     TERRITORY_ID = "4205407"
     start_date = date(2009, 6, 1)
 
@@ -24,7 +24,7 @@ class ScFlorianopolisSpider(BaseGazetteSpider):
         for year, month in periods_of_interest:
             data = dict(ano=str(year), mes=str(month), passo="1", enviar="")
             yield FormRequest(
-                "https://www.pmf.sc.gov.br/governo/index.php?pagina=govdiariooficial",
+                "https://www.pmf.sc.gov.br/governo/index.php?pagina=govdiarioantigo",
                 formdata=data,
             )
 

--- a/data_collection/gazette/spiders/sc/sc_florianopolis_2024.py
+++ b/data_collection/gazette/spiders/sc/sc_florianopolis_2024.py
@@ -1,0 +1,49 @@
+from datetime import date, datetime
+
+from scrapy import FormRequest
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class ScFlorianopolisSpider(BaseGazetteSpider):
+    name = "sc_florianopolis_2024"
+    TERRITORY_ID = "4205407"
+    start_date = date(2024, 8, 5)
+    allowed_domains = ["edicao.dom.sc.gov.br"]
+
+    def _requests(self, page):
+        formdata = {
+            "Edicao[cod_municipio]": "146",
+            "Edicao_page": str(page),
+            "r": "site/edicoes",
+        }
+        return FormRequest(
+            url="https://edicao.dom.sc.gov.br/?",
+            method="GET",
+            formdata=formdata,
+            callback=self.parse_pagination,
+            cb_kwargs={"page": page},
+        )
+
+    def start_requests(self):
+        yield self._requests(1)
+
+    def parse_pagination(self, response, page):
+        for item in response.css("tbody tr"):
+            edition_number = item.css("td::text")[1].get()
+            edition_url = item.css("td a")[1].attrib["href"]
+            raw_date = item.css("td::text")[2].get()
+            edition_date = datetime.strptime(raw_date, "%d/%m/%Y").date()
+
+            if self.start_date <= edition_date <= self.end_date:
+                yield Gazette(
+                    date=edition_date,
+                    edition_number=edition_number,
+                    is_extra_edition=False,
+                    power="executive_legislative",
+                    file_urls=[edition_url],
+                )
+
+        if edition_date > self.start_date:
+            yield self._requests(page + 1)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
[sc_florianopolis_2024_ultima.log](https://github.com/user-attachments/files/18383905/sc_florianopolis_2024_ultima.log) | [sc_florianopolis_2024_ultima.csv](https://github.com/user-attachments/files/18383906/sc_florianopolis_2024_ultima.csv)

- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
[sc_florianopolis_2024_periodo_1mes.log](https://github.com/user-attachments/files/18383907/sc_florianopolis_2024_periodo_1mes.log) | [sc_florianopolis_2024_periodo_1mes.csv](https://github.com/user-attachments/files/18383908/sc_florianopolis_2024_periodo_1mes.csv)
[sc_florianopolis_2024_periodo_1semana.log](https://github.com/user-attachments/files/18383909/sc_florianopolis_2024_periodo_1semana.log) | [sc_florianopolis_2024_periodo_1semana.csv](https://github.com/user-attachments/files/18383910/sc_florianopolis_2024_periodo_1semana.csv)

- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[sc_florianopolis_2024_completa.log](https://github.com/user-attachments/files/18383911/sc_florianopolis_2024_completa.log) | [sc_florianopolis_2024_completa.csv](https://github.com/user-attachments/files/18383912/sc_florianopolis_2024_completa.csv)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

Adiciona raspador para o novo site publicador de Florianópolis (resolve #1344) e atualiza o raspador antigo, cujo site continua no ar

Como a URL do site antigo mudou um pouco, tb anexo uma execução teste
[sc_florianopolis_2009.log](https://github.com/user-attachments/files/18383915/sc_florianopolis_2009.log)
[sc_florianopolis_2009.csv](https://github.com/user-attachments/files/18383916/sc_florianopolis_2009.csv)

 
