### PR TITLE
#1217 Cria spider rj_volta_redonda

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_volta_redonda.py
+++ b/data_collection/gazette/spiders/rj/rj_volta_redonda.py
@@ -1,0 +1,48 @@
+import re
+from datetime import datetime as dt
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjVoltaRedondaSpider(BaseGazetteSpider):
+    name = "rj_volta_redonda"
+    TERRITORY_ID = "3306305"
+    allowed_domains = ["voltaredonda.rj.gov.br"]
+    start_urls = ["https://www.voltaredonda.rj.gov.br/vrdestaque/index.php"]
+    start_date = dt(2019, 1, 4).date()
+
+    def parse(self, response):
+        gazettes = response.xpath('//select[@id="search"]/option[@value]')
+        gazettes.reverse()
+
+        for gazette in gazettes:
+            gazette_url = gazette.xpath("@value").get()
+
+            match = re.search(
+                r"(?<!\d)(?P<year>20[0-9]{2})-(?P<month>0[1-9]|1[0-2])-(?P<day>0[1-9]|[1-2][0-9]|3[0-1])(?!\d)",
+                gazette_url,
+            )
+            if not match:
+                continue
+
+            gazette_date = dt.strptime(match.group(), "%Y-%m-%d").date()
+
+            if gazette_date > self.end_date:
+                continue
+
+            if gazette_date < self.start_date:
+                return
+
+            title = gazette.xpath("text()").get().strip()
+            is_extra = "EXTRA" in title.upper()
+
+            gazette_edition_number = re.search(r"\d+", title).group()
+
+            yield Gazette(
+                date=gazette_date,
+                edition_number=gazette_edition_number,
+                is_extra_edition=is_extra,
+                file_urls=[response.urljoin(gazette_url)],
+                power="executive_legislative",
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[ultima.log](https://github.com/user-attachm
[completa.csv](https://github.com/user-attachments/files/18559427/completa.csv)
[completa.log](https://github.com/user-attachments/files/18559428/completa.log)
[intervalo.csv](https://github.com/user-attachments/files/18559429/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/18559430/intervalo.log)
ents/files/18559413/ultima.log)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

resolve#1217 para rj_volta_redonda
