### PR TITLE
Altera padrão de FILES_STORE_S3_ACL para string vazia

### DIFF
--- a/data_collection/gazette/settings.py
+++ b/data_collection/gazette/settings.py
@@ -56,7 +56,7 @@ AWS_ACCESS_KEY_ID = config("AWS_ACCESS_KEY_ID", default="")
 AWS_SECRET_ACCESS_KEY = config("AWS_SECRET_ACCESS_KEY", default="")
 AWS_ENDPOINT_URL = config("AWS_ENDPOINT_URL", default="")
 AWS_REGION_NAME = config("AWS_REGION_NAME", default="")
-FILES_STORE_S3_ACL = config("FILES_STORE_S3_ACL", default="public-read")
+FILES_STORE_S3_ACL = config("FILES_STORE_S3_ACL", default="")
 
 DOWNLOADER_MIDDLEWARES = {"scrapy_zyte_smartproxy.ZyteSmartProxyMiddleware": 610}
 ZYTE_SMARTPROXY_APIKEY = "<SMARTPROXY_APIKEY>"


### PR DESCRIPTION
## Descrição

Esta PR corrige um erro que ocorre ao executar os spiders quando o storage S3 (MinIO) não suporta ACLs.

## Problema
O erro `AccessControlListNotSupported` estava sendo lançado durante o upload de arquivos porque o valor padrão de `FILES_STORE_S3_ACL` era `"public-read"`, mas o MinIO (e algumas configurações S3) não suportam ACLs por padrão.

## Solução
Alterado o valor padrão de `FILES_STORE_S3_ACL` de `"public-read"` para string vazia (`""`), desabilitando o uso de ACLs por padrão.

## Impacto
- Spiders agora funcionam com MinIO e outras configurações S3 sem suporte a ACL
- Usuários que precisam de ACLs podem definir explicitamente `FILES_STORE_S3_ACL` no ambiente