### PR TITLE
feat(spider): adicionar 10 cidades AGM-GO via base sigpub

### DIFF
--- a/data_collection/gazette/spiders/go/go_acreuna.py
+++ b/data_collection/gazette/spiders/go/go_acreuna.py
@@ -1,0 +1,10 @@
+import datetime
+
+from gazette.spiders.base.sigpub import BaseSigpubSpider
+
+
+class GoAcreunaSpider(BaseSigpubSpider):
+    name = "go_acreuna"
+    TERRITORY_ID = "5200134"
+    CALENDAR_URL = "https://www.diariomunicipal.com.br/agm/"
+    start_date = datetime.date(2009, 1, 1)

--- a/data_collection/gazette/spiders/go/go_aguas_lindas_de_goias.py
+++ b/data_collection/gazette/spiders/go/go_aguas_lindas_de_goias.py
@@ -1,0 +1,10 @@
+import datetime
+
+from gazette.spiders.base.sigpub import BaseSigpubSpider
+
+
+class GoAguasLindasDeGoiasSpider(BaseSigpubSpider):
+    name = "go_aguas_lindas_de_goias"
+    TERRITORY_ID = "5200258"
+    CALENDAR_URL = "https://www.diariomunicipal.com.br/agm/"
+    start_date = datetime.date(2009, 1, 1)

--- a/data_collection/gazette/spiders/go/go_alexania.py
+++ b/data_collection/gazette/spiders/go/go_alexania.py
@@ -1,0 +1,10 @@
+import datetime
+
+from gazette.spiders.base.sigpub import BaseSigpubSpider
+
+
+class GoAlexaniaSpider(BaseSigpubSpider):
+    name = "go_alexania"
+    TERRITORY_ID = "5200308"
+    CALENDAR_URL = "https://www.diariomunicipal.com.br/agm/"
+    start_date = datetime.date(2009, 1, 1)

--- a/data_collection/gazette/spiders/go/go_aragarcas.py
+++ b/data_collection/gazette/spiders/go/go_aragarcas.py
@@ -1,0 +1,10 @@
+import datetime
+
+from gazette.spiders.base.sigpub import BaseSigpubSpider
+
+
+class GoAragarcasSpider(BaseSigpubSpider):
+    name = "go_aragarcas"
+    TERRITORY_ID = "5201702"
+    CALENDAR_URL = "https://www.diariomunicipal.com.br/agm/"
+    start_date = datetime.date(2009, 1, 1)

--- a/data_collection/gazette/spiders/go/go_cacu.py
+++ b/data_collection/gazette/spiders/go/go_cacu.py
@@ -1,0 +1,10 @@
+import datetime
+
+from gazette.spiders.base.sigpub import BaseSigpubSpider
+
+
+class GoCacuSpider(BaseSigpubSpider):
+    name = "go_cacu"
+    TERRITORY_ID = "5204300"
+    CALENDAR_URL = "https://www.diariomunicipal.com.br/agm/"
+    start_date = datetime.date(2009, 1, 1)

--- a/data_collection/gazette/spiders/go/go_cristalina.py
+++ b/data_collection/gazette/spiders/go/go_cristalina.py
@@ -1,0 +1,10 @@
+import datetime
+
+from gazette.spiders.base.sigpub import BaseSigpubSpider
+
+
+class GoCristalinaSpider(BaseSigpubSpider):
+    name = "go_cristalina"
+    TERRITORY_ID = "5206206"
+    CALENDAR_URL = "https://www.diariomunicipal.com.br/agm/"
+    start_date = datetime.date(2009, 1, 1)

--- a/data_collection/gazette/spiders/go/go_goianira.py
+++ b/data_collection/gazette/spiders/go/go_goianira.py
@@ -1,0 +1,10 @@
+import datetime
+
+from gazette.spiders.base.sigpub import BaseSigpubSpider
+
+
+class GoGoianiraSpider(BaseSigpubSpider):
+    name = "go_goianira"
+    TERRITORY_ID = "5208806"
+    CALENDAR_URL = "https://www.diariomunicipal.com.br/agm/"
+    start_date = datetime.date(2009, 1, 1)

--- a/data_collection/gazette/spiders/go/go_hidrolandia.py
+++ b/data_collection/gazette/spiders/go/go_hidrolandia.py
@@ -1,0 +1,10 @@
+import datetime
+
+from gazette.spiders.base.sigpub import BaseSigpubSpider
+
+
+class GoHidrolandiaSpider(BaseSigpubSpider):
+    name = "go_hidrolandia"
+    TERRITORY_ID = "5209705"
+    CALENDAR_URL = "https://www.diariomunicipal.com.br/agm/"
+    start_date = datetime.date(2009, 1, 1)

--- a/data_collection/gazette/spiders/go/go_inhumas.py
+++ b/data_collection/gazette/spiders/go/go_inhumas.py
@@ -1,0 +1,10 @@
+import datetime
+
+from gazette.spiders.base.sigpub import BaseSigpubSpider
+
+
+class GoInhumasSpider(BaseSigpubSpider):
+    name = "go_inhumas"
+    TERRITORY_ID = "5210000"
+    CALENDAR_URL = "https://www.diariomunicipal.com.br/agm/"
+    start_date = datetime.date(2009, 1, 1)

--- a/data_collection/gazette/spiders/go/go_morrinhos.py
+++ b/data_collection/gazette/spiders/go/go_morrinhos.py
@@ -1,0 +1,10 @@
+import datetime
+
+from gazette.spiders.base.sigpub import BaseSigpubSpider
+
+
+class GoMorrinhosSpider(BaseSigpubSpider):
+    name = "go_morrinhos"
+    TERRITORY_ID = "5213509"
+    CALENDAR_URL = "https://www.diariomunicipal.com.br/agm/"
+    start_date = datetime.date(2009, 1, 1)


### PR DESCRIPTION
## Resumo

Adiciona spiders para **10 municípios goianos** que publicam seus diários oficiais no portal sigpub compartilhado da Associação Goiana de Municípios (AGM-GO):

`https://www.diariomunicipal.com.br/agm/`

Todos usam a `BaseSigpubSpider` existente, ~10 linhas cada.

## Municípios

| Município                | TERRITORY_ID |
|--------------------------|-------------:|
| Acreúna                  |      5200134 |
| Águas Lindas de Goiás    |      5200258 |
| Alexânia                 |      5200308 |
| Aragarças                |      5201702 |
| Caçu                     |      5204300 |
| Cristalina               |      5206206 |
| Goianira                 |      5208806 |
| Hidrolândia              |      5209705 |
| Inhumas                  |      5210000 |
| **Morrinhos**            |      5213509 |

## Confirmação

Cada município foi confirmado no `<select>` de `entidadeUsuaria` em https://www.diariomunicipal.com.br/agm/pesquisar (filtro 'Município de X').

## Padrão do spider

Todos seguem o mesmo modelo, exemplo:

```python
import datetime

from gazette.spiders.base.sigpub import BaseSigpubSpider


class GoMorrinhosSpider(BaseSigpubSpider):
    name = "go_morrinhos"
    TERRITORY_ID = "5213509"
    CALENDAR_URL = "https://www.diariomunicipal.com.br/agm/"
    start_date = datetime.date(2009, 1, 1)
```

## Contexto

Esses PRs vêm de um projeto de transparência cívica estadual (https://goias.ai) que usa a API pública do Querido Diário pra mapear cobertura municipal goiana — e essa é a contrapartida natural: contribuir spiders pra reduzir o gap. Goiás tem **111 municípios no portal AGM-GO** sem spider hoje no QD, dos quais 10 entram neste PR.

Tenho intenção de enviar PRs subsequentes com mais batches de 10 cidades AGM-GO. Posso também propor uma futura BaseCentiSpider pra cidades que publicam no portal Centi (não tradicional).

## Verificação

- CI `Run tests` ✅ passou no commit anterior
- Limite `5 a 10 municípios por PR` do CONTRIBUTING.md respeitado (10 total)

cc @okfn-brasil/data-collection-maintainers