### PR TITLE
Cria spider rj_resende

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_resende.py
+++ b/data_collection/gazette/spiders/rj/rj_resende.py
@@ -1,0 +1,56 @@
+import re
+from datetime import date
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjResendeSpider(BaseGazetteSpider):
+    name = "rj_resende"
+    TERRITORY_ID = "3302254"
+    allowed_domains = ["resende.rj.gov.br"]
+    start_date = date(2009, 1, 1)
+    BASE_URL = (
+        "https://resende.rj.gov.br/blogtransparencia/page/boletim_oficialselect.asp"
+    )
+
+    def start_requests(self):
+        for year in range(self.end_date.year, self.start_date.year - 1, -1):
+            payload = {"ano": str(year), "funcao": "buscaBo"}
+            yield scrapy.FormRequest(
+                url=self.BASE_URL,
+                formdata=payload,
+                meta={"year": year},
+            )
+
+    def parse(self, response):
+        year = response.meta["year"]
+        gazettes = response.xpath("//option[starts-with(@value, 'Boletim_')]")
+
+        for gazette in gazettes:
+            gazette_filename = gazette.xpath("@value").get()
+            gazette_text = gazette.xpath("text()").get("").strip()
+
+            full_url = f"https://resende.rj.gov.br/conteudo/boletim_oficial/{year}/{gazette_filename}"
+
+            match = re.search(r"N[°º\.]*\s*(\d+)\s*-\s*(\d{2})/(\d{2})", gazette_text)
+            if not match:
+                continue
+
+            edition_number, day, month = match.groups()
+            gazette_date = date(year, int(month), int(day))
+
+            if gazette_date > self.end_date:
+                continue
+            if gazette_date < self.start_date:
+                return
+
+            yield Gazette(
+                date=gazette_date,
+                edition_number=edition_number,
+                is_extra_edition=False,
+                file_urls=[full_url],
+                power="executive_legislative",
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[completo.csv](https://github.com/user-attachments/files/18888562/completo.csv)
[completo.log](https://github.com/user-attachments/files/18888563/completo.log)
[intervalo.csv](https://github.com/user-attachments/files/18888564/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/18888565/intervalo.log)
[ultima.log](https://github.com/user-attachments/files/18888566/ultima.log)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição
não foi possível extrair as edições extras.
As edições só possuem data a partir de 04/10/2024
resolve #1206 
