### PR TITLE
[WIP - Preciso de feedback] Add spider de sc_itapema

### DIFF
--- a/data_collection/gazette/items.py
+++ b/data_collection/gazette/items.py
@@ -15,4 +15,5 @@ class Gazette(scrapy.Item):
     scraped_at = scrapy.Field()
     file_urls = scrapy.Field()
     files = scrapy.Field()
+    in_memory_files = scrapy.Field()  # TODO: Hide base64 from logs!
     _validation = scrapy.Field()

--- a/data_collection/gazette/resources/gazette_schema.json
+++ b/data_collection/gazette/resources/gazette_schema.json
@@ -59,6 +59,23 @@
                     }
                 }
             }
+        },
+        "in_memory_files": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "base64": {
+                        "type": "string"
+                    }
+                }
+            }
         }
     },
     "required": [

--- a/data_collection/gazette/spiders/sc/sc_itapema.py
+++ b/data_collection/gazette/spiders/sc/sc_itapema.py
@@ -1,0 +1,115 @@
+import base64
+from datetime import date, datetime
+from io import BytesIO
+from typing import Optional, Tuple
+
+from pypdf import PdfReader, PdfWriter
+from pypdf.generic import Destination
+from scrapy import FormRequest, Request
+from scrapy.http import Response
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+# TODO: Share abstraction with Florianopolis
+class ScItapemaSpider(BaseGazetteSpider):
+    name = "sc_itapema"
+    TERRITORY_ID = "4208302"
+    start_date = date(2015, 12, 17)  # TODO: É essa data mesmo?
+    allowed_domains = ["edicao.dom.sc.gov.br"]
+    city_name = "Itapema"
+
+    def _requests(self, page):
+        formdata = {
+            "Edicao[cod_municipio]": "-1",
+            "Edicao_page": str(page),
+            "r": "site/edicoes",
+        }
+        return FormRequest(
+            url="https://edicao.dom.sc.gov.br/?",
+            method="GET",
+            formdata=formdata,
+            callback=self.parse_pagination,
+            cb_kwargs={"page": page},
+        )
+
+    def start_requests(self):
+        yield self._requests(1)
+
+    def parse_pagination(self, response: Response, page):
+        for item in response.css("tbody tr"):
+            edition_number = item.css("td::text")[1].get()
+            edition_url = item.css("td a")[1].attrib["href"]
+            raw_date = item.css("td::text")[2].get()
+            edition_date = datetime.strptime(raw_date, "%d/%m/%Y").date()
+
+            if self.start_date <= edition_date <= self.end_date:
+                yield Request(
+                    url=edition_url,
+                    callback=self.parse_pdf,
+                    cb_kwargs={
+                        "date": edition_date,
+                        "edition_number": edition_number,
+                        "is_extra_edition": False,
+                        "power": "executive_legislative",
+                    },
+                )
+        last_page = "next disabled" in response.url
+        if edition_date > self.start_date and not last_page:
+            yield self._requests(page + 1)
+
+    def parse_pdf(
+        self, response: Response, date, edition_number, is_extra_edition, power
+    ):
+        # TODO: What if its not a PDF?
+        yield Gazette(
+            date=date,
+            edition_number=edition_number,
+            is_extra_edition=is_extra_edition,
+            power=power,
+            file_urls=[],
+            in_memory_files=[
+                {
+                    "url": response.url,
+                    "name": f"{self.name}_{edition_number}_extracted.pdf",
+                    "base64": GazettePDFExtractor(
+                        response, self.city_name
+                    ).process_item(),
+                }
+            ],
+        )
+
+
+class GazettePDFExtractor:
+    def __init__(self, response: Response, city_name: str):
+        self.response = response
+        self.reader = PdfReader(BytesIO(response.body))
+        self.city_name = city_name
+        super().__init__()
+
+    def find_city_page(self, city_name: str) -> Tuple[Destination, Destination]:
+        outline = self.reader.outline
+        found = None
+        for item in outline:
+            if item.title == city_name:
+                found = item
+            elif found:
+                return found, item
+        return (None, None)
+
+    def process_item(self) -> Optional[str]:
+        writer = PdfWriter()
+        city_item, following_city_item = self.find_city_page(self.city_name)
+        if city_item:
+            city_page_number = self.reader.get_destination_page_number(city_item)
+            following_city_page_number = self.reader.get_destination_page_number(
+                following_city_item
+            )  # TODO: What if following city is None?
+            writer.add_page(self.reader.pages[0])
+            for page_number in range(city_page_number, following_city_page_number):
+                writer.add_page(self.reader.pages[page_number])
+            with BytesIO() as buffer:
+                writer.write(buffer)
+                return base64.b64encode(buffer.getvalue()).decode("utf-8")
+        return None


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [x] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [ ] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [ ] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [ ] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

Muitos municípios de Santa Catarina utilizam a plataforma CIGA e o sistema "Diário Oficial" para publicar seus diários. Essa plataforma emite [uma edição diária em formato PDF](https://edicao.dom.sc.gov.br/?Edicao%5Bcod_municipio%5D=-1&Edicao_page=1&r=site%2Fedicoes) que contém todos os munícipios que aderiram a plataforma. Trecho em anexo. Não é possível anexar o PDF inteiro por limitações de tamanho do GitHub.

[sc_itapema_5008_extracted.pdf](https://github.com/user-attachments/files/24155918/sc_itapema_5008_extracted.pdf)

A abordagem que estou seguindo é: Baixar o PDF da edição geral, e usar um parser de PDF para extrair as páginas referentes ao município de Itapema em SC. Em um segundo momento podemos evoluir essa solução e seguir a mesma ideia para extrair dados de todos os municípios que já vem no PDF (+100)

O sistema do QD espera que cada spider retorne (yield) um arquivo a ser baixado, mas nesse cenário precisamos de uma etapa de pós processamento do arquivo baixado para chegar no que interessa, o que não parece ainda ser suportado.

Para tal, estou baixando o PDF dentro do spider e mandando um arquivo base64 encoded para a pipeline que agora sabe diferenciar entre "arquivos a baixar" e "arquivos já baixados".

Tentei também criar uma etapa de pipeline nova para pós processamento mas considerei essa uma solução menos clean (podemos entrar em detalhes se necessário).

Esse PR é WIP (work in progress). Ainda tenho vários pontos para trabalhar aqui como podem verificar pelos TODO's que deixei. **Preciso de um feedback do time do QD com relação a solução adotada para o scrape dessa plataforma já que não segue padrões de outras no sistema.**

