### PR TITLE
Corrige raspagem da base Portal gov (#1402)

### DIFF
--- a/data_collection/gazette/spiders/base/portalgov.py
+++ b/data_collection/gazette/spiders/base/portalgov.py
@@ -1,6 +1,5 @@
 import re
 from datetime import datetime as dt
-from urllib.parse import urlparse
 
 import scrapy
 from scrapy.exceptions import NotConfigured
@@ -16,7 +15,7 @@ class BasePortalGovSpider(BaseGazetteSpider):
         if not hasattr(self, "power"):
             raise NotConfigured("Please set a value for `power`")
 
-        self.allowed_domains = [urlparse(self.website).netloc]
+        self.allowed_domains = [self.website]
 
         super(BasePortalGovSpider, self).__init__(*args, **kwargs)
 
@@ -45,7 +44,7 @@ class BasePortalGovSpider(BaseGazetteSpider):
                 re.search(r"extra|supl", gazette_edition + gazette_desc, re.IGNORECASE)
             )
 
-            gazette_url = f"https://{self.domain}/arquivos/diario_oficial/{gazette_data['arquivo']}"
+            gazette_url = f"https://{self.website}/arquivos/diario_oficial/{gazette_data['arquivo']}"
 
             yield Gazette(
                 date=gazette_date,


### PR DESCRIPTION
## O que isto resolve

Issue #1402 — a base `BasePortalGovSpider` parou de coletar, afetando os
municípios que a usam (`rj_sao_joao_da_barra`, `rj_varre_sai`).

## Causa raiz

Em `parse()`, a URL do diário era montada com `self.domain`:

```python
gazette_url = f"https://{self.domain}/arquivos/diario_oficial/{...}"
```

mas os spiders da base definem `website` (não `domain`). Resultado:
`AttributeError: '...Spider' object has no attribute 'domain'` em toda edição ->
coleta zerada. **Esta é a causa da pane.**

## A correção (2 linhas + remoção de import)

1. `parse()`: `self.domain` -> `self.website` (corrige a pane).
2. `__init__`: `allowed_domains = [urlparse(self.website).netloc]` -> `[self.website]`.
   Como `website` é domínio puro (ex.: `www.sjb.rj.gov.br`), `urlparse(...).netloc`
   retornava `''`, deixando `allowed_domains` vazio. Alinha com a observação do autor
   da issue ("alterei 2 linhas relacionadas a `self.website`").
3. Remove o import `urlparse`, agora sem uso (mantém ruff/flake8 limpo).

## Verificação local

- `pre-commit run` (black, isort, ruff, bandit, …): **passou**.
- `scrapy crawl rj_sao_joao_da_barra -a start=2026-06-01`: voltou a coletar — **9
  edições**, incluindo a **#104 (15/06/2026)**, todas baixadas com sucesso (HTTP 200),
  0 exceções. Antes do fix: `AttributeError`, 0 itens.

## Sobre a checklist

Este PR é **manutenção de uma classe base** (não um spider novo): os spiders existentes
já têm os atributos exigidos; aqui apenas restauramos a base. Coleta-teste da última
edição feita e validada localmente; a coleta histórica completa não foi anexada por ser
uma correção de manutenção (e geraria volume desnecessário no site de origem).

---

### Disclosure de IA

Este PR foi produzido por um pipeline assistido por IA, com revisão humana antes da abertura:

- **Autor:** Claude (Opus 4.8).
- **Revisores (conselho multi-fabricante, independentes):** GPT-5.5 e Gemini 2.5 Flash.
- **Resumo do debate:** o GPT-5.5 apontou que corrigir apenas a `parse()` deixaria
  `allowed_domains` incorreto (a issue menciona "2 linhas"); a correção foi ampliada para
  incluir também a `__init__`. A decisão foi validada por execução real do spider.

Revisado por um humano antes da submissão.
