### PR TITLE
Cria Spider Rj_Paracambi #1204

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_paracambi.py
+++ b/data_collection/gazette/spiders/rj/rj_paracambi.py
@@ -1,0 +1,71 @@
+import re
+from datetime import date, datetime
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RjParacambiSpider(BaseGazetteSpider):
+    name = "rj_paracambi"
+    TERRITORY_ID = "3303609"
+    allowed_domains = ["paracambi.rj.gov.br"]
+    start_urls = ["https://paracambi.rj.gov.br/diario-oficial-eletronico-2025/"]
+    start_date = date(2020, 2, 4)
+
+    def parse(self, response):
+        years_link = response.css(
+            "a.wp-block-button__link.has-background.wp-element-button::attr(href)"
+        ).getall()
+        for link in years_link:
+            year = int(re.sub(r"\D", "", link))
+            if self.start_date.year <= year <= self.end_date.year:
+                yield scrapy.Request(
+                    url=link,
+                    callback=self.parse_month,
+                    cb_kwargs={"year": year},
+                )
+
+    def parse_month(self, response, year):
+        months = response.css("div.tab-content div.tab-pane")
+        for month in months:
+            current_month = month.css("::attr(id)").get()
+            current_month = int(re.search(r"(\d+)$", current_month).group()) + 1
+
+            current_date = date(year, current_month, 1)
+
+            if current_date < date(self.start_date.year, self.start_date.month, 1):
+                continue
+
+            if current_date > date(self.end_date.year, self.end_date.month, 1):
+                return
+
+            days = month.css("li")
+            for day in days:
+                edition_text = day.css("a::text").get() or day.css("span::text").get()
+                if not edition_text:
+                    continue
+
+                date_match = re.search(r"\d{2}\.\d{2}\.\d{4}", edition_text)
+                if not date_match:
+                    continue
+
+                edition_date = datetime.strptime(date_match.group(), "%d.%m.%Y").date()
+
+                if not self.start_date <= edition_date <= self.end_date:
+                    continue
+
+                edition_url = day.css("a::attr(href)").get()
+                extra_edition = "extra" in edition_text.lower()
+
+                edition_num_match = re.search(r"Ed(\d+)", edition_text)
+                edition_num = edition_num_match.group(1) if edition_num_match else None
+
+                yield Gazette(
+                    date=edition_date,
+                    edition_number=edition_num,
+                    is_extra_edition=extra_edition,
+                    file_urls=[edition_url],
+                    power="executive",
+                )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [X] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [X] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [X] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [X] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [X] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[completo.csv](https://github.com/user-attachments/files/22146450/completo.csv)
[completo.log](https://github.com/user-attachments/files/22146454/completo.log)
[intervalo.csv](https://github.com/user-attachments/files/22146459/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/22146460/intervalo.log)
[ultima.csv](https://github.com/user-attachments/files/22146463/ultima.csv)
[ultima.log](https://github.com/user-attachments/files/22146465/ultima.log)


#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [X] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [X] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

Cria spider para o município de Paracambi, resolve #1204 
