### PR TITLE
Cria spider Tres rios 

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_tres_rios.py
+++ b/data_collection/gazette/spiders/rj/rj_tres_rios.py
@@ -1,0 +1,53 @@
+import re
+from datetime import date, datetime as dt
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjTresRiosSpider(BaseGazetteSpider):
+    name = "rj_tres_rios"
+    TERRITORY_ID = "3306008"
+    allowed_domains = ["tresrios.rj.gov.br"]
+    start_urls = ["https://tresrios.rj.gov.br/bio"]
+    start_date = date(2018, 1, 10)
+
+    def parse(self, response):
+        years = response.css("div.wgl-accordion_panel div.wgl-accordion_content")
+        for year in years:
+            for item in year.css("p"):
+                full_text = "".join(item.css("::text").getall())
+                full_text = full_text.replace("/", "-").replace(".", "-")
+
+                gazette_pattern = (
+                    r"^Boletim Informativo.* (\d{4,}).* (\d{2}-\d{2}-\d{4})"
+                )
+                match = re.match(gazette_pattern, full_text)
+                if not match:
+                    continue
+
+                temp_date = dt.strptime(match.group(2), "%d-%m-%Y").date()
+                if temp_date > self.end_date:
+                    continue
+                if temp_date < self.start_date:
+                    return
+
+                num_ed = match.group(1)
+                extra_ed = bool(re.search(r"extra|supl", full_text, re.IGNORECASE))
+
+                # Em algumas edições há mais de um link na descrição da edição e apenas um dos links aponta para a edição correta. Ex. Edição de 16/01/2025
+                # Em outros casos não o número da edição no link. Ex. Edição de 15/01/2021
+
+                links = item.xpath(".//a/@href")
+                if len(links) == 1:
+                    url = links.get()
+                else:
+                    url = item.xpath(f"//a[contains(@href, '{num_ed}')]/@href").get()
+
+                yield Gazette(
+                    date=temp_date,
+                    edition_number=num_ed,
+                    is_extra_edition=extra_ed,
+                    file_urls=[url],
+                    power="executive",
+                )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [X] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [X] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [X] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [X] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [X] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[ultima.log](https://github.com/user-attachments/files/19324123/ultima.log)
[ultima.csv](https://github.com/user-attachments/files/19324124/ultima.csv)
[intervalo.csv](https://github.com/user-attachments/files/19324125/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/19324127/intervalo.log)
[completa.log](https://github.com/user-attachments/files/19324129/completa.log)
[completa.csv](https://github.com/user-attachments/files/19324131/completa.csv)


#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [X] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [X] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

Cria spider para Três Rios #1215 

na coleta completa o erro ocorre devido a um link quebrado no site da prefeitura, do dia: 15/01/2020
