### PR TITLE
Atualiza Spider Base portal_gov #1402

### DIFF
--- a/data_collection/gazette/spiders/base/portalgov.py
+++ b/data_collection/gazette/spiders/base/portalgov.py
@@ -1,6 +1,5 @@
 import re
 from datetime import datetime as dt
-from urllib.parse import urlparse
 
 import scrapy
 from scrapy.exceptions import NotConfigured
@@ -16,17 +15,14 @@ class BasePortalGovSpider(BaseGazetteSpider):
         if not hasattr(self, "power"):
             raise NotConfigured("Please set a value for `power`")
 
-        self.allowed_domains = [urlparse(self.website).netloc]
+        self.allowed_domains = [self.website]
 
         super(BasePortalGovSpider, self).__init__(*args, **kwargs)
 
     def start_requests(self):
         yield scrapy.FormRequest(
             url=f"https://{self.website}/controllers/diario_oficial/class_diario.php",
-            formdata={
-                "func": "5",
-                "param": "1",
-            },
+            formdata={"func": "5", "param": "1"},
         )
 
     def parse(self, response):
@@ -45,7 +41,7 @@ class BasePortalGovSpider(BaseGazetteSpider):
                 re.search(r"extra|supl", gazette_edition + gazette_desc, re.IGNORECASE)
             )
 
-            gazette_url = f"https://{self.domain}/arquivos/diario_oficial/{gazette_data['arquivo']}"
+            gazette_url = f"https://{self.website}/arquivos/diario_oficial/{gazette_data['arquivo']}"
 
             yield Gazette(
                 date=gazette_date,


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Trata-se de uma correção de um Spider base

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [X] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [X] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [X] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [X] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[ultima.csv](https://github.com/user-attachments/files/22102604/ultima.csv)
[ultima.log](https://github.com/user-attachments/files/22102605/ultima.log)
[intervalo.csv](https://github.com/user-attachments/files/22102606/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/22102608/intervalo.log)
[completo.csv](https://github.com/user-attachments/files/22102609/completo.csv)
[completo.log](https://github.com/user-attachments/files/22102610/completo.log)


#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [X] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [X] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

PR criado para consertar o Spider Base de PortalGov
