### PR TITLE
Habilita proxy em raspadores de BaseModernizacao

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_itaguai.py
+++ b/data_collection/gazette/spiders/rj/rj_itaguai.py
@@ -4,6 +4,8 @@ from gazette.spiders.base.modernizacao import BaseModernizacaoSpider
 
 
 class RjItaguaiSpider(BaseModernizacaoSpider):
+    zyte_smartproxy_enabled = True
+
     name = "rj_itaguai"
     TERRITORY_ID = "3302007"
     allowed_domains = ["portal.transparencia.itaguai.rj.gov.br"]

--- a/data_collection/gazette/spiders/rj/rj_mesquita.py
+++ b/data_collection/gazette/spiders/rj/rj_mesquita.py
@@ -4,6 +4,8 @@ from gazette.spiders.base.modernizacao import BaseModernizacaoSpider
 
 
 class RjMesquitaSpider(BaseModernizacaoSpider):
+    zyte_smartproxy_enabled = True
+
     TERRITORY_ID = "3302858"
     name = "rj_mesquita"
     allowed_domains = ["transparencia.mesquita.rj.gov.br"]

--- a/data_collection/gazette/spiders/rj/rj_miguel_pereira.py
+++ b/data_collection/gazette/spiders/rj/rj_miguel_pereira.py
@@ -4,6 +4,8 @@ from gazette.spiders.base.modernizacao import BaseModernizacaoSpider
 
 
 class RjMiguelPereiraSpider(BaseModernizacaoSpider):
+    zyte_smartproxy_enabled = True
+
     TERRITORY_ID = "3302908"
     name = "rj_miguel_pereira"
     allowed_domains = ["transparencia.miguelpereira.rj.gov.br"]

--- a/data_collection/gazette/spiders/rj/rj_quatis.py
+++ b/data_collection/gazette/spiders/rj/rj_quatis.py
@@ -4,6 +4,8 @@ from gazette.spiders.base.modernizacao import BaseModernizacaoSpider
 
 
 class RjQuatisSpider(BaseModernizacaoSpider):
+    zyte_smartproxy_enabled = True
+
     TERRITORY_ID = "3304128"
     name = "rj_quatis"
     allowed_domains = ["transparencia.quatis.rj.gov.br"]

--- a/data_collection/gazette/spiders/rj/rj_queimados.py
+++ b/data_collection/gazette/spiders/rj/rj_queimados.py
@@ -4,6 +4,8 @@ from gazette.spiders.base.modernizacao import BaseModernizacaoSpider
 
 
 class RjQueimadosSpider(BaseModernizacaoSpider):
+    zyte_smartproxy_enabled = True
+
     TERRITORY_ID = "3304144"
     name = "rj_queimados"
     allowed_domains = ["transparencia.queimados.rj.gov.br"]

--- a/data_collection/gazette/spiders/rj/rj_sao_joao_de_meriti.py
+++ b/data_collection/gazette/spiders/rj/rj_sao_joao_de_meriti.py
@@ -4,6 +4,8 @@ from gazette.spiders.base.modernizacao import BaseModernizacaoSpider
 
 
 class RjSaoJoaoDeMeritiSpider(BaseModernizacaoSpider):
+    zyte_smartproxy_enabled = True
+
     TERRITORY_ID = "3305109"
     name = "rj_sao_joao_de_meriti"
     allowed_domains = ["transparencia.meriti.rj.gov.br"]

--- a/data_collection/gazette/spiders/rj/rj_sao_pedro_da_aldeia.py
+++ b/data_collection/gazette/spiders/rj/rj_sao_pedro_da_aldeia.py
@@ -4,6 +4,8 @@ from gazette.spiders.base.modernizacao import BaseModernizacaoSpider
 
 
 class RjSaoPedroDaAldeiaSpider(BaseModernizacaoSpider):
+    zyte_smartproxy_enabled = True
+
     TERRITORY_ID = "3305208"
     name = "rj_sao_pedro_da_aldeia"
     allowed_domains = ["transparencia.pmspa.rj.gov.br"]


### PR DESCRIPTION
Todos os raspadores em produção de BaseModernizacao não fazem sequer a primeira requisição, enquanto funciona normalmente em execução local. 

Parece ser um caso de bloqueio de IP estrangeiro