### PR TITLE
Pin setuptools in dev requirements for --require-hashes

### DIFF
--- a/data_collection/requirements-dev.in
+++ b/data_collection/requirements-dev.in
@@ -6,3 +6,7 @@ isort
 pre-commit
 pip-tools
 pytest
+# setuptools is a transitive dependency of nodeenv (via pre-commit); pin it so
+# `pip install --require-hashes` works. Cap <81 to keep pkg_resources (removed in
+# setuptools 82), which nodeenv imports.
+setuptools<81

--- a/data_collection/requirements-dev.txt
+++ b/data_collection/requirements-dev.txt
@@ -1117,4 +1117,8 @@ zope-interface==6.0 \
     --hash=sha256:f299c020c6679cb389814a3b81200fe55d428012c5e76da7e722491f5d205990 \
     --hash=sha256:f72f23bab1848edb7472309e9898603141644faec9fd57a823ea6b4d1c4c8995 \
     --hash=sha256:fa90bac61c9dc3e1a563e5babb3fd2c0c1c80567e815442ddbe561eadc803b30
-    
+
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==80.10.2 \
+    --hash=sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70 \
+    --hash=sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173


### PR DESCRIPTION
## O que isto resolve

Issue #1431: `pip install --require-hashes -r data_collection/requirements-dev.txt`
falha porque `setuptools` não está pinado com hash.

## Causa

`nodeenv` (dependência transitiva via `pre-commit`) declara `setuptools` como
dependência de runtime. Em `--require-hashes`, toda dependência resolvida precisa
estar pinada com `==` e hash. Como `setuptools` não constava no arquivo, o pip
tentava resolvê-lo solto e abortava:

```
ERROR: In --require-hashes mode, all requirements must have their versions
pinned with ==. These do not:
    setuptools from .../setuptools-82.0.1-py3-none-any.whl
```

## Correção

- `requirements-dev.in`: adiciona `setuptools<81`. O `.txt` é gerado do `.in`
  (`make compile`), então o pino precisa existir na fonte para sobreviver a
  regenerações. O limite `<81` mantém `pkg_resources` -- que o `nodeenv` importa
  e que foi removido no `setuptools` 82.0.0 -- disponível.
- `requirements-dev.txt`: adiciona a entrada pinada com hash, na seção das
  dependências consideradas "unsafe", no formato do `pip-compile --allow-unsafe`
  (resolve para 80.10.2).

## Verificação

- Reprodução em venv limpo (Python 3.12, sem setuptools): antes do fix,
  `pip install --dry-run --require-hashes` aborta em setuptools; depois, resolve
  (`Would install ... setuptools-80.10.2`).
- Arquivo completo sob `--require-hashes`: o pip passa do check de pinos e segue
  para o download, sem nenhum outro pacote ficar sem hash.
- `pre-commit run` nos arquivos alterados: passa.
- Os hashes vêm dos artefatos oficiais do PyPI (wheel + sdist), conferidos com
  `pip hash` e com a saída do `pip-compile`.

A checklist do template cobre PRs de raspadores; este PR é manutenção das
dependências de desenvolvimento, então os itens de spider/coleta não se aplicam.

---

Disclosure: este PR foi produzido com assistência de IA (Claude Opus 4.8) e revisado por um humano antes da abertura.
