### PR TITLE
feat: integração com API do Querido Diário nos raspadores

### DIFF
--- a/.github/workflows/daily_crawl.yaml
+++ b/.github/workflows/daily_crawl.yaml
@@ -21,6 +21,8 @@ jobs:
       SPIDERMON_DISCORD_FAKE: ${{ secrets.SPIDERMON_DISCORD_FAKE }}
       SPIDERMON_DISCORD_WEBHOOK_URL: ${{ secrets.SPIDERMON_DISCORD_WEBHOOK_URL }}
       ZYTE_SMARTPROXY_APIKEY: ${{ secrets.ZYTE_SMARTPROXY_APIKEY }}
+      QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
+      QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,16 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install shub
+    - name: Inject API credentials into settings
+      env:
+        QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
+        QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
+      run: |
+        printf '\nQUERIDODIARIO_API_URL = "%s"\n' "$QUERIDODIARIO_API_URL" \
+          >> data_collection/gazette/settings.py
+        printf 'QUERIDODIARIO_API_KEY = "%s"\n' "$QUERIDODIARIO_API_KEY" \
+          >> data_collection/gazette/settings.py
+
     - name: Deploy to Scrapy Cloud
       env:
         SHUB_APIKEY: ${{ secrets.SHUB_APIKEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,16 +17,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install shub
-    - name: Inject API credentials into settings
-      env:
-        QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
-        QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
-      run: |
-        printf '\nQUERIDODIARIO_API_URL = "%s"\n' "$QUERIDODIARIO_API_URL" \
-          >> data_collection/gazette/settings.py
-        printf 'QUERIDODIARIO_API_KEY = "%s"\n' "$QUERIDODIARIO_API_KEY" \
-          >> data_collection/gazette/settings.py
-
     - name: Deploy to Scrapy Cloud
       env:
         SHUB_APIKEY: ${{ secrets.SHUB_APIKEY }}

--- a/.github/workflows/monthly_crawl.yaml
+++ b/.github/workflows/monthly_crawl.yaml
@@ -21,6 +21,8 @@ jobs:
       SPIDERMON_DISCORD_FAKE: ${{ secrets.SPIDERMON_DISCORD_FAKE }}
       SPIDERMON_DISCORD_WEBHOOK_URL: ${{ secrets.SPIDERMON_DISCORD_WEBHOOK_URL }}
       ZYTE_SMARTPROXY_APIKEY: ${{ secrets.ZYTE_SMARTPROXY_APIKEY }}
+      QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
+      QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/schedule_spider.yaml
+++ b/.github/workflows/schedule_spider.yaml
@@ -28,6 +28,8 @@ jobs:
       SPIDERMON_DISCORD_FAKE: ${{ secrets.SPIDERMON_DISCORD_FAKE }}
       SPIDERMON_DISCORD_WEBHOOK_URL: ${{ secrets.SPIDERMON_DISCORD_WEBHOOK_URL }}
       ZYTE_SMARTPROXY_APIKEY: ${{ secrets.ZYTE_SMARTPROXY_APIKEY }}
+      QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
+      QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/schedule_spider_by_date.yaml
+++ b/.github/workflows/schedule_spider_by_date.yaml
@@ -22,6 +22,8 @@ jobs:
       SPIDERMON_DISCORD_FAKE: ${{ secrets.SPIDERMON_DISCORD_FAKE }}
       SPIDERMON_DISCORD_WEBHOOK_URL: ${{ secrets.SPIDERMON_DISCORD_WEBHOOK_URL }}
       ZYTE_SMARTPROXY_APIKEY: ${{ secrets.ZYTE_SMARTPROXY_APIKEY }}
+      QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
+      QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/schedule_spider_yearly.yaml
+++ b/.github/workflows/schedule_spider_yearly.yaml
@@ -28,6 +28,8 @@ jobs:
       SPIDERMON_DISCORD_FAKE: ${{ secrets.SPIDERMON_DISCORD_FAKE }}
       SPIDERMON_DISCORD_WEBHOOK_URL: ${{ secrets.SPIDERMON_DISCORD_WEBHOOK_URL }}
       ZYTE_SMARTPROXY_APIKEY: ${{ secrets.ZYTE_SMARTPROXY_APIKEY }}
+      QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
+      QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2


### PR DESCRIPTION
## Resumo

- Migra o acesso a spiders habilitados do banco de dados direto para a API do Querido Diário (`QUERIDODIARIO_API_URL`)
- Persistência de gazettes via `ApiPipeline` quando a API está configurada (mantém `SQLDatabasePipeline` como fallback local)
- Adiciona `qd-sync-spiders` ao CI/CD: registra automaticamente spiders novos/atualizados na API após cada deploy na Zyte
- Adiciona `QUERIDODIARIO_API_URL` e `QUERIDODIARIO_API_KEY` aos 5 workflows de scheduling — o `scheduler.py` lê via `decouple` e repassa como job settings a cada job no Zyte, disponibilizando-as via `crawler.settings.get()` nos spiders
- Fail-fast quando `QUERIDODIARIO_API_URL` está definido mas `QUERIDODIARIO_API_KEY` está ausente

## Secrets necessários no repositório

| Secret | Valor |
|---|---|
| `QUERIDODIARIO_API_URL` | `https://api.queridodiario.ok.org.br` |
| `QUERIDODIARIO_API_KEY` | chave de acesso à API dos raspadores |

Workflows afetados: `daily_crawl`, `monthly_crawl`, `schedule_spider`, `schedule_spider_by_date`, `schedule_spider_yearly`.
`update_spider_status` não precisa — `enable/disable_spider` acessa o banco diretamente.

## Plano de teste

- [ ] Verificar que o CI passa após merge
- [ ] Confirmar que o step `Sync spiders to API` executa com sucesso (`POST /scraper/spiders/sync`)
- [ ] Validar que um spider agendado via `daily_crawl` recebe `QUERIDODIARIO_API_URL` nos job settings e envia gazettes via `ApiPipeline` (não via SQLite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
