### PR TITLE
Cria Spider Rj_BomJardim

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_bom_jardim.py
+++ b/data_collection/gazette/spiders/rj/rj_bom_jardim.py
@@ -1,0 +1,46 @@
+import re
+from datetime import date
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+from gazette.utils.extraction import get_date_from_text
+
+
+class RjBomJardimSpider(BaseGazetteSpider):
+    name = "rj_bom_jardim"
+    TERRITORY_ID = "3300506"
+    allowed_domains = ["diario-oficial.online"]
+    start_urls = ["https://diario-oficial.online/publicacoes/todas/1?page=1"]
+    start_date = date(2023, 2, 15)
+
+    def parse(self, response):
+        data = response.css("div.col-lg-4")
+        for item in data:
+            edition_number = item.css("h5::text").get().strip()
+            extra_edition = "extra" in edition_number.lower()
+            edition_number = re.sub(r"\D", "", edition_number)
+
+            raw_edition_date = (
+                item.css('span[style="font-size: 12px;"]::text').get().strip()
+            )
+            edition_date = get_date_from_text(raw_edition_date)
+
+            if edition_date > self.end_date:
+                continue
+            if edition_date < self.start_date:
+                return
+
+            edition_url = item.css("div.option-box a::attr(href)").get()
+            edition_url = response.urljoin(edition_url)
+
+            yield Gazette(
+                date=edition_date,
+                edition_number=edition_number,
+                is_extra_edition=extra_edition,
+                file_urls=[edition_url],
+                power="executive",
+            )
+
+        next_page = response.css('a[aria-label="Próxima"]::attr(href)').get()
+        if next_page:
+            yield response.follow(next_page, callback=self.parse)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [X] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [X] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [X] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [X] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [X] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [X] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [X] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [X] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [X] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[completo.csv](https://github.com/user-attachments/files/22216322/completo.csv)
[completo.log](https://github.com/user-attachments/files/22216323/completo.log)
[intervalo.csv](https://github.com/user-attachments/files/22216324/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/22216326/intervalo.log)
[ultima.csv](https://github.com/user-attachments/files/22216327/ultima.csv)
[ultima.log](https://github.com/user-attachments/files/22216328/ultima.log)

#### Verificações
- [X] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [X] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [X] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição
Cria spider Bom Jardim, resolve #1193 
