### PR TITLE
Adjusting Camaquâ/RS spider to support new replicate system AtendeV2.

### DIFF
--- a/data_collection/gazette/spiders/rs/rs_camaqua.py
+++ b/data_collection/gazette/spiders/rs/rs_camaqua.py
@@ -1,11 +1,10 @@
 from datetime import date
 
-from gazette.spiders.base.instar import BaseInstarSpider
+from gazette.spiders.base.atende_v2 import BaseAtendeV2Spider
 
 
-class RsCamaquaSpider(BaseInstarSpider):
-    TERRITORY_ID = "4303509"
+class RsCamaquaSpider(BaseAtendeV2Spider):
     name = "rs_camaqua"
-    base_url = "https://www.camaqua.rs.gov.br/portal/diario-oficial"
+    TERRITORY_ID = "4303509"
+    city_subdomain = "camaqua"
     start_date = date(2019, 7, 25)
-    end_date = date(2023, 7, 19)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [X] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [X] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [X] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [X] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [X] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [X] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [X] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

<Descreva o seu Pull Request informando a issue (caso exista) que está sendo solucionada ou uma descrição do código apresentado>

Ajustando a aranha Camaquâ/RS para suportar o novo sistema de replicação AtendeV2. Issue [#1038](https://github.com/okfn-brasil/querido-diario/issues/1038)

[camaqua_rs-2025-07-07-2025-07-11.csv](https://github.com/user-attachments/files/21206750/camaqua_rs-2025-07-07-2025-07-11.csv)
[camaqua_rs-2025-07-07-2025-07-11.log](https://github.com/user-attachments/files/21206751/camaqua_rs-2025-07-07-2025-07-11.log)
[camaqua_rs-2025-07-11.log](https://github.com/user-attachments/files/21206752/camaqua_rs-2025-07-11.log)
[camaqua_rs-full.csv](https://github.com/user-attachments/files/21206783/camaqua_rs-full.csv)
[camaqua_rs-full.log](https://github.com/user-attachments/files/21206785/camaqua_rs-full.log)
