### PR TITLE
Cria spider pr-juranda

### DIFF
--- a/data_collection/gazette/spiders/pr/pr_juranda.py
+++ b/data_collection/gazette/spiders/pr/pr_juranda.py
@@ -1,0 +1,10 @@
+from datetime import date
+
+from gazette.spiders.base.atende_v2 import BaseAtendeV2Spider
+
+
+class PrJurandaSpider(BaseAtendeV2Spider):
+    TERRITORY_ID = "4112959"
+    name = "pr_juranda"
+    city_subdomain = "juranda"
+    start_date = date(2021, 3, 24)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [x] É um *layout* padrão e todos os municípios adicionados usam a BaseAtendeV2Spider(https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base/atende_v2.py) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
[last_pr_juranda.txt](https://github.com/user-attachments/files/18564014/last_pr_juranda.txt)

- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
[pr_juranda.txt](https://github.com/user-attachments/files/18564055/pr_juranda.txt)
[pr_juranda.csv](https://github.com/user-attachments/files/18564058/pr_juranda.csv)

- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[full_pr_juranda.csv](https://github.com/user-attachments/files/18564072/full_pr_juranda.csv)
[full_pr_juranda.txt](https://github.com/user-attachments/files/18564078/full_pr_juranda.txt)


#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

Novo raspador para cidade de Juranda - Paraná