### PR TITLE
Adiciona spider base NucleoGov com Valparaíso de Goiás e Cidade Ocidental

### DIFF
--- a/data_collection/gazette/settings.py
+++ b/data_collection/gazette/settings.py
@@ -61,6 +61,11 @@ FILES_STORE_S3_ACL = config("FILES_STORE_S3_ACL", default="")
 DOWNLOADER_MIDDLEWARES = {"scrapy_zyte_smartproxy.ZyteSmartProxyMiddleware": 610}
 ZYTE_SMARTPROXY_APIKEY = "<SMARTPROXY_APIKEY>"
 
+NUCLEOGOV_S3_DOMAIN = config(
+    "NUCLEOGOV_S3_DOMAIN",
+    default="diariooficial.s3.us-east-2.amazonaws.com",
+)
+
 COMMANDS_MODULE = "gazette.commands"
 
 REQUEST_FINGERPRINTER_IMPLEMENTATION = "2.7"

--- a/data_collection/gazette/spiders/base/nucleogov.py
+++ b/data_collection/gazette/spiders/base/nucleogov.py
@@ -1,0 +1,63 @@
+from urllib.parse import urlparse
+
+import scrapy
+from scrapy.exceptions import NotConfigured
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+from gazette.utils.nucleogov import DiarioPage
+
+
+class BaseNucleoGovSpider(BaseGazetteSpider):
+    url_api_path = "/api/diarios"
+    per_page = 100
+
+    def __init__(self, *args, **kwargs):
+        if not hasattr(self, "base_url"):
+            raise NotConfigured("Please set a value for `base_url`")
+
+        self.allowed_domains = [urlparse(self.base_url).netloc]
+
+        super().__init__(*args, **kwargs)
+
+    def start_requests(self):
+        s3_domain = self.crawler.settings.get(
+            "NUCLEOGOV_S3_DOMAIN",
+            "diariooficial.s3.us-east-2.amazonaws.com",
+        )
+        self.allowed_domains.append(s3_domain)
+
+        yield scrapy.Request(
+            url=self._build_url(page=1),
+            callback=self.parse,
+        )
+
+    def _build_url(self, page):
+        return (
+            f"{self.base_url}{self.url_api_path}"
+            f"?situacao=2&per_page={self.per_page}&page={page}"
+        )
+
+    def parse(self, response):
+        page = DiarioPage.from_response(response)
+
+        for diario in page.diarios:
+            if diario.data < self.start_date or diario.data > self.end_date:
+                continue
+
+            if not diario.file_urls:
+                continue
+
+            yield Gazette(
+                date=diario.data,
+                edition_number=diario.numero,
+                file_urls=diario.file_urls,
+                is_extra_edition=diario.is_extra_edition,
+                power="executive",
+            )
+
+        if page.has_next_page:
+            yield scrapy.Request(
+                url=self._build_url(page=page.next_page),
+                callback=self.parse,
+            )

--- a/data_collection/gazette/spiders/base/nucleogov.py
+++ b/data_collection/gazette/spiders/base/nucleogov.py
@@ -40,8 +40,12 @@ class BaseNucleoGovSpider(BaseGazetteSpider):
 
     def parse(self, response):
         page = DiarioPage.from_response(response)
+        all_before_start = True
 
         for diario in page.diarios:
+            if diario.data >= self.start_date:
+                all_before_start = False
+
             if diario.data < self.start_date or diario.data > self.end_date:
                 continue
 
@@ -56,7 +60,7 @@ class BaseNucleoGovSpider(BaseGazetteSpider):
                 power="executive",
             )
 
-        if page.has_next_page:
+        if page.has_next_page and not all_before_start:
             yield scrapy.Request(
                 url=self._build_url(page=page.next_page),
                 callback=self.parse,

--- a/data_collection/gazette/spiders/go/go_cidade_ocidental.py
+++ b/data_collection/gazette/spiders/go/go_cidade_ocidental.py
@@ -1,0 +1,10 @@
+from datetime import date
+
+from gazette.spiders.base.nucleogov import BaseNucleoGovSpider
+
+
+class GoCidadeOcidentalSpider(BaseNucleoGovSpider):
+    TERRITORY_ID = "5205497"
+    name = "go_cidade_ocidental"
+    base_url = "https://dom.cidadeocidental.go.gov.br"
+    start_date = date(2023, 2, 1)

--- a/data_collection/gazette/spiders/go/go_valparaiso_de_goias.py
+++ b/data_collection/gazette/spiders/go/go_valparaiso_de_goias.py
@@ -1,0 +1,10 @@
+from datetime import date
+
+from gazette.spiders.base.nucleogov import BaseNucleoGovSpider
+
+
+class GoValparaisoDeGoiasSpider(BaseNucleoGovSpider):
+    TERRITORY_ID = "5221858"
+    name = "go_valparaiso_de_goias"
+    base_url = "https://diariooficial.valparaisodegoias.go.gov.br"
+    start_date = date(2021, 2, 17)

--- a/data_collection/gazette/utils/nucleogov.py
+++ b/data_collection/gazette/utils/nucleogov.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+from datetime import date, datetime
+
+
+@dataclass
+class DiarioTipo:
+    descricao: str
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(descricao=data["descricao"])
+
+
+@dataclass
+class DiarioMidia:
+    url: str
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(url=data["url"])
+
+
+@dataclass
+class Diario:
+    data: date
+    numero: str
+    tipo: DiarioTipo
+    midias: list[DiarioMidia]
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(
+            data=parse_date(data["data"]),
+            numero=data.get("numero", ""),
+            tipo=DiarioTipo.from_dict(data["tipo"]),
+            midias=[DiarioMidia.from_dict(m) for m in data.get("midias", [])],
+        )
+
+    @property
+    def is_extra_edition(self):
+        return is_extra_edition(self.tipo.descricao)
+
+    @property
+    def file_urls(self):
+        return [m.url for m in self.midias if m.url]
+
+
+@dataclass
+class DiarioPage:
+    current_page: int
+    last_page: int
+    diarios: list[Diario]
+
+    @classmethod
+    def from_response(cls, response):
+        payload = response.json()
+        return cls(
+            current_page=payload["current_page"],
+            last_page=payload["last_page"],
+            diarios=[Diario.from_dict(d) for d in payload["data"]],
+        )
+
+    @property
+    def has_next_page(self):
+        return self.current_page < self.last_page
+
+    @property
+    def next_page(self):
+        return self.current_page + 1
+
+
+def parse_date(date_string):
+    return datetime.strptime(date_string, "%Y-%m-%d").date()
+
+
+def is_extra_edition(tipo_descricao):
+    tipo = tipo_descricao.lower()
+    return "oficial" not in tipo and "semanal" not in tipo

--- a/data_collection/tests/test_nucleogov.py
+++ b/data_collection/tests/test_nucleogov.py
@@ -1,0 +1,192 @@
+from datetime import date
+
+import pytest
+
+from gazette.utils.nucleogov import (
+    Diario,
+    DiarioMidia,
+    DiarioPage,
+    DiarioTipo,
+    is_extra_edition,
+    parse_date,
+)
+
+
+class TestParseDate:
+    def test_valid_date(self):
+        assert parse_date("2026-03-19") == date(2026, 3, 19)
+
+    def test_valid_date_single_digit_month_day(self):
+        assert parse_date("2021-1-5") == date(2021, 1, 5)
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError):
+            parse_date("19/03/2026")
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError):
+            parse_date("")
+
+
+class TestIsExtraEdition:
+    def test_diario_oficial_is_not_extra(self):
+        assert is_extra_edition("Diário Oficial") is False
+
+    def test_edicao_semanal_is_not_extra(self):
+        assert is_extra_edition("Edição Semanal") is False
+
+    def test_edicao_especial_is_extra(self):
+        assert is_extra_edition("Edição Especial") is True
+
+    def test_edicao_suplementar_is_extra(self):
+        assert is_extra_edition("Edição Suplementar") is True
+
+    def test_edicao_extraordinaria_is_extra(self):
+        assert is_extra_edition("Edição Extraordinária") is True
+
+    def test_case_insensitive(self):
+        assert is_extra_edition("DIÁRIO OFICIAL") is False
+        assert is_extra_edition("EDIÇÃO ESPECIAL") is True
+
+    def test_empty_string_is_extra(self):
+        assert is_extra_edition("") is True
+
+
+class TestDiarioTipo:
+    def test_from_dict(self):
+        tipo = DiarioTipo.from_dict({"id": 1, "descricao": "Diário Oficial"})
+        assert tipo.descricao == "Diário Oficial"
+
+    def test_missing_descricao_raises(self):
+        with pytest.raises(KeyError):
+            DiarioTipo.from_dict({"id": 1})
+
+
+class TestDiarioMidia:
+    def test_from_dict(self):
+        midia = DiarioMidia.from_dict({"url": "https://example.com/file.pdf"})
+        assert midia.url == "https://example.com/file.pdf"
+
+    def test_missing_url_raises(self):
+        with pytest.raises(KeyError):
+            DiarioMidia.from_dict({"name": "file.pdf"})
+
+
+class TestDiario:
+    VALID_DIARIO = {
+        "data": "2026-03-19",
+        "numero": "052",
+        "tipo": {"id": 1, "descricao": "Diário Oficial"},
+        "midias": [{"url": "https://example.com/file.pdf"}],
+    }
+
+    EXTRA_DIARIO = {
+        "data": "2026-03-19",
+        "numero": "012",
+        "tipo": {"id": 2, "descricao": "Edição Especial"},
+        "midias": [{"url": "https://example.com/extra.pdf"}],
+    }
+
+    def test_from_dict(self):
+        diario = Diario.from_dict(self.VALID_DIARIO)
+        assert diario.data == date(2026, 3, 19)
+        assert diario.numero == "052"
+        assert diario.tipo.descricao == "Diário Oficial"
+
+    def test_file_urls(self):
+        diario = Diario.from_dict(self.VALID_DIARIO)
+        assert diario.file_urls == ["https://example.com/file.pdf"]
+
+    def test_is_extra_edition_false(self):
+        diario = Diario.from_dict(self.VALID_DIARIO)
+        assert diario.is_extra_edition is False
+
+    def test_is_extra_edition_true(self):
+        diario = Diario.from_dict(self.EXTRA_DIARIO)
+        assert diario.is_extra_edition is True
+
+    def test_missing_midias_defaults_to_empty(self):
+        data = {**self.VALID_DIARIO}
+        del data["midias"]
+        diario = Diario.from_dict(data)
+        assert diario.file_urls == []
+
+    def test_missing_numero_defaults_to_empty(self):
+        data = {**self.VALID_DIARIO}
+        del data["numero"]
+        diario = Diario.from_dict(data)
+        assert diario.numero == ""
+
+    def test_missing_data_raises(self):
+        with pytest.raises(KeyError):
+            Diario.from_dict({"numero": "1", "tipo": {"descricao": "X"}, "midias": []})
+
+    def test_missing_tipo_raises(self):
+        with pytest.raises(KeyError):
+            Diario.from_dict({"data": "2026-01-01", "midias": []})
+
+
+class TestDiarioPage:
+    def test_has_next_page_true(self):
+        page = DiarioPage(current_page=1, last_page=5, diarios=[])
+        assert page.has_next_page is True
+        assert page.next_page == 2
+
+    def test_has_next_page_false(self):
+        page = DiarioPage(current_page=5, last_page=5, diarios=[])
+        assert page.has_next_page is False
+
+
+class TestApiContractBreaks:
+    """Tests that API structure changes produce clear, diagnosable errors."""
+
+    VALID_DIARIO = {
+        "data": "2026-03-19",
+        "numero": "052",
+        "tipo": {"id": 1, "descricao": "Diário Oficial"},
+        "midias": [{"url": "https://example.com/file.pdf"}],
+    }
+
+    def test_data_field_renamed(self):
+        broken = {**self.VALID_DIARIO, "data": None}
+        del broken["data"]
+        broken["date"] = "2026-03-19"
+        with pytest.raises(KeyError, match="data"):
+            Diario.from_dict(broken)
+
+    def test_tipo_field_renamed(self):
+        broken = {**self.VALID_DIARIO}
+        del broken["tipo"]
+        broken["type"] = {"id": 1, "descricao": "Diário Oficial"}
+        with pytest.raises(KeyError, match="tipo"):
+            Diario.from_dict(broken)
+
+    def test_tipo_descricao_renamed(self):
+        broken = {
+            **self.VALID_DIARIO,
+            "tipo": {"id": 1, "description": "Diário Oficial"},
+        }
+        with pytest.raises(KeyError, match="descricao"):
+            Diario.from_dict(broken)
+
+    def test_midias_url_renamed(self):
+        broken = {
+            **self.VALID_DIARIO,
+            "midias": [{"link": "https://example.com/file.pdf"}],
+        }
+        with pytest.raises(KeyError, match="url"):
+            Diario.from_dict(broken)
+
+    def test_data_format_changed(self):
+        broken = {**self.VALID_DIARIO, "data": "19/03/2026"}
+        with pytest.raises(ValueError):
+            Diario.from_dict(broken)
+
+    def test_pagination_field_missing(self):
+        payload = {"data": [], "current_page": 1}
+        with pytest.raises(KeyError, match="last_page"):
+            DiarioPage(
+                current_page=payload["current_page"],
+                last_page=payload["last_page"],
+                diarios=[],
+            )


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [ ] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/data_collection/gazette/spiders/base) adequada para o padrão.

> **Nota:** O NucleoGov ainda não consta na lista de layouts padrão do projeto. É uma plataforma usada por 12+ municípios em 3 estados (TO, GO, MT). Diferente dos demais layouts, o NucleoGov expõe uma **API JSON pública** (`/api/diarios`) com paginação — não é necessário scraping HTML. Esta PR adiciona a spider base + 2 municípios iniciais; os demais ficam para PRs futuras via #1096.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log`e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

Implementa spider base (`BaseNucleoGovSpider`) para a plataforma NucleoGov, usada por 12+ municípios em 3 estados (TO, GO, MT) para publicar diários oficiais. Inclui spiders para 2 municípios iniciais:

- **Valparaíso de Goiás** (IBGE: 5221858) — `start_date: 2021-02-17`
- **Cidade Ocidental** (IBGE: 5205497) — `start_date: 2023-02-01`

Os demais municípios serão adicionados em PRs futuras via issue #1096.

**Referências:**
- Resolve #1019 (spider base NucleoGov)
- Contribui para #1096 (lista de municípios NucleoGov)
- Resolve os problemas da PR #1147 (abandonada):
  - API path agora é construído no base class (child só fornece `base_url`)
  - Usa paginação (`per_page=100`) em vez de requests dia-a-dia (elimina HTTP 429s)
  - Early termination: para de paginar quando todos os itens de uma página são anteriores a `start_date`

**Arquivos adicionados:**

| Arquivo | Descrição |
|---|---|
| `gazette/spiders/base/nucleogov.py` | Spider base — paginação, filtragem por data, extração de PDFs |
| `gazette/utils/nucleogov.py` | Dataclasses (`Diario`, `DiarioPage`, etc.) + `is_extra_edition()` |
| `gazette/spiders/go/go_valparaiso_de_goias.py` | Spider Valparaíso de Goiás (~5 linhas) |
| `gazette/spiders/go/go_cidade_ocidental.py` | Spider Cidade Ocidental (~5 linhas) |
| `gazette/settings.py` | Adiciona `NUCLEOGOV_S3_DOMAIN` (configurável via env var) |
| `tests/test_nucleogov.py` | 31 testes unitários para dataclasses e lógica de parsing |

**Resultados dos testes:**

| Spider | Teste | Items | Requests | HTTP 200 | Erros |
|---|---|---|---|---|---|
| Valparaíso | última edição | 3 | 2 | 100% | 0 |
| Valparaíso | intervalo (Jan-Mar 2026) | 47 | 2 | 100% | 0 |
| Valparaíso | completa (desde 2021-02-17) | 1552 | 16 | 100% | 0 |
| Cidade Ocidental | última edição | 2 | 2 | 100% | 0 |
| Cidade Ocidental | intervalo (Jan-Mar 2026) | 43 | 2 | 100% | 0 |
| Cidade Ocidental | completa (desde 2023-02-01) | 859 | 9 | 100% | 0 |

📎 **Logs e CSVs:** https://gist.github.com/regiscamimura/8569fa8f615c8c52924e1da0e855f5cd