### PR TITLE
Cria spider rj_valenca

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_valenca.py
+++ b/data_collection/gazette/spiders/rj/rj_valenca.py
@@ -1,0 +1,53 @@
+import re
+from datetime import date
+
+import dateparser
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjValencaSpider(BaseGazetteSpider):
+    name = "rj_valenca"
+    TERRITORY_ID = "3306107"
+    allowed_domains = ["valenca.rj.gov.br"]
+    start_urls = ["https://valenca.rj.gov.br/boletins-oficiais/"]
+    start_date = date(2011, 1, 1)
+
+    def parse(self, response):
+        gazettes = response.xpath('//div[@class="accordionContent"]//a')
+
+        for gazette in gazettes:
+            title = gazette.xpath("text()").get("").strip()
+            file_url = gazette.xpath("@href").get()
+
+            match = re.search(
+                r"n[°º\.]*\s*([\d\.]+)\s*–\s*(\d{1,2} de [A-Za-z]+ de \d{4})",
+                title,
+                flags=re.IGNORECASE,
+            )
+            if not match:
+                continue
+
+            edition_number = match.group(1).replace(".", "")
+            gazette_date_str = match.group(2)
+
+            gazette_date = dateparser.parse(gazette_date_str, languages=["pt"])
+            if gazette_date:
+                gazette_date = gazette_date.date()
+            else:
+                continue
+
+            if gazette_date > self.end_date:
+                continue
+
+            if gazette_date < self.start_date:
+                return
+
+            yield Gazette(
+                date=gazette_date,
+                edition_number=edition_number,
+                file_urls=[file_url],
+                is_extra_edition=False,
+                power="executive_legislative",
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[completo.csv](https://github.com/user-attachments/files/18845435/completo.csv)
[completo.log](https://github.com/user-attachments/files/18845436/completo.log)
[intervalo.csv](https://github.com/user-attachments/files/18845437/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/18845438/intervalo.log)
[ultima.log](https://github.com/user-attachments/files/18845439/ultima.log)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

resolve #1216 

