### PR TITLE
Adicionar raspador para Barueri SP

### DIFF
--- a/data_collection/gazette/spiders/sp/sp_barueri.py
+++ b/data_collection/gazette/spiders/sp/sp_barueri.py
@@ -1,0 +1,101 @@
+import datetime as dt
+import re
+from datetime import date
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class SpBarueriSpider(BaseGazetteSpider):
+    name = "sp_barueri"
+    TERRITORY_ID = "3505708"
+    allowed_domains = ["portal.barueri.sp.gov.br"]
+    PAGINATION_URL = "https://portal.barueri.sp.gov.br/Diario/CbkOutrosDiarios"
+    start_urls = ["https://portal.barueri.sp.gov.br/diario"]
+    EDITION_NUMBER_REGEX = re.compile(r"Edição\s+(\d+)")
+    start_date = date(2010, 1, 6)
+
+    def parse(self, response):
+        follow_next_page = True
+        current_page = response.xpath(
+            '//div[contains(@class, "pagination")]//select/option[@selected]/@value'
+        ).get()
+
+        if current_page == "1":
+            recentGazettes = response.xpath(
+                "//div[contains(@class, 'container') and contains(@class, 'container-diario')]"
+            )
+            for gazette in recentGazettes:
+                raw_date = gazette.xpath(
+                    ".//div[contains(@class, 'diarioTopoText')][1]//b/text()"
+                ).get()
+                date = dt.datetime.strptime(raw_date, "%d/%m/%Y").date()
+
+                if date < self.start_date:
+                    follow_next_page = False
+                    break
+
+                if date > self.end_date:
+                    continue
+
+                edition_number = gazette.xpath(
+                    ".//div[contains(@class, 'diarioTopoText')][2]/text()"
+                ).get()
+                url = gazette.xpath(
+                    ".//a[contains(@class, 'acessarJornal')]/@href"
+                ).get()
+                distribution = gazette.xpath(
+                    ".//div[contains(@class, 'diarioTopoText')][4]/text()"
+                ).get()
+                is_extra_edition = "extraordinária" in distribution.lower()
+
+                item = Gazette(
+                    date=date,
+                    file_urls=[url],
+                    is_extra_edition=is_extra_edition,
+                    power="executive_legislative",
+                    edition_number=edition_number,
+                )
+                yield item
+
+        gazettes = response.xpath('//table[contains(@class, "OutrosDiarios")]//tr')
+        for gazette in gazettes:
+            raw_date = gazette.xpath("./td/div/b/text()").get()
+            date = dt.datetime.strptime(raw_date, "%d/%m/%Y").date()
+
+            if date < self.start_date:
+                follow_next_page = False
+                break
+
+            if date > self.end_date:
+                continue
+
+            url = gazette.xpath("./td/a/@href").get()
+            text = gazette.xpath("./td/div[2]/text()").get()
+            edition_number = int(self.EDITION_NUMBER_REGEX.search(text).group(1))
+            is_extra_edition = "extraordinária" in text.lower()
+
+            item = Gazette(
+                date=date,
+                file_urls=[url],
+                is_extra_edition=is_extra_edition,
+                power="executive_legislative",
+                edition_number=edition_number,
+            )
+            yield item
+
+        if follow_next_page:
+            page_options = response.xpath(
+                '//div[contains(@class, "pagination")]//select/option/@value'
+            ).getall()
+            next_page = str(int(current_page) + 1)
+            if next_page in page_options:
+                formdata = {"pagina": str(next_page)}
+                yield scrapy.FormRequest(
+                    url=self.PAGINATION_URL,
+                    formdata=formdata,
+                    callback=self.parse,
+                    method="POST",
+                )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
[sp_barueri_ultima_edicao.csv](https://github.com/user-attachments/files/21568113/sp_barueri_ultima_edicao.csv)
[log_sp_barueri_ultima_edicao.txt](https://github.com/user-attachments/files/21568114/log_sp_barueri_ultima_edicao.txt)

- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
[log_sp_barueri_ano_2014.txt](https://github.com/user-attachments/files/21568150/log_sp_barueri_ano_2014.txt)
[sp_barueri_ano_2014.csv](https://github.com/user-attachments/files/21568154/sp_barueri_ano_2014.csv)

- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[sp_barueri_completo.csv](https://github.com/user-attachments/files/21568123/sp_barueri_completo.csv)
[log_sp_barueri_completo.txt](https://github.com/user-attachments/files/21568124/log_sp_barueri_completo.txt)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição
O diário de [Barueri SP](https://portal.barueri.sp.gov.br/Diario) tem duas seções principais, uma chamada **Adicionados Recentemente** que sempre exibe os últimos 4 diários (independente da página), e uma com outros 20 diários (em ordem cronológica), que permite paginação.
![image](https://github.com/user-attachments/assets/cb6cf2db-f67c-4ee6-a7d4-ac064e2f74d6)

O Spider implementado inicia com a URL `https://portal.barueri.sp.gov.br/Diario`, para os 4 diários mais recentes e os 20 dispostos inicialmente na seção de paginação, e vai iterando sobre a paginação disponível pelo diário, pela URL `https://portal.barueri.sp.gov.br/Diario/CbkOutrosDiarios` enquanto os parametros `end_date` e `start_date` forem válidos para as datas dos diários.

Existe um if `if current_page == "1":` que permite buscar apenas os diários da seção **Adicionados Recentemente** na primeira página, para que isso não se repita desnecessariamente nas demais páginas.

resolves https://github.com/okfn-brasil/querido-diario/issues/883