### PR TITLE
Atualiza GitHub Actions para versões modernas (checkout@v4, setup-python@v5) e Python 3.12

### DIFF
--- a/.github/workflows/daily_crawl.yaml
+++ b/.github/workflows/daily_crawl.yaml
@@ -22,10 +22,10 @@ jobs:
       SPIDERMON_DISCORD_WEBHOOK_URL: ${{ secrets.SPIDERMON_DISCORD_WEBHOOK_URL }}
       ZYTE_SMARTPROXY_APIKEY: ${{ secrets.ZYTE_SMARTPROXY_APIKEY }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Prepare environment
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,10 +9,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install shub
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/monthly_crawl.yaml
+++ b/.github/workflows/monthly_crawl.yaml
@@ -22,10 +22,10 @@ jobs:
       SPIDERMON_DISCORD_WEBHOOK_URL: ${{ secrets.SPIDERMON_DISCORD_WEBHOOK_URL }}
       ZYTE_SMARTPROXY_APIKEY: ${{ secrets.ZYTE_SMARTPROXY_APIKEY }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Prepare environment
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/schedule_spider.yaml
+++ b/.github/workflows/schedule_spider.yaml
@@ -29,10 +29,10 @@ jobs:
       SPIDERMON_DISCORD_WEBHOOK_URL: ${{ secrets.SPIDERMON_DISCORD_WEBHOOK_URL }}
       ZYTE_SMARTPROXY_APIKEY: ${{ secrets.ZYTE_SMARTPROXY_APIKEY }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Prepare environment
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/schedule_spider_by_date.yaml
+++ b/.github/workflows/schedule_spider_by_date.yaml
@@ -23,10 +23,10 @@ jobs:
       SPIDERMON_DISCORD_WEBHOOK_URL: ${{ secrets.SPIDERMON_DISCORD_WEBHOOK_URL }}
       ZYTE_SMARTPROXY_APIKEY: ${{ secrets.ZYTE_SMARTPROXY_APIKEY }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Prepare environment
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/schedule_spider_yearly.yaml
+++ b/.github/workflows/schedule_spider_yearly.yaml
@@ -29,10 +29,10 @@ jobs:
       SPIDERMON_DISCORD_WEBHOOK_URL: ${{ secrets.SPIDERMON_DISCORD_WEBHOOK_URL }}
       ZYTE_SMARTPROXY_APIKEY: ${{ secrets.ZYTE_SMARTPROXY_APIKEY }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Prepare environment
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,10 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: pip install pre-commit
       - name: Check pre-commit hooks

--- a/.github/workflows/update_spider_status.yaml
+++ b/.github/workflows/update_spider_status.yaml
@@ -20,10 +20,10 @@ jobs:
     env:
       QUERIDODIARIO_DATABASE_URL: ${{ secrets.QUERIDODIARIO_DATABASE_URL }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Prepare environment
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Descrição

Atualiza todos os 8 workflows do GitHub Actions para usar versões modernas das actions e Python 3.12, conforme solicitado na issue #1286.

### Mudanças realizadas

- `actions/checkout@v2` → `actions/checkout@v4`
- - `actions/setup-python@v2` → `actions/setup-python@v5`
- - `python-version: "3.10"` → `python-version: "3.12"`
### Arquivos modificados

- `.github/workflows/deploy.yml`
- - `.github/workflows/tests.yml`
- - `.github/workflows/daily_crawl.yaml`
- - `.github/workflows/monthly_crawl.yaml`
- - `.github/workflows/schedule_spider.yaml`
- - `.github/workflows/schedule_spider_by_date.yaml`
- - `.github/workflows/schedule_spider_yearly.yaml`
- - `.github/workflows/update_spider_status.yaml`
### Motivação

As versões `v2` de `actions/checkout` e `actions/setup-python` estão depreciadas pelo GitHub e não recebem mais atualizações de segurança. Além disso, o Python 3.10 chegou ao fim do seu ciclo de suporte em outubro de 2026, tornando a migração para 3.12 necessária para manter a compatibilidade com pacotes modernos.

Closes #1286