### PR TITLE
Sao fidelis

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_sao_fidelis.py
+++ b/data_collection/gazette/spiders/rj/rj_sao_fidelis.py
@@ -1,0 +1,71 @@
+from datetime import datetime as dt
+
+import dateparser
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjSaoFidelisSpider(BaseGazetteSpider):
+    name = "rj_sao_fidelis"
+    TERRITORY_ID = "3304805"
+    allowed_domains = ["saofidelis.rj.gov.br"]
+    start_urls = ["https://saofidelis.rj.gov.br/diariooficial/"]
+    start_date = dt(2017, 7, 1).date()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if "start_date" in kwargs:
+            self.start_date = dt.strptime(kwargs["start_date"], "%Y-%m-%d").date()
+
+        if "end_date" in kwargs:
+            self.end_date = dt.strptime(kwargs["end_date"], "%Y-%m-%d").date()
+        else:
+            self.end_date = dt.today().date()
+
+    def parse(self, response):
+        year_buttons = response.xpath('//button[contains(@id, "e-n-tab-title")]')
+
+        for button in year_buttons:
+            year_container_id = button.xpath("./@aria-controls").get()
+            year_container = response.xpath(f'//div[@id="{year_container_id}"]')
+            accordion_items = year_container.xpath(
+                './/details[contains(@class,"e-n-accordion-item")]'
+            )
+
+            for accordion in accordion_items:
+                paragraphs = accordion.xpath(
+                    './/div[contains(@class,"elementor-widget-text-editor")]//p'
+                )
+
+                for p in paragraphs:
+                    date_str = p.xpath("text()[1]").re_first(r"(\d{2} de \w+ de \d{4})")
+                    if not date_str:
+                        continue
+
+                    gazette_date = dateparser.parse(
+                        date_str.strip(), languages=["pt"]
+                    ).date()
+                    if gazette_date > self.end_date:
+                        continue
+
+                    if gazette_date < self.start_date:
+                        return
+
+                    edition = p.xpath(
+                        './/strong[contains(text(),"Edição")]/text()'
+                    ).re_first(r"Edição\s*(\d+[.\d]*)")
+                    gazette_url = p.xpath(
+                        './/a[contains(text(),"Download")]/@href'
+                    ).get()
+
+                    if gazette_url:
+                        gazette_url = response.urljoin(gazette_url)
+
+                        yield Gazette(
+                            date=gazette_date,
+                            edition_number=edition,
+                            is_extra_edition=False,
+                            file_urls=[gazette_url],
+                            power="executive",
+                        )

--- a/data_collection/gazette/spiders/rj/rj_sao_fidelis.py
+++ b/data_collection/gazette/spiders/rj/rj_sao_fidelis.py
@@ -1,9 +1,8 @@
-from datetime import datetime as dt
-
-import dateparser
+from datetime import date
 
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
+from gazette.utils.extraction import get_date_from_text
 
 
 class RjSaoFidelisSpider(BaseGazetteSpider):
@@ -11,7 +10,7 @@ class RjSaoFidelisSpider(BaseGazetteSpider):
     TERRITORY_ID = "3304805"
     allowed_domains = ["saofidelis.rj.gov.br"]
     start_urls = ["https://saofidelis.rj.gov.br/diariooficial/"]
-    start_date = dt(2017, 7, 1).date()
+    start_date = date(2017, 7, 1)
 
     def parse(self, response):
         year_buttons = response.xpath('//button[contains(@id, "e-n-tab-title")]')
@@ -33,9 +32,7 @@ class RjSaoFidelisSpider(BaseGazetteSpider):
                     if not date_str:
                         continue
 
-                    gazette_date = dateparser.parse(
-                        date_str.strip(), languages=["pt"]
-                    ).date()
+                    gazette_date = get_date_from_text(date_str)
                     if gazette_date > self.end_date:
                         continue
 

--- a/data_collection/gazette/spiders/rj/rj_sao_fidelis.py
+++ b/data_collection/gazette/spiders/rj/rj_sao_fidelis.py
@@ -13,16 +13,6 @@ class RjSaoFidelisSpider(BaseGazetteSpider):
     start_urls = ["https://saofidelis.rj.gov.br/diariooficial/"]
     start_date = dt(2017, 7, 1).date()
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if "start_date" in kwargs:
-            self.start_date = dt.strptime(kwargs["start_date"], "%Y-%m-%d").date()
-
-        if "end_date" in kwargs:
-            self.end_date = dt.strptime(kwargs["end_date"], "%Y-%m-%d").date()
-        else:
-            self.end_date = dt.today().date()
-
     def parse(self, response):
         year_buttons = response.xpath('//button[contains(@id, "e-n-tab-title")]')
 


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[ultima.log](https://github.com/user-attachments/files/22125346/ultima.log)
[intervalo.log](https://github.com/user-attachments/files/22125347/intervalo.log)
[intervalo.csv](https://github.com/user-attachments/files/22125348/intervalo.csv)
[completa.log](https://github.com/user-attachments/files/22125349/completa.log)
[completa.csv](https://github.com/user-attachments/files/22125350/completa.csv)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

resolve #1220 
