### PR TITLE
fix: detecta bloqueio por Cloudflare Turnstile e falha o raspador

### DIFF
--- a/querido_diario_raspadores/gazette/middlewares.py
+++ b/querido_diario_raspadores/gazette/middlewares.py
@@ -4,9 +4,12 @@
 # See documentation in:
 # https://doc.scrapy.org/en/latest/topics/spider-middleware.html
 from scrapy import signals
+from scrapy.exceptions import CloseSpider
 from scrapy_zyte_smartproxy import (
     ZyteSmartProxyMiddleware as BaseZyteSmartProxyMiddleware,
 )
+
+from gazette.utils.blocking import is_cloudflare_challenge
 
 
 class ZyteSmartProxyMiddleware(BaseZyteSmartProxyMiddleware):
@@ -93,6 +96,23 @@ class GazetteDownloaderMiddleware:
         # - return a Response object
         # - return a Request object
         # - or raise IgnoreRequest
+        if is_cloudflare_challenge(response):
+            spider.crawler.stats.inc_value("cloudflare_challenge/blocked_count")
+            spider.logger.error(
+                "Blocked by a Cloudflare Turnstile challenge at %s. Aborting "
+                "the spider instead of treating the challenge page as valid "
+                "content.",
+                request.url,
+            )
+            # Raised here, this is caught the same way an exception raised
+            # from a spider callback would be: it stops the spider with a
+            # finish_reason that isn't "finished", which our Spidermon
+            # monitors (FinishReasonMonitor/ErrorCountMonitor) already treat
+            # as a failure. For requests started by the files pipeline
+            # (downloading the gazette PDF), this is instead caught by
+            # Scrapy's MediaPipeline as a failed download, so the fake file
+            # is dropped rather than saved as if it were the real gazette.
+            raise CloseSpider(reason="blocked_by_cloudflare_turnstile")
         return response
 
     def process_exception(self, request, exception, spider):

--- a/querido_diario_raspadores/gazette/settings.py
+++ b/querido_diario_raspadores/gazette/settings.py
@@ -63,7 +63,13 @@ AWS_ENDPOINT_URL = config("AWS_ENDPOINT_URL", default="")
 AWS_REGION_NAME = config("AWS_REGION_NAME", default="")
 FILES_STORE_S3_ACL = config("FILES_STORE_S3_ACL", default="")
 
-DOWNLOADER_MIDDLEWARES = {"gazette.middlewares.ZyteSmartProxyMiddleware": 610}
+DOWNLOADER_MIDDLEWARES = {
+    "gazette.middlewares.ZyteSmartProxyMiddleware": 610,
+    # Detects when a response is actually a Cloudflare Turnstile challenge
+    # page and fails the request/spider instead of treating it as valid
+    # content (see gazette/utils/blocking.py).
+    "gazette.middlewares.GazetteDownloaderMiddleware": 620,
+}
 ZYTE_SMARTPROXY_APIKEY = "<SMARTPROXY_APIKEY>"
 
 COMMANDS_MODULE = "gazette.commands"

--- a/querido_diario_raspadores/gazette/utils/blocking.py
+++ b/querido_diario_raspadores/gazette/utils/blocking.py
@@ -1,0 +1,26 @@
+# Some websites started protecting themselves with Cloudflare Turnstile.
+# When a spider (or Zyte Smart Proxy) is challenged, Cloudflare replies with
+# an HTTP 200/403/503 response carrying an interstitial HTML page instead of
+# the real content. Without this check, that harmless-looking HTML gets
+# parsed as if it were the actual gazette page, or saved as if it were the
+# gazette PDF file, silently producing wrong results.
+CLOUDFLARE_CHALLENGE_MARKERS = (
+    b"challenges.cloudflare.com",
+    b"cf-turnstile",
+    b"cf_chl_opt",
+    b"cf-chl-",
+    b"Just a moment...",
+    b"Attention Required! | Cloudflare",
+    b"Checking if the site connection is secure",
+)
+
+# Only look at the first few KB: the markers always appear near the top of
+# the interstitial page, and PDFs/large files would be costly to scan fully.
+_MAX_BODY_BYTES_TO_INSPECT = 8192
+
+
+def is_cloudflare_challenge(response) -> bool:
+    """Return True if `response` is a Cloudflare Turnstile/challenge page
+    rather than the content that was actually requested."""
+    body = response.body[:_MAX_BODY_BYTES_TO_INSPECT]
+    return any(marker in body for marker in CLOUDFLARE_CHALLENGE_MARKERS)

--- a/querido_diario_raspadores/tests/test_blocking.py
+++ b/querido_diario_raspadores/tests/test_blocking.py
@@ -1,0 +1,66 @@
+from unittest.mock import MagicMock
+
+import pytest
+from scrapy.exceptions import CloseSpider
+from scrapy.http import Request, TextResponse
+
+from gazette.middlewares import GazetteDownloaderMiddleware
+from gazette.utils.blocking import is_cloudflare_challenge
+
+
+def make_response(body: bytes, status: int = 200, url: str = "https://example.org"):
+    return TextResponse(url=url, body=body, status=status)
+
+
+class TestIsCloudflareChallenge:
+    def test_real_gazette_page_is_not_a_challenge(self):
+        response = make_response(b"<html><body>Diario Oficial</body></html>")
+        assert is_cloudflare_challenge(response) is False
+
+    def test_real_pdf_is_not_a_challenge(self):
+        response = make_response(b"%PDF-1.4 some binary pdf content")
+        assert is_cloudflare_challenge(response) is False
+
+    @pytest.mark.parametrize(
+        "marker",
+        [
+            b"challenges.cloudflare.com",
+            b"cf-turnstile",
+            b"cf_chl_opt",
+            b"Just a moment...",
+            b"Attention Required! | Cloudflare",
+        ],
+    )
+    def test_detects_known_turnstile_markers(self, marker):
+        response = make_response(
+            b"<html><head><title>%s</title></html>" % marker, status=403
+        )
+        assert is_cloudflare_challenge(response) is True
+
+    def test_marker_outside_inspection_window_is_not_detected(self):
+        padding = b"x" * 8192
+        response = make_response(padding + b"cf-turnstile")
+        assert is_cloudflare_challenge(response) is False
+
+
+class TestGazetteDownloaderMiddleware:
+    def setup_method(self):
+        self.middleware = GazetteDownloaderMiddleware()
+        self.spider = MagicMock()
+        self.spider.crawler.stats = MagicMock()
+        self.request = Request("https://example.org")
+
+    def test_returns_response_when_not_blocked(self):
+        response = make_response(b"<html>real content</html>")
+        result = self.middleware.process_response(self.request, response, self.spider)
+        assert result is response
+        self.spider.crawler.stats.inc_value.assert_not_called()
+
+    def test_raises_close_spider_when_blocked(self):
+        response = make_response(b"cf-turnstile challenge page", status=403)
+        with pytest.raises(CloseSpider) as exc_info:
+            self.middleware.process_response(self.request, response, self.spider)
+        assert exc_info.value.reason == "blocked_by_cloudflare_turnstile"
+        self.spider.crawler.stats.inc_value.assert_called_once_with(
+            "cloudflare_challenge/blocked_count"
+        )


### PR DESCRIPTION
## Resumo
- Alguns raspadores enfrentam sites que passaram a usar Cloudflare Turnstile para bloquear robôs. Sem tratamento, o raspador coletava a página de desafio (HTML inócuo) como se fosse conteúdo real, ou salvava essa página como se fosse o PDF do diário, reportando um resultado incorreto como sucesso.
- Adiciona `gazette/utils/blocking.py` com `is_cloudflare_challenge(response)`, que inspeciona o início do corpo da resposta procurando marcadores conhecidos do desafio Turnstile (`cf-turnstile`, `challenges.cloudflare.com`, `Just a moment...`, etc).
- Ativa `GazetteDownloaderMiddleware` (antes inerte, apenas boilerplate) em `DOWNLOADER_MIDDLEWARES`, usando o helper acima em `process_response` para levantar `CloseSpider(reason="blocked_by_cloudflare_turnstile")` quando o bloqueio é detectado.

## Por que isso cobre os dois cenários de falha
- **Página de listagem bloqueada**: o `CloseSpider` interrompe o raspador com um `finish_reason` distinto de `"finished"`, que os monitores Spidermon já existentes (`FinishReasonMonitor`, `ErrorCountMonitor`) tratam como falha e alertam via Discord.
- **PDF do diário bloqueado**: as requisições de arquivo do `QueridoDiarioFilesPipeline` passam pelo mesmo `Downloader`, então o middleware intercepta a resposta antes de chegar ao pipeline de arquivos. Como a exceção não é `IgnoreRequest`, o `MediaPipeline` do Scrapy trata como falha de download — o "PDF" falso é descartado em vez de salvo. O item fica com `files=[]`, o que falha a validação do schema (`minItems: 1`) e é descartado, ficando visível via `ItemValidationMonitor`.

## Test plan
- [x] `pytest tests/test_blocking.py` — 10 casos novos cobrindo detecção de marcadores, falsos positivos (HTML/PDF legítimos) e comportamento do middleware.
- [x] `pytest tests/` — suíte completa (84 testes) passando.
- [ ] Validar em execução real contra um município que atualmente sofre bloqueio por Turnstile, confirmando que o raspador falha visivelmente em vez de produzir um item incorreto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)