### PR TITLE
Add tutorials documentation index

### DIFF
--- a/README-en-US.md
+++ b/README-en-US.md
@@ -138,6 +138,7 @@ Here is a complete list of all documentation available in the `docs/` folder:
 - [Contribution Guide](docs/CONTRIBUTING.md) | [Contribution Guide (EN)](docs/CONTRIBUTING-en-US.md)
 - [Support](docs/SUPPORT.md) | [Support (EN)](docs/SUPPORT-en-US.md)
 - [Troubleshooting](docs/TROUBLESHOOTING.md) | [Troubleshooting (EN)](docs/TROUBLESHOOTING-en-US.md)
+- [Tutorials](docs/tutorials/README.md) | [Tutorials (EN)](docs/tutorials/README-en-US.md)
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Aqui está uma lista completa de toda a documentação disponível na pasta `doc
 - [Guia de Contribuição](docs/CONTRIBUTING.md) | [Guia de Contribuição (EN)](docs/CONTRIBUTING-en-US.md)
 - [Suporte](docs/SUPPORT.md) | [Suporte (EN)](docs/SUPPORT-en-US.md)
 - [Solução de Problemas](docs/TROUBLESHOOTING.md) | [Solução de Problemas (EN)](docs/TROUBLESHOOTING-en-US.md)
+- [Tutoriais](docs/tutorials/README.md) | [Tutoriais (EN)](docs/tutorials/README-en-US.md)
 
 ## Licença
 

--- a/docs/tutorials/README-en-US.md
+++ b/docs/tutorials/README-en-US.md
@@ -1,0 +1,22 @@
+**English (US)** | [Português (BR)](/docs/tutorials/README.md)
+
+# Tutorials
+
+This folder gathers practical tutorials for people who are getting started with Querido Diário contributions.
+
+Tutorials should work as step-by-step guides, with small examples, reproducible commands, and links to the main documentation when more details are available elsewhere.
+
+## Planned tutorials
+
+- First scraper
+- Scraper debugging
+- Collection tests and validation
+
+## How to add a new tutorial
+
+1. Create a Markdown file in this folder using a short, descriptive name.
+2. Use examples that can be executed from the repository root or from the `data_collection` directory.
+3. Include the commands needed to reproduce the described flow.
+4. Update this index with a link to the new tutorial.
+
+Before opening a pull request, also check the [Contribution Guide](/docs/CONTRIBUTING-en-US.md).

--- a/docs/tutorials/README-en-US.md
+++ b/docs/tutorials/README-en-US.md
@@ -1,4 +1,4 @@
-**English (US)** | [Português (BR)](/docs/tutorials/README.md)
+**English (US)** | [Português (BR)](README.md)
 
 # Tutorials
 
@@ -19,4 +19,4 @@ Tutorials should work as step-by-step guides, with small examples, reproducible 
 3. Include the commands needed to reproduce the described flow.
 4. Update this index with a link to the new tutorial.
 
-Before opening a pull request, also check the [Contribution Guide](/docs/CONTRIBUTING-en-US.md).
+Before opening a pull request, also check the [Contribution Guide](../CONTRIBUTING-en-US.md).

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,22 @@
+**Português (BR)** | [English (US)](/docs/tutorials/README-en-US.md)
+
+# Tutoriais
+
+Esta pasta reúne tutoriais práticos para quem está começando a contribuir com o Querido Diário.
+
+Os tutoriais devem funcionar como guias passo a passo, com exemplos pequenos, comandos reproduzíveis e links para a documentação principal quando houver mais detalhes sobre o assunto.
+
+## Tutoriais planejados
+
+- Primeiro raspador
+- Debugging de raspadores
+- Testes e validação de coletas
+
+## Como adicionar um novo tutorial
+
+1. Crie um arquivo Markdown nesta pasta usando um nome curto e descritivo.
+2. Use exemplos que possam ser executados a partir da raiz do repositório ou do diretório `data_collection`.
+3. Inclua os comandos necessários para reproduzir o fluxo descrito.
+4. Atualize este índice com o link para o novo tutorial.
+
+Antes de abrir um pull request, consulte também o [Guia de Contribuição](/docs/CONTRIBUTING.md).

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,4 +1,4 @@
-**Português (BR)** | [English (US)](/docs/tutorials/README-en-US.md)
+**Português (BR)** | [English (US)](README-en-US.md)
 
 # Tutoriais
 
@@ -19,4 +19,4 @@ Os tutoriais devem funcionar como guias passo a passo, com exemplos pequenos, co
 3. Inclua os comandos necessários para reproduzir o fluxo descrito.
 4. Atualize este índice com o link para o novo tutorial.
 
-Antes de abrir um pull request, consulte também o [Guia de Contribuição](/docs/CONTRIBUTING.md).
+Antes de abrir um pull request, consulte também o [Guia de Contribuição](../CONTRIBUTING.md).


### PR DESCRIPTION
Closes #1441.

Summary:
- creates the docs/tutorials folder with PT-BR and EN-US index files
- documents the planned getting started tutorial pages
- adds the tutorials index to both README documentation lists

Validation:
- checked documentation links added in README.md, README-en-US.md, and docs/tutorials