### PR TITLE
Cria Spider Rj_Mangaratiba

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_mangaratiba.py
+++ b/data_collection/gazette/spiders/rj/rj_mangaratiba.py
@@ -1,0 +1,50 @@
+import re
+from datetime import date, datetime as dt
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjMangaratibaSpider(BaseGazetteSpider):
+    name = "rj_mangaratiba"
+    TERRITORY_ID = "3302601"
+    allowed_domains = ["www.mangaratiba.rj.gov.br"]
+    start_date = date(2012, 1, 1)
+
+    def start_requests(self):
+        years_range = range(self.start_date.year, self.end_date.year + 1)
+        for year in years_range:
+            yield scrapy.Request(
+                f"https://www.mangaratiba.rj.gov.br/novoportal/publicacoes-ano.php?ano={year}"
+            )
+
+    def parse(self, response):
+        for tr in response.css("tbody tr"):
+            date_tmp = tr.css("td:nth-child(2)::text").get()
+            date_tmp = dt.strptime(date_tmp, "%d/%m/%Y").date()
+
+            if date_tmp > self.end_date:
+                continue
+            if date_tmp < self.start_date:
+                return
+
+            raw_edition = tr.css("td:nth-child(1)::text").get()
+            match = re.search(r"^\d+", raw_edition)
+            edition_number = match.group(0) if match else ""
+
+            extra = not raw_edition.isdigit()
+
+            gazzete_link = tr.css("td:nth-child(4) a::attr(onclick)").get()
+            gazzete_link = gazzete_link.split("window.open('")[-1].split("','_blank'")[
+                0
+            ]
+
+            yield Gazette(
+                date=date_tmp,
+                edition_number=edition_number,
+                is_extra_edition=extra,
+                file_urls=[gazzete_link],
+                power="executive_legislative",
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [X] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [X] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [X] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [X] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [X] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[completa.csv](https://github.com/user-attachments/files/18892022/completa.csv)
[completa.log](https://github.com/user-attachments/files/18892023/completa.log)
[intervalo.csv](https://github.com/user-attachments/files/18892025/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/18892026/intervalo.log)
[ultima.csv](https://github.com/user-attachments/files/18892027/ultima.csv)
[ultima.log](https://github.com/user-attachments/files/18892028/ultima.log)


#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [X] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [X] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

Cria Spider Rj_Mangaratiba, resolve #1202 

nos logs as edições 328 do ano 2012 e a edição 1000 de 04/04/2020, estão com o link quebrado no site da prefeitura.

OBS: de 2012 até 2016, todas as datas constam como 01/01
