### PR TITLE
Modifica base dosp para coletar código dinamicamente

### DIFF
--- a/data_collection/gazette/spiders/ce/ce_horizonte.py
+++ b/data_collection/gazette/spiders/ce/ce_horizonte.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class CeHorizonteSpider(BaseDospSpider):
     TERRITORY_ID = "2305233"
     name = "ce_horizonte"
-    code = 687
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/horizonte"]
     start_date = date(2023, 7, 3)

--- a/data_collection/gazette/spiders/mg/mg_itajuba.py
+++ b/data_collection/gazette/spiders/mg/mg_itajuba.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class MgItajubaSpider(BaseDospSpider):
     TERRITORY_ID = "3132404"
     name = "mg_itajuba"
-    code = 1908
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/itajuba"]
     start_date = date(2023, 5, 15)

--- a/data_collection/gazette/spiders/mg/mg_uberaba_2021.py
+++ b/data_collection/gazette/spiders/mg/mg_uberaba_2021.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class MgUberabaSpider(BaseDospSpider):
     TERRITORY_ID = "3170107"
     name = "mg_uberaba_2021"
-    code = 2364
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/uberaba"]
     start_date = date(2021, 9, 1)

--- a/data_collection/gazette/spiders/ms/ms_deodapolis.py
+++ b/data_collection/gazette/spiders/ms/ms_deodapolis.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class MsDeodapolisSpider(BaseDospSpider):
     TERRITORY_ID = "5003454"
     name = "ms_deodapolis"
-    code = 1492
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/deodapolis"]
     start_date = date(2023, 11, 17)

--- a/data_collection/gazette/spiders/ms/ms_gloria_de_dourados.py
+++ b/data_collection/gazette/spiders/ms/ms_gloria_de_dourados.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class MsGloriaDeDouradosSpider(BaseDospSpider):
     TERRITORY_ID = "5004007"
     name = "ms_gloria_de_dourados"
-    code = 1498
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/gloria_de_dourados"]
     start_date = date(2023, 11, 7)

--- a/data_collection/gazette/spiders/ms/ms_paranhos.py
+++ b/data_collection/gazette/spiders/ms/ms_paranhos.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class MsParanhosSpider(BaseDospSpider):
     TERRITORY_ID = "5006358"
     name = "ms_paranhos"
-    code = 1521
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/paranhos"]
     start_date = date(2023, 7, 13)

--- a/data_collection/gazette/spiders/ms/ms_rio_brilhante.py
+++ b/data_collection/gazette/spiders/ms/ms_rio_brilhante.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class MsRioBrilhanteSpider(BaseDospSpider):
     TERRITORY_ID = "5007208"
     name = "ms_rio_brilhante"
-    code = 1526
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/rio_brilhante"]
     start_date = date(2024, 2, 1)

--- a/data_collection/gazette/spiders/pe/pe_cabrobo.py
+++ b/data_collection/gazette/spiders/pe/pe_cabrobo.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class PeCabroboSpider(BaseDospSpider):
     TERRITORY_ID = "2603009"
     name = "pe_cabrobo"
-    code = 3190
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/cabrobo"]
     start_date = date(2019, 4, 8)

--- a/data_collection/gazette/spiders/pr/pr_cafelandia.py
+++ b/data_collection/gazette/spiders/pr/pr_cafelandia.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class PrCafelandiaSpider(BaseDospSpider):
     TERRITORY_ID = "4103453"
     name = "pr_cafelandia"
-    code = 4748
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/cafelandia"]
     start_date = date(2017, 6, 12)

--- a/data_collection/gazette/spiders/pr/pr_cafezal_do_sul.py
+++ b/data_collection/gazette/spiders/pr/pr_cafezal_do_sul.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class PrCafezalDoSulSpider(BaseDospSpider):
     TERRITORY_ID = "4103479"
     name = "pr_cafezal_do_sul"
-    code = 2808
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/cafezal_do_sul"]
     start_date = date(2016, 4, 14)

--- a/data_collection/gazette/spiders/pr/pr_carambei.py
+++ b/data_collection/gazette/spiders/pr/pr_carambei.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class PrCarambeiSpider(BaseDospSpider):
     TERRITORY_ID = "4104659"
     name = "pr_carambei"
-    code = 2826
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/carambei"]
     start_date = date(2022, 11, 9)

--- a/data_collection/gazette/spiders/rj/rj_sao_jose_do_vale_do_rio_preto.py
+++ b/data_collection/gazette/spiders/rj/rj_sao_jose_do_vale_do_rio_preto.py
@@ -6,5 +6,7 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class RjSaoJoseDoValeDoRioPretoSpider(BaseDospSpider):
     TERRITORY_ID = "3305158"
     name = "rj_sao_jose_do_vale_do_rio_preto"
-    code = 3640
+    start_urls = [
+        "https://www.imprensaoficialmunicipal.com.br/sao_jose_do_vale_do_rio_preto"
+    ]
     start_date = date(2023, 5, 24)

--- a/data_collection/gazette/spiders/rs/rs_marau.py
+++ b/data_collection/gazette/spiders/rs/rs_marau.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class RsMarauSpider(BaseDospSpider):
     TERRITORY_ID = "4311809"
     name = "rs_marau"
-    code = 4049
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/marau"]
     start_date = date(2017, 10, 10)

--- a/data_collection/gazette/spiders/rs/rs_quatro_irmaos.py
+++ b/data_collection/gazette/spiders/rs/rs_quatro_irmaos.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class RsQuatroIrmaosSpider(BaseDospSpider):
     TERRITORY_ID = "4315313"
     name = "rs_quatro_irmaos"
-    code = 4135
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/quatro_irmaos"]
     start_date = date(2024, 5, 14)

--- a/data_collection/gazette/spiders/rs/rs_santa_clara_do_sul.py
+++ b/data_collection/gazette/spiders/rs/rs_santa_clara_do_sul.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class RsSantaClaraDoSulSpider(BaseDospSpider):
     TERRITORY_ID = "4316758"
     name = "rs_santa_clara_do_sul"
-    code = 4159
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/santa_clara_do_sul"]
     start_date = date(2017, 9, 5)

--- a/data_collection/gazette/spiders/rs/rs_tres_arroios.py
+++ b/data_collection/gazette/spiders/rs/rs_tres_arroios.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class RsTresArroiosSpider(BaseDospSpider):
     TERRITORY_ID = "4321634"
     name = "rs_tres_arroios"
-    code = 4247
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/tres_arroios"]
     start_date = date(2017, 4, 26)

--- a/data_collection/gazette/spiders/sp/sp_adolfo.py
+++ b/data_collection/gazette/spiders/sp/sp_adolfo.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpAdolfoSpider(BaseDospSpider):
     TERRITORY_ID = "3500204"
     name = "sp_adolfo"
-    code = 4650
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/adolfo"]
     start_date = date(2015, 5, 14)

--- a/data_collection/gazette/spiders/sp/sp_aguai.py
+++ b/data_collection/gazette/spiders/sp/sp_aguai.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpAguaiSpider(BaseDospSpider):
     TERRITORY_ID = "3500303"
     name = "sp_aguai"
-    code = 4651
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/aguai"]
     start_date = date(2022, 10, 19)

--- a/data_collection/gazette/spiders/sp/sp_aguas_da_prata.py
+++ b/data_collection/gazette/spiders/sp/sp_aguas_da_prata.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpAguasDaPrataSpider(BaseDospSpider):
     TERRITORY_ID = "3500402"
     name = "sp_aguas_da_prata"
-    code = 4652
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/aguas_da_prata"]
     start_date = date(2018, 8, 23)

--- a/data_collection/gazette/spiders/sp/sp_aracatuba.py
+++ b/data_collection/gazette/spiders/sp/sp_aracatuba.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpAracatubaSpider(BaseDospSpider):
     TERRITORY_ID = "3502804"
     name = "sp_aracatuba"
-    code = 4680
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/aracatuba"]
     start_date = date(2020, 4, 22)

--- a/data_collection/gazette/spiders/sp/sp_avare.py
+++ b/data_collection/gazette/spiders/sp/sp_avare.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpAvareSpider(BaseDospSpider):
     TERRITORY_ID = "3504503"
     name = "sp_avare"
-    code = 4700
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/avare"]
     start_date = date(2018, 10, 3)

--- a/data_collection/gazette/spiders/sp/sp_birigui.py
+++ b/data_collection/gazette/spiders/sp/sp_birigui.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpBiriguiSpider(BaseDospSpider):
     TERRITORY_ID = "3506508"
     name = "sp_birigui"
-    code = 4722
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/birigui"]
     start_date = date(2016, 12, 28)

--- a/data_collection/gazette/spiders/sp/sp_botucatu.py
+++ b/data_collection/gazette/spiders/sp/sp_botucatu.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpBotucatuSpider(BaseDospSpider):
     TERRITORY_ID = "3507506"
     name = "sp_botucatu"
-    code = 4734
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/botucatu"]
     start_date = date(2000, 1, 6)

--- a/data_collection/gazette/spiders/sp/sp_braganca_paulista.py
+++ b/data_collection/gazette/spiders/sp/sp_braganca_paulista.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpBragancaPaulistaSpider(BaseDospSpider):
     TERRITORY_ID = "3507605"
     name = "sp_braganca_paulista"
-    code = 4735
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/braganca_paulista"]
     start_date = date(2019, 1, 4)

--- a/data_collection/gazette/spiders/sp/sp_campo_limpo_paulista.py
+++ b/data_collection/gazette/spiders/sp/sp_campo_limpo_paulista.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpCampoLimpoPaulistaSpider(BaseDospSpider):
     TERRITORY_ID = "3509601"
     name = "sp_campo_limpo_paulista"
-    code = 4758
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/campo_limpo_paulista"]
     start_date = date(2022, 1, 7)

--- a/data_collection/gazette/spiders/sp/sp_catanduva.py
+++ b/data_collection/gazette/spiders/sp/sp_catanduva.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpCatanduvaSpider(BaseDospSpider):
     TERRITORY_ID = "3511102"
     name = "sp_catanduva"
-    code = 4775
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/catanduva"]
     start_date = date(2016, 3, 18)

--- a/data_collection/gazette/spiders/sp/sp_cunha.py
+++ b/data_collection/gazette/spiders/sp/sp_cunha.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpCunhaSpider(BaseDospSpider):
     TERRITORY_ID = "3513603"
     name = "sp_cunha"
-    code = 4800
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/cunha"]
     start_date = date(2021, 10, 19)

--- a/data_collection/gazette/spiders/sp/sp_dirce_reis.py
+++ b/data_collection/gazette/spiders/sp/sp_dirce_reis.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpDirceReisSpider(BaseDospSpider):
     TERRITORY_ID = "3513850"
     name = "sp_dirce_reis"
-    code = 4803
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/dirce_reis"]
     start_date = date(2019, 4, 4)

--- a/data_collection/gazette/spiders/sp/sp_guaracai.py
+++ b/data_collection/gazette/spiders/sp/sp_guaracai.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpGuaracaiSpider(BaseDospSpider):
     TERRITORY_ID = "3517802"
     name = "sp_guaracai"
-    code = 4853
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/guaracai"]
     start_date = date(2018, 9, 27)

--- a/data_collection/gazette/spiders/sp/sp_itapeva.py
+++ b/data_collection/gazette/spiders/sp/sp_itapeva.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpItapevaSpider(BaseDospSpider):
     TERRITORY_ID = "3522406"
     name = "sp_itapeva"
-    code = 4907
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/itapeva"]
     start_date = date(2017, 12, 18)

--- a/data_collection/gazette/spiders/sp/sp_itapevi.py
+++ b/data_collection/gazette/spiders/sp/sp_itapevi.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpItapeviSpider(BaseDospSpider):
     TERRITORY_ID = "3522505"
     name = "sp_itapevi"
-    code = 4908
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/itapevi"]
     start_date = date(2018, 12, 21)

--- a/data_collection/gazette/spiders/sp/sp_itu.py
+++ b/data_collection/gazette/spiders/sp/sp_itu.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpItuSpider(BaseDospSpider):
     TERRITORY_ID = "3523909"
     name = "sp_itu"
-    code = 4923
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/itu"]
     start_date = date(2019, 8, 15)

--- a/data_collection/gazette/spiders/sp/sp_jandira.py
+++ b/data_collection/gazette/spiders/sp/sp_jandira.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpJandiraSpider(BaseDospSpider):
     TERRITORY_ID = "3525003"
     name = "sp_jandira"
-    code = 4934
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/jandira"]
     start_date = date(2022, 3, 22)

--- a/data_collection/gazette/spiders/sp/sp_jau_2023.py
+++ b/data_collection/gazette/spiders/sp/sp_jau_2023.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpJauSpider_2023(BaseDospSpider):
     TERRITORY_ID = "3525300"
     name = "sp_jau_2023"
-    code = 4937
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/jau"]
     start_date = date(2023, 1, 6)

--- a/data_collection/gazette/spiders/sp/sp_mogi_guacu.py
+++ b/data_collection/gazette/spiders/sp/sp_mogi_guacu.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpMogiGuacuSpider(BaseDospSpider):
     TERRITORY_ID = "3530706"
     name = "sp_mogi_guacu"
-    code = 4995
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/mogi_guacu"]
     start_date = date(2022, 1, 20)

--- a/data_collection/gazette/spiders/sp/sp_monteiro_lobato.py
+++ b/data_collection/gazette/spiders/sp/sp_monteiro_lobato.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpMonteiroLobatoSpider(BaseDospSpider):
     TERRITORY_ID = "3531704"
     name = "sp_monteiro_lobato"
-    code = 5006
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/monteiro_lobato"]
     start_date = date(2020, 11, 26)

--- a/data_collection/gazette/spiders/sp/sp_rio_claro.py
+++ b/data_collection/gazette/spiders/sp/sp_rio_claro.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpRioClaroSpider(BaseDospSpider):
     TERRITORY_ID = "3543907"
     name = "sp_rio_claro"
-    code = 5142
-    start_date = date(2023, 6, 21)
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/rio_claro"]
+    start_date = date(2006, 5, 23)

--- a/data_collection/gazette/spiders/sp/sp_salto.py
+++ b/data_collection/gazette/spiders/sp/sp_salto.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpSaltoSpider(BaseDospSpider):
     TERRITORY_ID = "3545209"
     name = "sp_salto"
-    code = 5158
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/salto"]
     start_date = date(2018, 2, 1)

--- a/data_collection/gazette/spiders/sp/sp_sao_bernardo_do_campo.py
+++ b/data_collection/gazette/spiders/sp/sp_sao_bernardo_do_campo.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpSaoBernardoDoCampoSpider(BaseDospSpider):
     TERRITORY_ID = "3548708"
     name = "sp_sao_bernardo_do_campo"
-    code = 5195
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/sao_bernardo_do_campo"]
     start_date = date(2017, 5, 12)

--- a/data_collection/gazette/spiders/sp/sp_sertaozinho.py
+++ b/data_collection/gazette/spiders/sp/sp_sertaozinho.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpSertaozinhoSpider(BaseDospSpider):
     TERRITORY_ID = "3551702"
     name = "sp_sertaozinho"
-    code = 5227
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/sertaozinho"]
     start_date = date(2019, 8, 7)

--- a/data_collection/gazette/spiders/sp/sp_tremembe.py
+++ b/data_collection/gazette/spiders/sp/sp_tremembe.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpTremembeSpider(BaseDospSpider):
     TERRITORY_ID = "3554805"
     name = "sp_tremembe"
-    code = 5264
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/tremembe"]
     start_date = date(2016, 5, 11)

--- a/data_collection/gazette/spiders/sp/sp_votuporanga.py
+++ b/data_collection/gazette/spiders/sp/sp_votuporanga.py
@@ -6,5 +6,5 @@ from gazette.spiders.base.dosp import BaseDospSpider
 class SpVotuporangaSpider(BaseDospSpider):
     TERRITORY_ID = "3557105"
     name = "sp_votuporanga"
-    code = 5292
+    start_urls = ["https://www.imprensaoficialmunicipal.com.br/votuporanga"]
     start_date = date(2015, 10, 5)


### PR DESCRIPTION
Por padrão, a base dosp exige que os raspadores-filhos tenham o atributo `code` que é o código do município para o sistema do serviço. 

Entretanto, ao invés de forçar a contribuição de ir procurar o valor no código-fonte do site, é mais simples que o raspador exija a URL do site e a base usar de `response` para obter o valor do código. O impacto é de apenas 1 requisição extra.