### PR TITLE
feat: migra acesso direto ao banco para chamadas de API nos raspadores

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,3 +23,16 @@ jobs:
       run: |
         cd data_collection/
         shub deploy ${{ secrets.SCRAPY_CLOUD_PROJECT_ID }}
+
+    - name: Install project dependencies
+      run: |
+        cd data_collection/
+        pip install -r requirements.txt
+
+    - name: Sync spiders to API
+      env:
+        QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
+        QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
+      run: |
+        cd data_collection/
+        scrapy qd-sync-spiders

--- a/data_collection/gazette/commands/qd-list-enabled.py
+++ b/data_collection/gazette/commands/qd-list-enabled.py
@@ -34,13 +34,13 @@ class Command(ScrapyCommand):
 
         if opts.start is not None:
             try:
-                start = datetime.datetime.strptime(opts.start, "%Y-%m-%d")
+                start = datetime.date.fromisoformat(opts.start)
             except ValueError:
                 raise UsageError("'start' must match YYYY-MM-DD format")
 
         if opts.end is not None:
             try:
-                end = datetime.datetime.strptime(opts.end, "%Y-%m-%d")
+                end = datetime.date.fromisoformat(opts.end)
             except ValueError:
                 raise UsageError("'end' must match YYYY-MM-DD format")
 

--- a/data_collection/gazette/commands/qd-list-enabled.py
+++ b/data_collection/gazette/commands/qd-list-enabled.py
@@ -47,6 +47,8 @@ class Command(ScrapyCommand):
         print("\nEnabled spiders\n===============")
         for spider_name in get_enabled_spiders(
             database_url=self.settings["QUERIDODIARIO_DATABASE_URL"],
+            api_url=self.settings.get("QUERIDODIARIO_API_URL"),
+            api_key=self.settings.get("QUERIDODIARIO_API_KEY"),
             start_date=start,
             end_date=end,
         ):

--- a/data_collection/gazette/commands/qd-sync-spiders.py
+++ b/data_collection/gazette/commands/qd-sync-spiders.py
@@ -1,0 +1,55 @@
+"""Register spiders and their territory mapping in the platform.
+
+This command replaces the side effect that ``initialize_database()`` used to
+have when spiders opened in production: registering new/modified spiders in
+the ``querido_diario_spiders`` table (and their ``territory_spider_map``).
+
+It MUST be executed after deploying new spiders, otherwise they will never
+show up as schedulable in production.
+
+Usage:
+    scrapy qd-sync-spiders
+
+Configuration:
+    - QUERIDODIARIO_API_URL / QUERIDODIARIO_API_KEY: sync through the
+      Querido Diario API (POST /api/scraper/spiders/sync) — preferred;
+    - QUERIDODIARIO_DATABASE_URL: fallback with direct database access
+      (also initializes tables and territories, as before).
+"""
+
+from scrapy.commands import ScrapyCommand
+from scrapy.exceptions import UsageError
+
+from gazette.database.models import initialize_database
+from gazette.utils.api_client import api_client_from_settings
+from gazette.utils.database import generate_territory_spider_map
+
+
+class Command(ScrapyCommand):
+    requires_project = True
+
+    def short_desc(self):
+        return (
+            "Register spiders/territories in the platform "
+            "(run after deploying new spiders)"
+        )
+
+    def run(self, args, opts):
+        territory_spider_map = generate_territory_spider_map()
+        print(f"Found {len(territory_spider_map)} spiders in the project.")
+
+        client = api_client_from_settings(self.settings)
+        if client is not None:
+            result = client.sync_spiders(territory_spider_map)
+            print(f"Spiders synced through the API: {result}")
+            return
+
+        database_url = self.settings.get("QUERIDODIARIO_DATABASE_URL")
+        if not database_url:
+            raise UsageError(
+                "Neither QUERIDODIARIO_API_URL nor QUERIDODIARIO_DATABASE_URL "
+                "is set. Configure one of them to sync spiders."
+            )
+
+        initialize_database(database_url, territory_spider_map)
+        print(f"Spiders synced through direct database access: {database_url}")

--- a/data_collection/gazette/extensions.py
+++ b/data_collection/gazette/extensions.py
@@ -1,51 +1,47 @@
 import json
 import os
 
+import requests
 from scrapy import signals
-from sqlalchemy import JSON, Column, DateTime, Integer, String, create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from scrapy.exceptions import NotConfigured
 
-DeclarativeBase = declarative_base()
-
-
-class JobStats(DeclarativeBase):
-    __tablename__ = "job_stats"
-    id = Column(Integer, primary_key=True)
-    spider = Column(String)
-    start_time = Column(DateTime)
-    job_id = Column(String)
-    job_stats = Column(JSON)
+from gazette.utils.api_client import api_client_from_settings
 
 
 class StatsPersist:
-    def __init__(self, crawler, database_url):
+    """Persist the Scrapy stats of a finished job through the API.
+
+    Disabled (NotConfigured) when QUERIDODIARIO_API_URL is not set,
+    keeping local development free of external dependencies.
+    """
+
+    def __init__(self, crawler, client):
         self._stats = crawler.stats
-        self._database_url = database_url
+        self._client = client
 
     @classmethod
     def from_crawler(cls, crawler):
-        database_url = crawler.settings.get("QUERIDODIARIO_DATABASE_URL")
+        client = api_client_from_settings(crawler.settings)
+        if client is None:
+            raise NotConfigured(
+                "QUERIDODIARIO_API_URL is not set. StatsPersist disabled."
+            )
 
-        o = cls(crawler, database_url)
-        crawler.signals.connect(o.spider_opened, signal=signals.spider_opened)
+        o = cls(crawler, client)
         crawler.signals.connect(o.spider_closed, signal=signals.spider_closed)
         return o
-
-    def spider_opened(self, spider):
-        engine = create_engine(self._database_url)
-        DeclarativeBase.metadata.create_all(engine)
-        self.Session = sessionmaker(bind=engine)
 
     def spider_closed(self, spider, reason):
         stats = self._stats.get_stats()
         serializable_stats = json.loads(json.dumps(stats, default=str))
-        job_stats = JobStats(
-            spider=spider.name,
-            start_time=stats["start_time"],
-            job_id=os.environ.get("SHUB_JOBKEY", ""),
-            job_stats=serializable_stats,
-        )
-        session = self.Session()
-        session.add(job_stats)
-        session.commit()
+        try:
+            self._client.post_job_stats(
+                spider_name=spider.name,
+                job_id=os.environ.get("SHUB_JOBKEY", ""),
+                stats_dict=serializable_stats,
+            )
+        except requests.RequestException as exc:
+            spider.logger.warning(
+                f"Something wrong has happened when sending job stats to the API. "
+                f"Details: {exc}"
+            )

--- a/data_collection/gazette/monitors.py
+++ b/data_collection/gazette/monitors.py
@@ -7,10 +7,8 @@ from spidermon.contrib.scrapy.monitors import (
     FinishReasonMonitor,
     ItemValidationMonitor,
 )
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
-from gazette.extensions import JobStats
+from gazette.utils.api_client import api_client_from_settings
 
 
 @monitors.name("Requests/Items Ratio")
@@ -38,32 +36,30 @@ class RequestsItemsRatioMonitor(Monitor):
 
 @monitors.name("Comparison Between Executions")
 class ComparisonBetweenSpiderExecutionsMonitor(Monitor):
-    def _get_session(self):
-        database_url = self.data.crawler.settings.get("QUERIDODIARIO_DATABASE_URL")
-        engine = create_engine(database_url)
-        Session = sessionmaker(bind=engine)
-        return Session()
-
     @monitors.name("Days without gazettes")
     def test_days_without_gazettes(self):
         max_days_without_gazettes = self.data.crawler.settings.getint(
             "QUERIDODIARIO_MAX_DAYS_WITHOUT_GAZETTES"
         )
         if max_days_without_gazettes:
-            session = self._get_session()
+            client = api_client_from_settings(self.data.crawler.settings)
+            if client is None:
+                self.skipTest("QUERIDODIARIO_API_URL is not set. Monitor disabled.")
+
             reference_date = (
                 datetime.today() - timedelta(days=max_days_without_gazettes)
             ).replace(hour=0, minute=0)
 
-            job_stats = (
-                session.query(JobStats)
-                .filter(JobStats.start_time >= reference_date)
-                .filter(JobStats.spider == self.data.spider.name)
-                .all()
+            job_stats = client.get_job_stats(
+                spider_name=self.data.spider.name,
+                since_date=reference_date.date(),
             )
             n_scraped_items = self.data.stats.get("item_scraped_count", 0)
             extracted_in_period = (
-                sum([stat.job_stats.get("item_scraped_count", 0) for stat in job_stats])
+                sum(
+                    stat.get("stats", {}).get("item_scraped_count", 0)
+                    for stat in job_stats
+                )
                 + n_scraped_items
             )
             self.assertNotEqual(

--- a/data_collection/gazette/pipelines.py
+++ b/data_collection/gazette/pipelines.py
@@ -3,18 +3,19 @@ from pathlib import Path
 
 import boto3
 import filetype
+import requests
 from itemadapter import ItemAdapter
-from scrapy import spiderloader
 from scrapy.exceptions import DropItem
 from scrapy.http import Request
 from scrapy.http.request import NO_CALLBACK
 from scrapy.pipelines.files import FilesPipeline
 from scrapy.settings import Settings
-from scrapy.utils import project
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import sessionmaker
 
 from gazette.database.models import Gazette, initialize_database
+from gazette.utils.api_client import api_client_from_settings
+from gazette.utils.database import generate_territory_spider_map
 
 
 class GazetteDateFilteringPipeline:
@@ -36,6 +37,72 @@ class DefaultValuesPipeline:
         return item
 
 
+class ApiPipeline:
+    """Persist scraped gazettes through the Querido Diário API.
+
+    Replaces the direct database INSERT done by SQLDatabasePipeline when
+    QUERIDODIARIO_API_URL is configured. When the API is not configured
+    (local development), this pipeline is a no-op and SQLDatabasePipeline
+    keeps the current SQLite-based behavior.
+    """
+
+    ITEM_FIELDS = [
+        "source_text",
+        "date",
+        "edition_number",
+        "is_extra_edition",
+        "power",
+        "scraped_at",
+        "territory_id",
+    ]
+
+    def __init__(self, crawler):
+        self.crawler = crawler
+        self.client = None
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls(crawler)
+
+    def open_spider(self, spider):
+        # No-op when QUERIDODIARIO_API_URL is not set (local development)
+        self.client = api_client_from_settings(self.crawler.settings)
+
+    def process_item(self, item, spider):
+        if self.client is None:
+            return item
+
+        # "date" and "scraped_at" are already ISO formatted strings
+        # (see DefaultValuesPipeline), which is what the API expects.
+        gazette_item = {field: item.get(field) for field in self.ITEM_FIELDS}
+
+        for file_info in item.get("files", []):
+            already_downloaded = file_info["status"] == "uptodate"
+            if already_downloaded:
+                # We should not persist information of files that
+                # were already downloaded before
+                continue
+
+            gazette_item["file_path"] = file_info["path"]
+            gazette_item["file_url"] = file_info["url"]
+            gazette_item["file_checksum"] = file_info["checksum"]
+
+            try:
+                self.client.post_gazette(dict(gazette_item))
+            except requests.RequestException as exc:
+                # Same behavior as SQLDatabasePipeline: log and keep crawling.
+                # The item is recoverable by re-running the spider for the day
+                # (the API insert is idempotent).
+                spider.logger.warning(
+                    f"Something wrong has happened when sending the gazette to the API. "
+                    f"Date: {gazette_item['date']}. "
+                    f"File Checksum: {gazette_item['file_checksum']}. "
+                    f"Details: {exc}"
+                )
+
+        return item
+
+
 class SQLDatabasePipeline:
     def __init__(self, database_url):
         self.database_url = database_url
@@ -43,26 +110,15 @@ class SQLDatabasePipeline:
     @classmethod
     def from_crawler(cls, crawler):
         database_url = crawler.settings.get("QUERIDODIARIO_DATABASE_URL")
+        if crawler.settings.get("QUERIDODIARIO_API_URL"):
+            # ApiPipeline takes over gazette persistence when the API is
+            # configured; disable the direct database access.
+            database_url = None
         return cls(database_url=database_url)
-
-    def _generate_territory_spider_map(self):
-        settings = project.get_project_settings()
-        spider_loader = spiderloader.SpiderLoader.from_settings(settings)
-        spiders = spider_loader.list()
-        classes = [spider_loader.load(name) for name in spiders]
-
-        mapping = []
-        for spider_class in classes:
-            spider_name = getattr(spider_class, "name", None)
-            territory_id = getattr(spider_class, "TERRITORY_ID", None)
-            date_from = getattr(spider_class, "start_date", None)
-            if all((spider_name, territory_id, date_from)):
-                mapping.append((spider_name, territory_id, date_from))
-        return mapping
 
     def open_spider(self, spider):
         if self.database_url is not None:
-            territory_spider_map = self._generate_territory_spider_map()
+            territory_spider_map = generate_territory_spider_map()
             engine = initialize_database(self.database_url, territory_spider_map)
             self.Session = sessionmaker(bind=engine)
 

--- a/data_collection/gazette/settings.py
+++ b/data_collection/gazette/settings.py
@@ -10,7 +10,11 @@ ITEM_PIPELINES = {
     "gazette.pipelines.DefaultValuesPipeline": 200,
     "gazette.pipelines.QueridoDiarioFilesPipeline": 300,
     "spidermon.contrib.scrapy.pipelines.ItemValidationPipeline": 400,
-    "gazette.pipelines.SQLDatabasePipeline": 500,
+    # ApiPipeline persists gazettes through the Querido Diário API when
+    # QUERIDODIARIO_API_URL is set; otherwise it is a no-op and
+    # SQLDatabasePipeline keeps the direct database behavior (local dev).
+    "gazette.pipelines.ApiPipeline": 500,
+    "gazette.pipelines.SQLDatabasePipeline": 510,
 }
 USER_AGENT = (
     "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0"
@@ -47,6 +51,10 @@ SPIDERMON_DISCORD_WEBHOOK_URL = config(
 QUERIDODIARIO_DATABASE_URL = config(
     "QUERIDODIARIO_DATABASE_URL", default="sqlite:///querido-diario.db"
 )
+# When set, gazettes/job stats are persisted through the Querido Diário API
+# instead of direct database access (see ApiPipeline and StatsPersist)
+QUERIDODIARIO_API_URL = config("QUERIDODIARIO_API_URL", default="")
+QUERIDODIARIO_API_KEY = config("QUERIDODIARIO_API_KEY", default="")
 QUERIDODIARIO_MAX_REQUESTS_ITEMS_RATIO = 5
 QUERIDODIARIO_MAX_DAYS_WITHOUT_GAZETTES = 7
 

--- a/data_collection/gazette/utils/api_client.py
+++ b/data_collection/gazette/utils/api_client.py
@@ -7,7 +7,7 @@ with an API Key sent in the ``X-API-Key`` header.
 Configuration (environment variables or Scrapy settings):
     - ``QUERIDODIARIO_API_URL``: base URL of the API
       (e.g. ``https://queridodiario.ok.org.br/api``... base host only,
-      the ``/api/scraper/*`` path is appended by the client)
+      the ``/scraper/*`` path is appended by the client)
     - ``QUERIDODIARIO_API_KEY``: API Key for the scraper endpoints
 """
 
@@ -22,7 +22,7 @@ RETRY_STATUS_FORCELIST = [429, 500, 502, 503, 504]
 
 
 class QueridoDiarioAPIClient:
-    """Client for the ``/api/scraper/*`` endpoints of the Querido Diário API.
+    """Client for the ``/scraper/*`` endpoints of the Querido Diário API.
 
     Retries with exponential backoff are enabled for GET and POST requests.
     Retrying POSTs is safe because the server-side inserts are idempotent
@@ -61,30 +61,30 @@ class QueridoDiarioAPIClient:
     def get_enabled_spiders(self, start_date=None, end_date=None):
         """Return the names of the enabled spiders within the date period.
 
-        GET /api/scraper/spiders
+        GET /scraper/spiders
         """
         params = {}
         if start_date is not None:
             params["start_date"] = str(start_date)
         if end_date is not None:
             params["end_date"] = str(end_date)
-        data = self._get("/api/scraper/spiders", params=params)
+        data = self._get("/scraper/spiders", params=params)
         return [spider["spider_name"] for spider in data["spiders"]]
 
     def post_gazette(self, gazette):
         """Persist a scraped gazette (metadata only).
 
-        POST /api/scraper/gazettes
+        POST /scraper/gazettes
 
         The endpoint is idempotent: posting a duplicate
         (same territory_id + date + file_checksum) is a no-op.
         """
-        return self._post("/api/scraper/gazettes", gazette)
+        return self._post("/scraper/gazettes", gazette)
 
     def post_job_stats(self, spider_name, job_id, stats_dict):
         """Persist the Scrapy stats of a finished job.
 
-        POST /api/scraper/job-stats
+        POST /scraper/job-stats
         """
         payload = {
             "spider_name": spider_name,
@@ -92,24 +92,24 @@ class QueridoDiarioAPIClient:
             "start_time": str(stats_dict.get("start_time", "")),
             "stats": stats_dict,
         }
-        return self._post("/api/scraper/job-stats", payload)
+        return self._post("/scraper/job-stats", payload)
 
     def get_job_stats(self, spider_name, since_date):
         """Return the job stats of a spider since a given date.
 
-        GET /api/scraper/job-stats?spider=<name>&since=<YYYY-MM-DD>
+        GET /scraper/job-stats?spider=<name>&since=<YYYY-MM-DD>
 
         Returns a list of dicts, each one with at least a ``stats`` key
         holding the Scrapy stats collected for that job.
         """
         params = {"spider": spider_name, "since": str(since_date)}
-        data = self._get("/api/scraper/job-stats", params=params)
+        data = self._get("/scraper/job-stats", params=params)
         return data["job_stats"]
 
     def sync_spiders(self, territory_spider_map):
         """Register new/modified spiders and their territory mapping.
 
-        POST /api/scraper/spiders/sync
+        POST /scraper/spiders/sync
 
         ``territory_spider_map`` is an iterable of
         ``(spider_name, territory_id, date_from)`` tuples.
@@ -124,7 +124,7 @@ class QueridoDiarioAPIClient:
                 for spider_name, territory_id, date_from in territory_spider_map
             ]
         }
-        return self._post("/api/scraper/spiders/sync", payload)
+        return self._post("/scraper/spiders/sync", payload)
 
 
 def api_client_from_settings(settings):

--- a/data_collection/gazette/utils/api_client.py
+++ b/data_collection/gazette/utils/api_client.py
@@ -1,0 +1,136 @@
+"""HTTP client for the Querido Diário API scraper endpoints.
+
+Replaces the direct database access previously done by the spiders when
+running in production (Zyte / Scrapy Cloud). All endpoints are authenticated
+with an API Key sent in the ``X-API-Key`` header.
+
+Configuration (environment variables or Scrapy settings):
+    - ``QUERIDODIARIO_API_URL``: base URL of the API
+      (e.g. ``https://queridodiario.ok.org.br/api``... base host only,
+      the ``/api/scraper/*`` path is appended by the client)
+    - ``QUERIDODIARIO_API_KEY``: API Key for the scraper endpoints
+"""
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+DEFAULT_TIMEOUT = 30
+RETRY_TOTAL = 5
+RETRY_BACKOFF_FACTOR = 2  # 2s, 4s, 8s, 16s, 32s
+RETRY_STATUS_FORCELIST = [429, 500, 502, 503, 504]
+
+
+class QueridoDiarioAPIClient:
+    """Client for the ``/api/scraper/*`` endpoints of the Querido Diário API.
+
+    Retries with exponential backoff are enabled for GET and POST requests.
+    Retrying POSTs is safe because the server-side inserts are idempotent
+    (``ON CONFLICT DO NOTHING`` over unique constraints).
+    """
+
+    def __init__(self, base_url, api_key, timeout=DEFAULT_TIMEOUT):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers["X-API-Key"] = api_key or ""
+        retry = Retry(
+            total=RETRY_TOTAL,
+            backoff_factor=RETRY_BACKOFF_FACTOR,
+            status_forcelist=RETRY_STATUS_FORCELIST,
+            allowed_methods=["GET", "POST"],  # POST is idempotent server-side
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
+
+    def _get(self, path, params=None):
+        response = self.session.get(
+            f"{self.base_url}{path}", params=params, timeout=self.timeout
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _post(self, path, payload):
+        response = self.session.post(
+            f"{self.base_url}{path}", json=payload, timeout=self.timeout
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_enabled_spiders(self, start_date=None, end_date=None):
+        """Return the names of the enabled spiders within the date period.
+
+        GET /api/scraper/spiders
+        """
+        params = {}
+        if start_date is not None:
+            params["start_date"] = str(start_date)
+        if end_date is not None:
+            params["end_date"] = str(end_date)
+        data = self._get("/api/scraper/spiders", params=params)
+        return [spider["spider_name"] for spider in data["spiders"]]
+
+    def post_gazette(self, gazette):
+        """Persist a scraped gazette (metadata only).
+
+        POST /api/scraper/gazettes
+
+        The endpoint is idempotent: posting a duplicate
+        (same territory_id + date + file_checksum) is a no-op.
+        """
+        return self._post("/api/scraper/gazettes", gazette)
+
+    def post_job_stats(self, spider_name, job_id, stats_dict):
+        """Persist the Scrapy stats of a finished job.
+
+        POST /api/scraper/job-stats
+        """
+        payload = {
+            "spider_name": spider_name,
+            "job_id": job_id,
+            "start_time": str(stats_dict.get("start_time", "")),
+            "stats": stats_dict,
+        }
+        return self._post("/api/scraper/job-stats", payload)
+
+    def get_job_stats(self, spider_name, since_date):
+        """Return the job stats of a spider since a given date.
+
+        GET /api/scraper/job-stats?spider=<name>&since=<YYYY-MM-DD>
+
+        Returns a list of dicts, each one with at least a ``stats`` key
+        holding the Scrapy stats collected for that job.
+        """
+        params = {"spider": spider_name, "since": str(since_date)}
+        data = self._get("/api/scraper/job-stats", params=params)
+        return data["job_stats"]
+
+    def sync_spiders(self, territory_spider_map):
+        """Register new/modified spiders and their territory mapping.
+
+        POST /api/scraper/spiders/sync
+
+        ``territory_spider_map`` is an iterable of
+        ``(spider_name, territory_id, date_from)`` tuples.
+        """
+        payload = {
+            "spiders": [
+                {
+                    "spider_name": spider_name,
+                    "territory_id": territory_id,
+                    "date_from": str(date_from),
+                }
+                for spider_name, territory_id, date_from in territory_spider_map
+            ]
+        }
+        return self._post("/api/scraper/spiders/sync", payload)
+
+
+def api_client_from_settings(settings):
+    """Build a client from Scrapy settings, or return None when the API
+    is not configured (local development without API access)."""
+    api_url = settings.get("QUERIDODIARIO_API_URL")
+    if not api_url:
+        return None
+    return QueridoDiarioAPIClient(api_url, settings.get("QUERIDODIARIO_API_KEY", ""))

--- a/data_collection/gazette/utils/api_client.py
+++ b/data_collection/gazette/utils/api_client.py
@@ -133,4 +133,10 @@ def api_client_from_settings(settings):
     api_url = settings.get("QUERIDODIARIO_API_URL")
     if not api_url:
         return None
-    return QueridoDiarioAPIClient(api_url, settings.get("QUERIDODIARIO_API_KEY", ""))
+    api_key = settings.get("QUERIDODIARIO_API_KEY", "")
+    if not api_key:
+        raise RuntimeError(
+            "QUERIDODIARIO_API_URL is set but QUERIDODIARIO_API_KEY is missing. "
+            "Configure the API key to authenticate with the Querido Diário API."
+        )
+    return QueridoDiarioAPIClient(api_url, api_key)

--- a/data_collection/gazette/utils/database.py
+++ b/data_collection/gazette/utils/database.py
@@ -1,14 +1,50 @@
+from decouple import config
+from scrapy import spiderloader
+from scrapy.utils import project
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from gazette.database.models import QueridoDiarioSpider
+from gazette.utils.api_client import QueridoDiarioAPIClient
 
 
-def get_enabled_spiders(*, database_url, start_date=None, end_date=None):
+def generate_territory_spider_map():
+    """Build the (spider_name, territory_id, date_from) mapping from the
+    spider classes available in the project."""
+    settings = project.get_project_settings()
+    spider_loader = spiderloader.SpiderLoader.from_settings(settings)
+    spiders = spider_loader.list()
+    classes = [spider_loader.load(name) for name in spiders]
+
+    mapping = []
+    for spider_class in classes:
+        spider_name = getattr(spider_class, "name", None)
+        territory_id = getattr(spider_class, "TERRITORY_ID", None)
+        date_from = getattr(spider_class, "start_date", None)
+        if all((spider_name, territory_id, date_from)):
+            mapping.append((spider_name, territory_id, date_from))
+    return mapping
+
+
+def get_enabled_spiders(
+    *, database_url=None, start_date=None, end_date=None, api_url=None, api_key=None
+):
     """Return list of all currently enabled spiders within date period.
     If start_date and/or end_date are provided, it will return only
     the enabled spiders that are within the requested date period.
+
+    When QUERIDODIARIO_API_URL is configured (argument or environment
+    variable), the list is fetched from the Querido Diário API. Otherwise
+    it falls back to direct database access through database_url (local
+    development compatibility).
     """
+    api_url = api_url or config("QUERIDODIARIO_API_URL", default="")
+    if api_url:
+        api_key = api_key or config("QUERIDODIARIO_API_KEY", default="")
+        client = QueridoDiarioAPIClient(api_url, api_key)
+        yield from client.get_enabled_spiders(start_date=start_date, end_date=end_date)
+        return
+
     engine = create_engine(database_url)
     Session = sessionmaker(bind=engine)
     session = Session()

--- a/data_collection/gazette/utils/database.py
+++ b/data_collection/gazette/utils/database.py
@@ -45,6 +45,11 @@ def get_enabled_spiders(
         yield from client.get_enabled_spiders(start_date=start_date, end_date=end_date)
         return
 
+    if not database_url:
+        raise RuntimeError(
+            "Neither QUERIDODIARIO_API_URL nor QUERIDODIARIO_DATABASE_URL is set. "
+            "Configure one of them to fetch enabled spiders."
+        )
     engine = create_engine(database_url)
     Session = sessionmaker(bind=engine)
     session = Session()

--- a/data_collection/requirements.in
+++ b/data_collection/requirements.in
@@ -11,6 +11,7 @@ psycopg2-binary
 pyyaml==5.3.1
 python-dateutil
 python-decouple
+requests
 scrapy
 scrapy-zyte-smartproxy
 SQLAlchemy

--- a/data_collection/scheduler.py
+++ b/data_collection/scheduler.py
@@ -12,14 +12,16 @@ from gazette.utils.database import get_enabled_spiders
 YESTERDAY = datetime.date.today() - datetime.timedelta(days=1)
 
 
-def _schedule_job(start, full, spider_name):
-    client = ScrapinghubClient(config("SHUB_APIKEY"))
-    project = client.get_project(config("SCRAPY_CLOUD_PROJECT_ID"))
-
-    job_settings = {
+def _job_settings():
+    return {
         "FILES_STORE": config("FILES_STORE"),
         "FILES_STORE_SECONDARY": config("FILES_STORE_SECONDARY", default=""),
-        "QUERIDODIARIO_DATABASE_URL": config("QUERIDODIARIO_DATABASE_URL"),
+        # Gazettes are persisted through the API when QUERIDODIARIO_API_URL
+        # is set. QUERIDODIARIO_DATABASE_URL is kept only while job_stats
+        # (phase 2) has not migrated to the API.
+        "QUERIDODIARIO_API_URL": config("QUERIDODIARIO_API_URL", default=""),
+        "QUERIDODIARIO_API_KEY": config("QUERIDODIARIO_API_KEY", default=""),
+        "QUERIDODIARIO_DATABASE_URL": config("QUERIDODIARIO_DATABASE_URL", default=""),
         "AWS_ACCESS_KEY_ID": config("AWS_ACCESS_KEY_ID"),
         "AWS_SECRET_ACCESS_KEY": config("AWS_SECRET_ACCESS_KEY"),
         "AWS_ENDPOINT_URL": config("AWS_ENDPOINT_URL"),
@@ -28,6 +30,23 @@ def _schedule_job(start, full, spider_name):
         "SPIDERMON_DISCORD_WEBHOOK_URL": config("SPIDERMON_DISCORD_WEBHOOK_URL"),
         "ZYTE_SMARTPROXY_APIKEY": config("ZYTE_SMARTPROXY_APIKEY"),
     }
+
+
+def _get_enabled_spiders(start_date=None, end_date=None):
+    return get_enabled_spiders(
+        database_url=config("QUERIDODIARIO_DATABASE_URL", default=None),
+        api_url=config("QUERIDODIARIO_API_URL", default=""),
+        api_key=config("QUERIDODIARIO_API_KEY", default=""),
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+
+def _schedule_job(start, full, spider_name):
+    client = ScrapinghubClient(config("SHUB_APIKEY"))
+    project = client.get_project(config("SCRAPY_CLOUD_PROJECT_ID"))
+
+    job_settings = _job_settings()
 
     job_args = {}
     if not full:
@@ -65,18 +84,7 @@ def schedule_spider(spider_name, start, end):
     sh_client = ScrapinghubClient(config("SHUB_APIKEY"))
     project = sh_client.get_project(config("SCRAPY_CLOUD_PROJECT_ID"))
 
-    job_settings = {
-        "FILES_STORE": config("FILES_STORE"),
-        "FILES_STORE_SECONDARY": config("FILES_STORE_SECONDARY", default=""),
-        "QUERIDODIARIO_DATABASE_URL": config("QUERIDODIARIO_DATABASE_URL"),
-        "AWS_ACCESS_KEY_ID": config("AWS_ACCESS_KEY_ID"),
-        "AWS_SECRET_ACCESS_KEY": config("AWS_SECRET_ACCESS_KEY"),
-        "AWS_ENDPOINT_URL": config("AWS_ENDPOINT_URL"),
-        "AWS_REGION_NAME": config("AWS_REGION_NAME"),
-        "SPIDERMON_DISCORD_FAKE": config("SPIDERMON_DISCORD_FAKE"),
-        "SPIDERMON_DISCORD_WEBHOOK_URL": config("SPIDERMON_DISCORD_WEBHOOK_URL"),
-        "ZYTE_SMARTPROXY_APIKEY": config("ZYTE_SMARTPROXY_APIKEY"),
-    }
+    job_settings = _job_settings()
 
     job_args = {}
     if start:
@@ -154,9 +162,7 @@ def schedule_job(start, full, spider_name):
 
 @cli.command()
 def schedule_enabled_spiders():
-    for spider_name in get_enabled_spiders(
-        database_url=config("QUERIDODIARIO_DATABASE_URL"), start_date=YESTERDAY
-    ):
+    for spider_name in _get_enabled_spiders(start_date=YESTERDAY):
         _schedule_job(start=YESTERDAY, full=False, spider_name=spider_name)
 
 
@@ -166,9 +172,7 @@ def last_month_schedule_enabled_spiders():
     # day as the physical one (sometimes it take more than two days and other weeks)
     # so running this command will ensure that we get the data of the latest month
     start = datetime.date.today() - datetime.timedelta(days=31)
-    for spider_name in get_enabled_spiders(
-        database_url=config("QUERIDODIARIO_DATABASE_URL"), start_date=start
-    ):
+    for spider_name in _get_enabled_spiders(start_date=start):
         _schedule_job(start=start, full=False, spider_name=spider_name)
 
 
@@ -178,9 +182,7 @@ def last_month_schedule_enabled_spiders():
 )
 @cli.command()
 def schedule_all_spiders_by_date(start):
-    for spider_name in get_enabled_spiders(
-        database_url=config("QUERIDODIARIO_DATABASE_URL"), start_date=start
-    ):
+    for spider_name in _get_enabled_spiders(start_date=start):
         _schedule_job(start=start, full=False, spider_name=spider_name)
 
 


### PR DESCRIPTION
## Summary

Substitui o acesso direto ao PostgreSQL de produção (distribuído como `QUERIDODIARIO_DATABASE_URL` nos job settings da Zyte) por chamadas HTTP autenticadas aos endpoints `/scraper/*` da API.

Mantém compatibilidade com o fluxo local (SQLite/banco direto) quando `QUERIDODIARIO_API_URL` não está definida.

- **`gazette/utils/api_client.py`** (novo): `QueridoDiarioAPIClient` com header `X-API-Key`, retry exponencial (5×, fator 2, GET+POST) e timeout 30s. POST é seguro para retry pois os inserts são idempotentes no servidor. Falha rápida se `QUERIDODIARIO_API_URL` está definida mas `QUERIDODIARIO_API_KEY` não.
- **`pipelines.py`**: nova `ApiPipeline` (posição 500) envia gazettes via `POST /scraper/gazettes`; `SQLDatabasePipeline` (510) vira no-op quando API configurada, preservando fluxo local.
- **`extensions.py`**: `StatsPersist` migrado para `POST /scraper/job-stats`; desabilitado silenciosamente sem `QUERIDODIARIO_API_URL`.
- **`monitors.py`**: `ComparisonBetweenSpiderExecutionsMonitor` usa `GET /scraper/job-stats`.
- **`utils/database.py`**: `get_enabled_spiders` delega à API quando configurada, com fallback SQLAlchemy. Falha rápido com mensagem clara quando nem API nem banco estão configurados.
- **`scheduler.py`**: job settings passam `QUERIDODIARIO_API_URL` + `QUERIDODIARIO_API_KEY` (mantém `QUERIDODIARIO_DATABASE_URL` até job_stats estar 100% migrado).
- **`commands/qd-sync-spiders.py`** (novo): registra spiders/territories via API ou banco. **Executado automaticamente pelo CI após cada deploy** (via `scrapy qd-sync-spiders` no `deploy.yml`).
- **`commands/qd-list-enabled.py`**: `--start`/`--end` convertidos para `date` (em vez de `datetime`) para compatibilidade com o formato esperado pela API.

## Test plan

- [ ] `scrapy qd-list-enabled` funciona com e sem `QUERIDODIARIO_API_URL`
- [ ] `scrapy qd-sync-spiders` registra spiders via API (com URL) e via banco (sem URL)
- [ ] `ApiPipeline` posta gazette → verifica no banco via `GET /scraper/gazettes` (ou direto)
- [ ] `ApiPipeline` posta gazette duplicada → 200 sem erro, crawl continua
- [ ] `StatsPersist` sem `QUERIDODIARIO_API_URL` → spider sobe sem crash (`NotConfigured` silencioso)
- [ ] Definir `QUERIDODIARIO_API_URL` sem `QUERIDODIARIO_API_KEY` → erro claro antes de iniciar
- [ ] Job settings na Zyte incluem `QUERIDODIARIO_API_URL` e `QUERIDODIARIO_API_KEY`

**Pré-requisitos para merge:** secrets `QUERIDODIARIO_API_URL` e `QUERIDODIARIO_API_KEY` adicionados no repositório (necessários para o CI executar `qd-sync-spiders` após deploy).

Relacionado: PR #106 em `querido-diario-api` e PR #55 em `querido-diario-deployment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
