### PR TITLE
Atualiza rj_varre_sai para novo sistema

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_varre_sai.py
+++ b/data_collection/gazette/spiders/rj/rj_varre_sai.py
@@ -1,11 +1,48 @@
-from datetime import date
+import re
+from datetime import date, datetime
 
-from gazette.spiders.base.portalgov import BasePortalGovSpider
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class RjVarreSaiSpider(BasePortalGovSpider):
+class RjVarreSaiSpider(BaseGazetteSpider):
     name = "rj_varre_sai"
     TERRITORY_ID = "3306156"
     start_date = date(2019, 9, 21)
-    power = "executive_legislative"
-    website = "varresai.rj.gov.br"
+    allowed_domains = ["dados.varresai.rj.gov.br"]
+    start_urls = ["https://varresai.rj.gov.br/diarios-oficiais/"]
+
+    def parse(self, response):
+        script_content = response.xpath(
+            '//script[contains(text(), "window.__NUXT__")]/text()'
+        ).get()
+        match = re.search(r'key:"([^"]+)"', script_content)
+        if match:
+            key_value = match.group(1)
+            headers = {"key": key_value, "content-type": "application/json"}
+            url = "https://dados.varresai.rj.gov.br/api/diarios-oficiais/lista/simples"
+            yield scrapy.Request(url=url, headers=headers, callback=self.gazette_parse)
+
+    def gazette_parse(self, response):
+        for gazette in response.json()["payload"]:
+            gazette_date = datetime.strptime(
+                gazette["data_publicacao"][:10], "%Y-%m-%d"
+            ).date()
+            if gazette_date > self.end_date:
+                continue
+
+            if gazette_date < self.start_date:
+                return
+
+            edition_number = gazette["numero"].lstrip("0")
+            url = response.urljoin(gazette["arquivo"])
+
+            yield Gazette(
+                date=gazette_date,
+                edition_number=edition_number,
+                is_extra_edition=False,
+                file_urls=[url],
+                power="executive_legislative",
+            )


### PR DESCRIPTION
#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

[completa.csv](https://github.com/user-attachments/files/22127756/completa.csv)
[completa.log](https://github.com/user-attachments/files/22127757/completa.log)
[intervalo.csv](https://github.com/user-attachments/files/22127758/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/22127759/intervalo.log)
[ultimo.csv](https://github.com/user-attachments/files/22127760/ultimo.csv)
[ultimo.log](https://github.com/user-attachments/files/22127761/ultimo.log)


#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

resolve #1409

Atualiza rj_varre_sai, que passou a usar sistema próprio.
