### PR TITLE
cria spider RjItatiaia

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_itatiaia.py
+++ b/data_collection/gazette/spiders/rj/rj_itatiaia.py
@@ -1,0 +1,69 @@
+import re
+from datetime import date, datetime as dt
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjItatiaiaSpider(BaseGazetteSpider):
+    name = "rj_itatiaia"
+    TERRITORY_ID = "3302254"
+    allowed_domains = ["itatiaia.rj.gov.br"]
+    start_date = date(2019, 1, 28)
+    BASE_URL = "https://itatiaia.rj.gov.br/wp-admin/admin-ajax.php"
+
+    payload = {
+        "action": "jet_smart_filters",
+        "provider": "jet-engine/default",
+        "defaults[post_status][]": "publish",
+        "defaults[post_type]": "boletim-",
+        "defaults[posts_per_page]": "50",
+        "defaults[paged]": "1",
+        "defaults[ignore_sticky_posts]": "1",
+        "settings[lisitng_id]": "32705",
+    }
+
+    headers = {"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"}
+
+    def start_requests(self):
+        query_date = f"{self.start_date.strftime('%Y.%m.%d')}-{self.end_date.strftime('%Y.%m.%d')}"
+        self.payload["query[_date_query_|date]"] = query_date
+        yield scrapy.FormRequest(
+            url=self.BASE_URL, headers=self.headers, formdata=self.payload
+        )
+
+    def parse(self, response):
+        content = response.json()["content"]
+        gazette_list = content.split("\n\t\t\t\t\t\t\t\t")
+        for i in range(2, len(gazette_list), 2):
+            gazette_data = gazette_list[i]
+
+            date_match = re.search(r"<h6.*?>(.*?)</h6>", gazette_data).group(1)
+            gazette_date = dt.strptime(date_match, "%d/%m/%Y").date()
+
+            title_match = re.search(r"<h5.*?>(.*?)</h5>", gazette_data)
+            title_match = title_match.group(1).lower()
+            extra = "extra" in title_match
+
+            url_match = re.search(r'href="(.*?)"', gazette_data).group(1)
+
+            edition_match = re.search(r"nº (\d+)", title_match).group(1)
+
+            yield Gazette(
+                date=gazette_date,
+                edition_number=edition_match,
+                is_extra_edition=extra,
+                file_urls=[url_match],
+                power="executive_legislative",
+            )
+
+        pagination = response.json()["pagination"]
+        page = pagination["page"]
+        last_page = pagination["max_num_pages"]
+        self.payload["defaults[paged]"] = str(int(self.payload["defaults[paged]"]) + 1)
+        if page < last_page:
+            yield scrapy.FormRequest(
+                url=self.BASE_URL, headers=self.headers, formdata=self.payload
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [X] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [X] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [X] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [X] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [X] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[completa.csv](https://github.com/user-attachments/files/18772185/completa.csv)
[completa.log](https://github.com/user-attachments/files/18772186/completa.log)
[intervalo.csv](https://github.com/user-attachments/files/18772187/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/18772188/intervalo.log)
[ultima.log](https://github.com/user-attachments/files/18772189/ultima.log)
[ultima.csv](https://github.com/user-attachments/files/18772190/ultima.csv)


#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [X] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [X] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

cria spider RjItatiaia, resolve #1198 
há um erro no coleta completa, pois a edição da data 2022-12-19 está com o link quebrado (https://itatiaia.rj.gov.br/boletim-oficial/?jsf=jet-engine&date=-2022.12.19) no site da prefeitura
