### PR TITLE
add spider rj_sao_francisco_de_itabopoana

### DIFF
--- a/data_collection/gazette/spiders/rj/rj_sao_francisco_de_itabopoana.py
+++ b/data_collection/gazette/spiders/rj/rj_sao_francisco_de_itabopoana.py
@@ -1,0 +1,80 @@
+import re
+from datetime import date
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+from gazette.utils.extraction import get_date_from_text
+
+
+class RjSaoFranciscoDeItabopoanaSpider(BaseGazetteSpider):
+    TERRITORY_ID = "3304755"
+    name = "rj_sao_francisco_de_itabopoana"
+    allowed_domains = ["pmsfi.rj.gov.br"]
+    start_urls = ["https://pmsfi.rj.gov.br/diariooficial/"]
+    start_date = date(2016, 12, 1)
+
+    def parse(self, response):
+        year_links = response.css("div.pd-subcategory a::attr(href)").getall()
+
+        for link in year_links:
+            yield response.follow(link, self.parse_year_page)
+
+    def parse_year_page(self, response):
+        month_links = response.css("div.pd-subcategory a::attr(href)").getall()
+
+        for link in month_links:
+            yield scrapy.Request(
+                url=response.urljoin(link), callback=self.parse_month_page
+            )
+
+    def parse_month_page(self, response):
+        gazettes = response.css("div.pd-filebox, div.pd-document, .itemContainer")
+
+        if not gazettes:
+            return
+
+        for gazette in gazettes:
+            download_url = gazette.css('a[href*="download"]::attr(href)').get()
+            if not download_url:
+                continue
+
+            date_string = None
+            details_button = gazette.css(
+                'a[onmouseover*="overlib"]::attr(onmouseover)'
+            ).get()
+
+            gazette_date = get_date_from_text(details_button)
+
+            if gazette_date > self.end_date:
+                continue
+
+            if gazette_date < self.start_date:
+                return
+
+            if details_button:
+                date_match = re.search(
+                    r"Data:.*?<div class=\\'pd-fl-m\\'>(\d{1,2}\s+\w+\s+\d{4})<\/div>",
+                    details_button,
+                    re.IGNORECASE,
+                )
+                if date_match:
+                    date_string = date_match.group(1)
+
+            if not date_string:
+                continue
+
+            title = gazette.css("div.pd-title::text").get()
+
+            is_extra = "suplemento" in title.lower() or "extra" in title.lower()
+            edition_number_match = re.search(r"(\d+)", title)
+            edition_number = edition_number_match.group(1)
+
+            yield Gazette(
+                date=gazette_date,
+                edition_number=edition_number,
+                is_extra_edition=is_extra,
+                file_urls=[response.urljoin(download_url)],
+                power="executive",
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.


#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
[intervalo.csv](https://github.com/user-attachments/files/22363445/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/22363446/intervalo.log)
[completa.csv](https://github.com/user-attachments/files/22363447/completa.csv)
[completa.log](https://github.com/user-attachments/files/22363448/completa.log)

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

resolve #1209
