### PR TITLE
Atualiza raspadores para Centro do Guilherme e Maranhãozinho-MA

### DIFF
--- a/data_collection/gazette/spiders/base/aratext.py
+++ b/data_collection/gazette/spiders/base/aratext.py
@@ -1,0 +1,55 @@
+import re
+from urllib.parse import urlparse
+
+import dateparser
+from scrapy import Request
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class BaseAratextSpider(BaseGazetteSpider):
+    def parse(self, response, page=1):
+        for item in response.css("#edicoes-anteriores tbody tr"):
+            raw_edition_date = (
+                item.css("td")[2].css("::text").get().split(",")[1].strip()
+            )
+            edition_date = dateparser.parse(raw_edition_date, languages=["pt"]).date()
+
+            raw_edition_number = item.css("a::text").get().strip()
+            edition_number = re.search(r"(\d+)/", raw_edition_number).group(1)
+
+            path = item.css("a").attrib["href"]
+            intermediary_page = (
+                urlparse(self.start_urls[0])._replace(path=path).geturl()
+            )
+
+            if self.start_date <= edition_date <= self.end_date:
+                gazette = {
+                    "date": edition_date,
+                    "edition_number": edition_number,
+                    "is_extra_edition": False,
+                    "power": self.power,
+                }
+
+                yield Request(
+                    intermediary_page,
+                    callback=self.parse_intermediary_page,
+                    cb_kwargs={"gazette": gazette},
+                )
+
+        last_page = response.xpath('//*[@class="pagination"]//*[@rel="next"]') == []
+
+        if edition_date > self.start_date and not last_page:
+            page += 1
+            yield Request(
+                f"{self.start_urls[0]}?page={page}",
+                callback=self.parse,
+                cb_kwargs={"page": page},
+            )
+
+    def parse_intermediary_page(self, response, gazette):
+        file_path = response.css("#Box-area-title a").attrib["href"]
+        gazette_url = urlparse(self.start_urls[0])._replace(path=file_path).geturl()
+
+        yield Gazette(**gazette, file_urls=[gazette_url])

--- a/data_collection/gazette/spiders/ma/ma_centro_do_guilherme.py
+++ b/data_collection/gazette/spiders/ma/ma_centro_do_guilherme.py
@@ -1,13 +1,12 @@
 import datetime
 
-from gazette.spiders.base.siganet import BaseSiganetSpider
+from gazette.spiders.base.aratext import BaseAratextSpider
 
 
-class MaCentroDoGuilhermeSpider(BaseSiganetSpider):
-    zyte_smartproxy_enabled = True
-
+class MaCentroDoGuilhermeSpider(BaseAratextSpider):
     TERRITORY_ID = "2103158"
     name = "ma_centro_do_guilherme"
-    start_date = datetime.date(2021, 3, 12)
-    allowed_domains = ["transparencia.centrodoguilherme.ma.gov.br"]
-    BASE_URL = "https://transparencia.centrodoguilherme.ma.gov.br/acessoInformacao/diario/diario"
+    start_date = datetime.date(2024, 1, 4)
+    power = "executive"
+    allowed_domains = ["centrodoguilherme.ma.gov.br"]
+    start_urls = ["https://centrodoguilherme.ma.gov.br/diariooficial"]

--- a/data_collection/gazette/spiders/ma/ma_maranhaozinho.py
+++ b/data_collection/gazette/spiders/ma/ma_maranhaozinho.py
@@ -1,15 +1,12 @@
 import datetime
 
-from gazette.spiders.base.siganet import BaseSiganetSpider
+from gazette.spiders.base.aratext import BaseAratextSpider
 
 
-class MaMaranhaozinhoSpider(BaseSiganetSpider):
-    zyte_smartproxy_enabled = True
-
+class MaMaranhaozinhoSpider(BaseAratextSpider):
     TERRITORY_ID = "2106375"
     name = "ma_maranhaozinho"
-    start_date = datetime.date(2021, 1, 26)
-    allowed_domains = ["transparencia.maranhaozinho.ma.gov.br"]
-    BASE_URL = (
-        "https://transparencia.maranhaozinho.ma.gov.br/acessoInformacao/diario/diario"
-    )
+    start_date = datetime.date(2024, 1, 2)
+    power = "executive"
+    allowed_domains = ["maranhaozinho.ma.gov.br"]
+    start_urls = ["https://maranhaozinho.ma.gov.br/diariooficial"]

--- a/data_collection/gazette/spiders/sc/sc_florianopolis_2024.py
+++ b/data_collection/gazette/spiders/sc/sc_florianopolis_2024.py
@@ -44,6 +44,6 @@ class ScFlorianopolisSpider(BaseGazetteSpider):
                     power="executive_legislative",
                     file_urls=[edition_url],
                 )
-
-        if edition_date > self.start_date:
+        last_page = "next disabled" in response.url
+        if edition_date > self.start_date and not last_page:
             yield self._requests(page + 1)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [x] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
[ma_centro_do_guilherme_ultima.log](https://github.com/user-attachments/files/18386717/ma_centro_do_guilherme_ultima.log) | [ma_centro_do_guilherme_ultima.csv](https://github.com/user-attachments/files/18386718/ma_centro_do_guilherme_ultima.csv)
[ma_maranhaozinho_ultima.log](https://github.com/user-attachments/files/18386719/ma_maranhaozinho_ultima.log) | [ma_maranhaozinho_ultima.csv](https://github.com/user-attachments/files/18386720/ma_maranhaozinho_ultima.csv)

- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
[ma_centro_do_guilherme_periodo_1mes.log](https://github.com/user-attachments/files/18386701/ma_centro_do_guilherme_periodo_1mes.log) | [ma_centro_do_guilherme_periodo_1mes.csv](https://github.com/user-attachments/files/18386702/ma_centro_do_guilherme_periodo_1mes.csv)
[ma_centro_do_guilherme_periodo_1semana.log](https://github.com/user-attachments/files/18386703/ma_centro_do_guilherme_periodo_1semana.log) | [ma_centro_do_guilherme_periodo_1semana.csv](https://github.com/user-attachments/files/18386704/ma_centro_do_guilherme_periodo_1semana.csv)
[ma_maranhaozinho_periodo_1mes.log](https://github.com/user-attachments/files/18386705/ma_maranhaozinho_periodo_1mes.log) | [ma_maranhaozinho_periodo_1mes.csv](https://github.com/user-attachments/files/18386706/ma_maranhaozinho_periodo_1mes.csv)
[ma_maranhaozinho_periodo_1semana.log](https://github.com/user-attachments/files/18386707/ma_maranhaozinho_periodo_1semana.log) | [ma_maranhaozinho_periodo_1semana.csv](https://github.com/user-attachments/files/18386708/ma_maranhaozinho_periodo_1semana.csv)
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[ma_centro_do_guilherme_completa.log](https://github.com/user-attachments/files/18386695/ma_centro_do_guilherme_completa.log) | [ma_centro_do_guilherme_completa.csv](https://github.com/user-attachments/files/18386696/ma_centro_do_guilherme_completa.csv)
[ma_maranhaozinho_completa.log](https://github.com/user-attachments/files/18386697/ma_maranhaozinho_completa.log) | [ma_maranhaozinho_completa.csv](https://github.com/user-attachments/files/18386698/ma_maranhaozinho_completa.csv)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

Resolve #1343
