### PR TITLE
Crawlers de Carmo - RJ e Barra do Corda - MA

### DIFF
--- a/data_collection/gazette/spiders/ma/ma_barra_do_corda.py
+++ b/data_collection/gazette/spiders/ma/ma_barra_do_corda.py
@@ -1,14 +1,13 @@
 import datetime
 import json
 
-# Importe 'exceptions' do Scrapy para o try/except
 from scrapy import Request, exceptions
 
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
 
-class MABarraDoCordaSpider(BaseGazetteSpider):  # Mantive o nome da sua classe
+class MABarraDoCordaSpider(BaseGazetteSpider):
     TERRITORY_ID = "2101608"
     name = "ma_barra_do_corda"
     allowed_domains = ["dom.barradocorda.ma.gov.br"]
@@ -16,7 +15,6 @@ class MABarraDoCordaSpider(BaseGazetteSpider):  # Mantive o nome da sua classe
     BASE_API_URL = "https://dom.barradocorda.ma.gov.br/api/v1/diary/editions"
     BASE_PDF_URL = "https://dom.barradocorda.ma.gov.br/uploads/editions/13/"
 
-    # Mantive a data de início que você colocou
     start_date = datetime.date(2022, 1, 10)
 
     static_body_payload = json.dumps(
@@ -52,10 +50,10 @@ class MABarraDoCordaSpider(BaseGazetteSpider):  # Mantive o nome da sua classe
             method="POST",
             body=self.static_body_payload,
             headers={"Content-Type": "application/json"},
-            callback=self.parse,  # Mantive o nome do seu callback
+            callback=self.parse,
         )
 
-    def parse(self, response):  # Mantive o nome do seu método
+    def parse(self, response):
         """Processa o JSON da API, filtra por data e cuida da paginação."""
 
         if response.status != 200:
@@ -67,7 +65,6 @@ class MABarraDoCordaSpider(BaseGazetteSpider):  # Mantive o nome da sua classe
         try:
             data = response.json()
             editions_data = data["data"]["editions"]
-        # Use o 'exceptions' importado
         except (exceptions.JSONDecodeError, KeyError) as e:
             self.logger.error(
                 f"Erro ao processar JSON da API: {e} - URL: {response.url}"
@@ -79,7 +76,6 @@ class MABarraDoCordaSpider(BaseGazetteSpider):  # Mantive o nome da sua classe
             self.logger.info(f"Nenhum diário encontrado na página: {response.url}")
             return
 
-        # self.start_date e self.end_date são garantidamente 'date' objects
         start_date_obj = self.start_date
         end_date_obj = self.end_date
 
@@ -95,20 +91,14 @@ class MABarraDoCordaSpider(BaseGazetteSpider):  # Mantive o nome da sua classe
 
             oldest_date_in_page = edition_date
 
-            # --- A CORREÇÃO ---
-            # Adiciona o filtro para end_date aqui
-            # Compara date <= date e date >= date
             if not (start_date_obj <= edition_date <= end_date_obj):
-                # Se a data estiver FORA do intervalo [start_date, end_date], pula o item
                 continue
-            # --- FIM DA CORREÇÃO ---
 
             filename = item.get("file")
             if not filename:
                 self.logger.warning(f"Item sem 'file': {item}")
                 continue
 
-            # Corrige URL para arquivos antigos (wp-content)
             if filename.startswith("wp-content"):
                 pdf_url = f"https://dom.barradocorda.ma.gov.br/{filename}"
             else:
@@ -123,8 +113,6 @@ class MABarraDoCordaSpider(BaseGazetteSpider):  # Mantive o nome da sua classe
                 power="executive",
             )
 
-        # Lógica de Paginação (Otimizada)
-        # Compara date < date
         if oldest_date_in_page and oldest_date_in_page < start_date_obj:
             self.logger.info(
                 "Data mais antiga da página é anterior ao start_date. Parando paginação."
@@ -138,5 +126,5 @@ class MABarraDoCordaSpider(BaseGazetteSpider):  # Mantive o nome da sua classe
                 method="POST",
                 body=self.static_body_payload,
                 headers={"Content-Type": "application/json"},
-                callback=self.parse,  # Mantive o nome do seu callback
+                callback=self.parse,
             )

--- a/data_collection/gazette/spiders/ma/ma_barra_do_corda.py
+++ b/data_collection/gazette/spiders/ma/ma_barra_do_corda.py
@@ -1,0 +1,121 @@
+import json
+import datetime
+
+from scrapy import Request, exceptions
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class MABarraDoCordaSpider(BaseGazetteSpider):
+    
+    TERRITORY_ID = "2101608"
+    name = "ma_barra_do_corda"
+    allowed_domains = ["dom.barradocorda.ma.gov.br"]
+    
+    BASE_API_URL = "https://dom.barradocorda.ma.gov.br/api/v1/diary/editions"
+    BASE_PDF_URL = "https://dom.barradocorda.ma.gov.br/uploads/editions/13/"
+
+    start_date = datetime.date(2018, 3, 8) 
+    
+    static_body_payload = json.dumps({
+        "slug": "dom.barradocorda.ma.gov.br",
+        "dates": "",
+        "term": "",
+        "type_publication": "",
+        "type_book": "",
+        "number_edition": "",
+        "limit": "10", 
+    })
+
+    def __init__(self, *args, **kwargs):
+        """
+        Garante que start_date e end_date sejam objetos date,
+        mesmo se passados como string pela linha de comando.
+        """
+        super().__init__(*args, **kwargs)
+
+        if isinstance(self.start_date, str):
+            self.start_date = datetime.date.fromisoformat(self.start_date)
+        if isinstance(self.end_date, str):
+            self.end_date = datetime.date.fromisoformat(self.end_date)
+    
+
+    def start_requests(self):
+        
+        start_url_page_1 = f"{self.BASE_API_URL}?page=1"
+        
+        yield Request(
+            url=start_url_page_1,
+            method="POST",
+            body=self.static_body_payload,
+            headers={"Content-Type": "application/json"},
+            callback=self.parse_api,
+        )
+
+    def parse_api(self, response):
+        """ Processa o JSON da API e cuida da paginação. """
+        
+        if response.status != 200:
+            self.logger.error(
+                f"Falha ao acessar a API. Status: {response.status}. URL: {response.url}"
+            )
+            return
+
+        try:
+            data = response.json()
+            editions_data = data["data"]["editions"]
+        except (exceptions.JSONDecodeError, KeyError) as e:
+            self.logger.error(f"Erro ao processar JSON da API: {e} - URL: {response.url}")
+            return
+
+        gazettes = editions_data.get("data", [])
+        if not gazettes:
+            self.logger.info(f"Nenhum diário encontrado na página: {response.url}")
+            return
+
+        start_date_obj = self.start_date 
+
+        oldest_date_in_page = None
+
+        for item in gazettes:
+            try:
+                edition_date_str = item["created_at"].split("T")[0]
+                edition_date = datetime.date.fromisoformat(edition_date_str)
+            except (KeyError, ValueError):
+                self.logger.warning(f"Não foi possível extrair a data do item: {item}")
+                continue
+
+            oldest_date_in_page = edition_date 
+
+            filename = item.get("file")
+            if not filename:
+                self.logger.warning(f"Item sem 'file': {item}")
+                continue
+            
+            if filename.startswith("wp-content"):
+                 pdf_url = f"https://dom.barradocorda.ma.gov.br/{filename}"
+            else:
+                 main_filename = filename.replace("_signature", "")
+                 pdf_url = self.BASE_PDF_URL + main_filename
+
+            yield Gazette(
+                date=edition_date,
+                edition_number=str(item.get("edition_number") or ""),
+                is_extra_edition=bool(item.get("extra", 0)),
+                file_urls=[pdf_url], 
+                power="executive",
+            )
+
+        if oldest_date_in_page and oldest_date_in_page < start_date_obj:
+             self.logger.info("Data mais antiga da página é anterior ao start_date. Parando paginação.")
+             return
+
+        next_page_url = editions_data.get("next_page_url")
+        if next_page_url:
+            yield Request(
+                url=next_page_url, 
+                method="POST",
+                body=self.static_body_payload,
+                headers={"Content-Type": "application/json"},
+                callback=self.parse_api,
+            )

--- a/data_collection/gazette/spiders/ma/ma_barra_do_corda.py
+++ b/data_collection/gazette/spiders/ma/ma_barra_do_corda.py
@@ -1,31 +1,33 @@
-import json
 import datetime
+import json
 
 from scrapy import Request, exceptions
+
 from gazette.items import Gazette
 from gazette.spiders.base import BaseGazetteSpider
 
 
 class MABarraDoCordaSpider(BaseGazetteSpider):
-    
     TERRITORY_ID = "2101608"
     name = "ma_barra_do_corda"
     allowed_domains = ["dom.barradocorda.ma.gov.br"]
-    
+
     BASE_API_URL = "https://dom.barradocorda.ma.gov.br/api/v1/diary/editions"
     BASE_PDF_URL = "https://dom.barradocorda.ma.gov.br/uploads/editions/13/"
 
-    start_date = datetime.date(2018, 3, 8) 
-    
-    static_body_payload = json.dumps({
-        "slug": "dom.barradocorda.ma.gov.br",
-        "dates": "",
-        "term": "",
-        "type_publication": "",
-        "type_book": "",
-        "number_edition": "",
-        "limit": "10", 
-    })
+    start_date = datetime.date(2022, 1, 10)
+
+    static_body_payload = json.dumps(
+        {
+            "slug": "dom.barradocorda.ma.gov.br",
+            "dates": "",
+            "term": "",
+            "type_publication": "",
+            "type_book": "",
+            "number_edition": "",
+            "limit": "10",
+        }
+    )
 
     def __init__(self, *args, **kwargs):
         """
@@ -38,23 +40,22 @@ class MABarraDoCordaSpider(BaseGazetteSpider):
             self.start_date = datetime.date.fromisoformat(self.start_date)
         if isinstance(self.end_date, str):
             self.end_date = datetime.date.fromisoformat(self.end_date)
-    
+        print(self.end_date)
 
     def start_requests(self):
-        
+        """Envia o primeiro POST para a página 1."""
         start_url_page_1 = f"{self.BASE_API_URL}?page=1"
-        
         yield Request(
             url=start_url_page_1,
             method="POST",
             body=self.static_body_payload,
             headers={"Content-Type": "application/json"},
-            callback=self.parse_api,
+            callback=self.parse,
         )
 
-    def parse_api(self, response):
-        """ Processa o JSON da API e cuida da paginação. """
-        
+    def parse(self, response):
+        """Processa o JSON da API, filtra por data e cuida da paginação."""
+
         if response.status != 200:
             self.logger.error(
                 f"Falha ao acessar a API. Status: {response.status}. URL: {response.url}"
@@ -65,7 +66,9 @@ class MABarraDoCordaSpider(BaseGazetteSpider):
             data = response.json()
             editions_data = data["data"]["editions"]
         except (exceptions.JSONDecodeError, KeyError) as e:
-            self.logger.error(f"Erro ao processar JSON da API: {e} - URL: {response.url}")
+            self.logger.error(
+                f"Erro ao processar JSON da API: {e} - URL: {response.url}"
+            )
             return
 
         gazettes = editions_data.get("data", [])
@@ -73,7 +76,8 @@ class MABarraDoCordaSpider(BaseGazetteSpider):
             self.logger.info(f"Nenhum diário encontrado na página: {response.url}")
             return
 
-        start_date_obj = self.start_date 
+        start_date_obj = self.start_date
+        end_date_obj = self.end_date
 
         oldest_date_in_page = None
 
@@ -85,37 +89,42 @@ class MABarraDoCordaSpider(BaseGazetteSpider):
                 self.logger.warning(f"Não foi possível extrair a data do item: {item}")
                 continue
 
-            oldest_date_in_page = edition_date 
+            oldest_date_in_page = edition_date
+
+            if not (start_date_obj <= edition_date <= end_date_obj):
+                continue
 
             filename = item.get("file")
             if not filename:
                 self.logger.warning(f"Item sem 'file': {item}")
                 continue
-            
+
             if filename.startswith("wp-content"):
-                 pdf_url = f"https://dom.barradocorda.ma.gov.br/{filename}"
+                pdf_url = f"https://dom.barradocorda.ma.gov.br/{filename}"
             else:
-                 main_filename = filename.replace("_signature", "")
-                 pdf_url = self.BASE_PDF_URL + main_filename
+                main_filename = filename.replace("_signature", "")
+                pdf_url = self.BASE_PDF_URL + main_filename
 
             yield Gazette(
                 date=edition_date,
                 edition_number=str(item.get("edition_number") or ""),
                 is_extra_edition=bool(item.get("extra", 0)),
-                file_urls=[pdf_url], 
+                file_urls=[pdf_url],
                 power="executive",
             )
 
         if oldest_date_in_page and oldest_date_in_page < start_date_obj:
-             self.logger.info("Data mais antiga da página é anterior ao start_date. Parando paginação.")
-             return
+            self.logger.info(
+                "Data mais antiga da página é anterior ao start_date. Parando paginação."
+            )
+            return
 
         next_page_url = editions_data.get("next_page_url")
         if next_page_url:
             yield Request(
-                url=next_page_url, 
+                url=next_page_url,
                 method="POST",
                 body=self.static_body_payload,
                 headers={"Content-Type": "application/json"},
-                callback=self.parse_api,
+                callback=self.parse,
             )

--- a/data_collection/gazette/spiders/rj/rj_carmo.py
+++ b/data_collection/gazette/spiders/rj/rj_carmo.py
@@ -1,0 +1,115 @@
+from datetime import date, datetime
+from urllib import parse
+
+from gazette.utils.extraction import get_date_from_text
+from gazette.items import Gazette
+from scrapy import Request
+from gazette.spiders.base import BaseGazetteSpider
+
+class UFMunicipioSpider(BaseGazetteSpider):
+    name = "rj_carmo"
+    TERRITORY_ID = "3301207"
+    allowed_domains = ["gesdom.carmo.rj.gov.br"]
+    start_urls = ["https://gesdom.carmo.rj.gov.br/consulta_publica_todas_edicoes"]
+    start_date = date(2021, 7, 6)
+    pdf_base_url = "https://gesdom.carmo.rj.gov.br/_lib/file/doc/pdf/"
+
+    def __init__(self, *args, **kwargs):
+        """
+        Garante que start_date e end_date sejam objetos date,
+        mesmo se passados como string pela linha de comando.
+        """
+        super().__init__(*args, **kwargs)
+
+        if isinstance(self.start_date, str):
+            self.start_date = datetime.date.fromisoformat(self.start_date)
+        # Garante que end_date também seja um objeto date
+        if isinstance(self.end_date, str):
+            self.end_date = datetime.date.fromisoformat(self.end_date)
+
+    def start_requests(self):
+        yield self.make_request(parm=1)
+
+    def make_request(self, parm: int):
+        payload = f"nmgp_opcao=ajax_navigate&script_case_init=9183&opc=rec&parm={parm}"
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "X-Requested-With": "XMLHttpRequest",
+        }
+        return Request(
+            url=self.start_urls[0],
+            method="POST",
+            body=payload,
+            headers=headers,
+            callback=self.parse,
+            cb_kwargs={"parm": parm},
+        )
+
+    def parse_pdf(self, data):
+        start_string = "var urlPDF = '\\/_lib\\/file\\/doc\\/pdf\\/' + '"
+        end_string = ".pdf';"
+
+        start_index = data.find(start_string) + len(start_string)
+        end_index = data.find(end_string) + len(end_string) - 2 # Só até .pdf
+
+        filename = data[start_index:end_index]
+        url = self.pdf_base_url + filename
+
+        return url
+
+    def parse_date(self, data, id):
+        start_string = f'id_sc_field_data_edicao_{id}">'
+        start_index = data.find(start_string) + len(start_string)
+        end_index = start_index + 12 # dd\/mm\/yyyy
+
+        raw_date = data[start_index:end_index].replace('\\', '')
+        try:
+            return datetime.strptime(raw_date, '%d/%m/%Y')
+        except ValueError:
+            return get_date_from_text(raw_date)
+
+    def parse_edition(self, pdf_url):
+        start_index = pdf_url.find('/pdf/')
+        end_index = pdf_url.find(' Prefeitura')
+        return pdf_url[start_index+5:end_index]
+    
+    def parse_extra_edition(self, data, id):
+        start_string = f'id_sc_field_informacoes_{id}">EDIÇÃO '
+        start_index = data.find(start_string) + len(start_string)
+        if 'extra' in data[start_index:start_index+5].lower():
+            return True
+        return False
+
+    def parse(self, response, parm):
+        """Processa o JSON retornado e continua até scrollEOF=True."""
+        data = response.body.decode() # str
+        data = data.encode("utf-8").decode("unicode_escape")
+
+        pdf_url = self.parse_pdf(data)
+        date = self.parse_date(data,id=parm)
+        edition = self.parse_edition(pdf_url)
+        is_extra = self.parse_extra_edition(data, id=parm)
+        is_last = 'EOF":true' in data
+
+        print(f"Processing id {parm}")
+        print(data)
+        print(f"pdf_url: {pdf_url}")
+        print(f"date: {date}")
+        print(f"edition: {edition}")
+        print(f"is_extra: {is_extra}")
+        print()
+
+        yield Gazette(
+            date=date,
+            edition_number=edition,
+            is_extra_edition=False,
+            file_urls=[pdf_url],
+            power="executive",
+        )
+
+        # Continua o loop até o backend sinalizar o fim
+        if not is_last:
+            next_parm = parm + 1
+            yield self.make_request(parm=next_parm)
+
+


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [ ] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [ ] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [ ] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [ ] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [ ] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [ ] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [ ] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [ ] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

<Descreva o seu Pull Request informando a issue (caso exista) que está sendo solucionada ou uma descrição do código apresentado>
