### PR TITLE
Cria Spider Rj_Macuco #1200

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_macuco.py
+++ b/data_collection/gazette/spiders/rj/rj_macuco.py
@@ -1,0 +1,50 @@
+import re
+from datetime import date, datetime
+from urllib.parse import quote
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjMacucoSpider(BaseGazetteSpider):
+    name = "rj_macuco"
+    TERRITORY_ID = "3302452"
+    allowed_domains = ["prefeituramacuco.rj.gov.br"]
+    start_date = date(2021, 3, 5)
+
+    def start_requests(self):
+        start_year = self.start_date.year
+        end_year = self.end_date.year
+        for year in range(start_year, end_year + 1):
+            url = f"https://prefeituramacuco.rj.gov.br/transparencia_api/diario/buscar?ano={year}"
+            yield scrapy.Request(url)
+
+    def parse(self, response):
+        data = response.json()
+        for gazette in data:
+            date_str = gazette.get("data_p")
+            date_str = date_str[:10]
+            file_url = "https://prefeituramacuco.rj.gov.br/transparencia" + quote(
+                gazette.get("arquivo")
+            )
+            edition_number = gazette.get("edicao", "")
+            edition_number = re.sub(r"\D", "", edition_number)
+            is_extra_edition = "suplementar" in gazette.get("arquivo", "").lower()
+
+            publication_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+
+            if publication_date > self.end_date:
+                continue
+
+            if publication_date < self.start_date:
+                return
+
+            yield Gazette(
+                date=publication_date,
+                edition_number=edition_number,
+                is_extra_edition=is_extra_edition,
+                file_urls=[file_url],
+                power="executive",
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [X] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [X] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [X] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [X] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [X] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[ultima.csv](https://github.com/user-attachments/files/21779655/ultima.csv)
[ultima.log](https://github.com/user-attachments/files/21779656/ultima.log)
[intervalo.csv](https://github.com/user-attachments/files/21779657/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/21779658/intervalo.log)
[completo.csv](https://github.com/user-attachments/files/21779659/completo.csv)
[completo.log](https://github.com/user-attachments/files/21779660/completo.log)

#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [X] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [X] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

Resolve #1200 
cria spider para o município Macuco-RJ
