### PR TITLE
Cria spider rj_paraty

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_paraty.py
+++ b/data_collection/gazette/spiders/rj/rj_paraty.py
@@ -1,0 +1,66 @@
+import re
+from datetime import date, datetime as dt
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjParatySpider(BaseGazetteSpider):
+    name = "rj_paraty"
+    TERRITORY_ID = "3303807"
+    allowed_domains = ["paraty.rj.gov.br"]
+    start_date = date(2017, 9, 1)
+    BASE_URL = "https://www.paraty.rj.gov.br/API/API/Documentos?PageSize=100"
+
+    def start_requests(self):
+        yield scrapy.Request(
+            url=f"{self.BASE_URL}&PageNumber=1",
+            headers={"Accept": "application/json"},
+            meta={"page": 1},
+        )
+
+    def parse(self, response):
+        data = response.json()
+        if not data:
+            return
+
+        for doc in data:
+            gazette_date_str = doc["DataPublicacao"]
+            try:
+                gazette_date = dt.strptime(gazette_date_str, "%d/%m/%Y").date()
+            except ValueError:
+                continue
+
+            if gazette_date > self.end_date:
+                continue
+
+            if gazette_date < self.start_date:
+                return
+
+            doc_file_info = doc["DocumentoArquivoAtual"]
+            if not doc_file_info:
+                continue
+
+            file_url = doc_file_info["CaminhoLogicoArquivo"]
+
+            title = doc["Titulo"].strip()
+            cleaned_text = re.sub(r"[^\d/]", "", title)
+            match = re.search(r"(\d+)/\d{4}", cleaned_text)
+            edition_number = match.group(1) if match else None
+
+            is_extra = "EXTRA" in title.upper()
+            yield Gazette(
+                date=gazette_date,
+                edition_number=edition_number,
+                is_extra_edition=is_extra,
+                file_urls=[file_url],
+                power="executive_legislative",
+            )
+        page = response.request.meta["page"] + 1
+        yield scrapy.Request(
+            url=f"{self.BASE_URL}&PageNumber={page}",
+            headers={"Accept": "application/json"},
+            meta={"page": page},
+        )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- x ] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[completa.csv](https://github.com/user-attachments/files/18769193/completa.csv)
[completa.log](https://github.com/user-attachments/files/18769195/completa.log)
[intervalo.csv](https://github.com/user-attachments/files/18769196/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/18769197/intervalo.log)
[ultima.log](https://github.com/user-attachments/files/18769198/ultima.log)

há um erro no coleta completa, pois a edição nº 0064/2018 está com o link quebrado (https://www.paraty.rj.gov.br/API/Areas/Admin/Conteudo/Documento/fb86040b-8560-4328-85e1-120e7e0cef6c.doc) no site da prefeitura

#### Verificações
- [x ] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [ x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x ] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

resolve #1205 
Cria spider para rj_paraty


