### PR TITLE
Adiciona raspador para São Luís-MA

### DIFF
--- a/data_collection/gazette/spiders/ma/ma_sao_luis.py
+++ b/data_collection/gazette/spiders/ma/ma_sao_luis.py
@@ -1,0 +1,49 @@
+import re
+from datetime import date
+from urllib.parse import urlparse
+
+import dateparser
+from scrapy import Request
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class MASaoLuisSpider(BaseGazetteSpider):
+    name = "ma_sao_luis"
+    TERRITORY_ID = "2111300"
+    allowed_domains = ["diariooficial.saoluis.ma.gov.br"]
+    start_urls = ["https://diariooficial.saoluis.ma.gov.br/diario-oficial"]
+    start_date = date(1993, 1, 4)
+
+    def parse(self, response, page=1):
+        for item in response.css(".box-publicacao"):
+            raw_infos = "".join(item.css("::text").getall()).strip()
+
+            edition_number = re.search(r"(\d+)/", raw_infos).group(1)
+            is_extra_edition = "extra" in raw_infos.lower()
+
+            raw_edition_date = re.search(r",(.+)\s", raw_infos).group(1).strip()
+            edition_date = dateparser.parse(raw_edition_date, languages=["pt"]).date()
+
+            edition_path = item.css("a")[1].attrib["href"]
+            edition_url = (
+                urlparse(self.start_urls[0])._replace(path=edition_path).geturl()
+            )
+
+            if self.start_date <= edition_date <= self.end_date:
+                yield Gazette(
+                    date=edition_date,
+                    edition_number=edition_number,
+                    is_extra_edition=is_extra_edition,
+                    file_urls=[edition_url],
+                    power="executive_legislative",
+                )
+
+        last_page_number = int(response.css(".pagination .last a").attrib["data-page"])
+        if edition_date > self.start_date and page < last_page_number:
+            page += 1
+            yield Request(
+                f"https://diariooficial.saoluis.ma.gov.br/diario-oficial/index?page={page}",
+                cb_kwargs={"page": page},
+            )

--- a/data_collection/gazette/spiders/ma/ma_sao_luis.py
+++ b/data_collection/gazette/spiders/ma/ma_sao_luis.py
@@ -20,18 +20,24 @@ class MASaoLuisSpider(BaseGazetteSpider):
         for item in response.css(".box-publicacao"):
             raw_infos = "".join(item.css("::text").getall()).strip()
 
-            edition_number = re.search(r"(\d+)/", raw_infos).group(1)
-            is_extra_edition = "extra" in raw_infos.lower()
-
             raw_edition_date = re.search(r",(.+)\s", raw_infos).group(1).strip()
             edition_date = dateparser.parse(raw_edition_date, languages=["pt"]).date()
 
-            edition_path = item.css("a")[1].attrib["href"]
-            edition_url = (
-                urlparse(self.start_urls[0])._replace(path=edition_path).geturl()
-            )
-
             if self.start_date <= edition_date <= self.end_date:
+                edition_number = re.search(r"(\d+)/", raw_infos).group(1)
+                is_extra_edition = "extra" in raw_infos.lower()
+
+                try:
+                    edition_path = item.css("a")[1].attrib["href"]
+                    edition_url = (
+                        urlparse(self.start_urls[0])
+                        ._replace(path=edition_path)
+                        .geturl()
+                    )
+                except Exception:
+                    self.logger.error(f"Unable to retrieve PDF URL for {edition_date}.")
+                    continue
+
                 yield Gazette(
                     date=edition_date,
                     edition_number=edition_number,


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
[ma_sao_luis_ultima.log](https://github.com/user-attachments/files/18392181/ma_sao_luis_ultima.log) | [ma_sao_luis_ultima.csv](https://github.com/user-attachments/files/18392182/ma_sao_luis_ultima.csv)
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
[ma_sao_luis_periodo_1ano.log](https://github.com/user-attachments/files/18392184/ma_sao_luis_periodo_1ano.log) | [ma_sao_luis_periodo_1ano.csv](https://github.com/user-attachments/files/18392185/ma_sao_luis_periodo_1ano.csv)
[ma_sao_luis_periodo_2meses.log](https://github.com/user-attachments/files/18392186/ma_sao_luis_periodo_2meses.log) | [ma_sao_luis_periodo_2meses.csv](https://github.com/user-attachments/files/18392188/ma_sao_luis_periodo_2meses.csv)
[ma_sao_luis_periodo_1mes.log](https://github.com/user-attachments/files/18392189/ma_sao_luis_periodo_1mes.log) | [ma_sao_luis_periodo_1mes.csv](https://github.com/user-attachments/files/18392190/ma_sao_luis_periodo_1mes.csv)
[ma_sao_luis_periodo_1semana.log](https://github.com/user-attachments/files/18392191/ma_sao_luis_periodo_1semana.log) | [ma_sao_luis_periodo_1semana.csv](https://github.com/user-attachments/files/18392192/ma_sao_luis_periodo_1semana.csv)
- [ ] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

Como a série histórica é enorme e os documentos são grandes, não foi possível fazer a coleta completa. Por isso, foram feitas 3 coletas de 3 anos, no começo, meio e fim da série histórica:

**Antigo** (1993-01-01 a 1995-12-30): 
[ma_sao_luis_periodo_3anos_antigo.log](https://github.com/user-attachments/files/18392417/ma_sao_luis_periodo_3anos_antigo.log) | [ma_sao_luis_periodo_3anos_antigo.csv](https://github.com/user-attachments/files/18392418/ma_sao_luis_periodo_3anos_antigo.csv)
**Meio** (2007-01-01 a 2010-12-30): 
[ma_sao_luis_periodo_3anos_meio.log](https://github.com/user-attachments/files/18392352/ma_sao_luis_periodo_3anos_meio.log) | [ma_sao_luis_periodo_3anos_meio.csv](https://github.com/user-attachments/files/18392353/ma_sao_luis_periodo_3anos_meio.csv)
**Recente** (2021-01-01 até hoje, 2025-01-12): 
[ma_sao_luis_periodo_3anos_recente.log](https://github.com/user-attachments/files/18392331/ma_sao_luis_periodo_3anos_recente.log) | [ma_sao_luis_periodo_3anos_recente.csv](https://github.com/user-attachments/files/18392333/ma_sao_luis_periodo_3anos_recente.csv)


#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

resolve #615
closes #887

O raspador implementa um aviso de erro no log para casos em que não há arquivo da edição completa (exemplo é o dia 7/julho/2022) para não impedir o código de seguir executando.
