### PR TITLE
ci: pina actions do GitHub Actions por SHA

### DIFF
--- a/.github/workflows/daily_crawl.yaml
+++ b/.github/workflows/daily_crawl.yaml
@@ -24,8 +24,8 @@ jobs:
       QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
       QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: "3.10"
     - name: Prepare environment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: "3.12"
     - name: Install shub

--- a/.github/workflows/monthly_crawl.yaml
+++ b/.github/workflows/monthly_crawl.yaml
@@ -24,8 +24,8 @@ jobs:
       QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
       QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: "3.10"
     - name: Prepare environment

--- a/.github/workflows/schedule_spider.yaml
+++ b/.github/workflows/schedule_spider.yaml
@@ -31,8 +31,8 @@ jobs:
       QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
       QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: '3.10'
     - name: Prepare environment

--- a/.github/workflows/schedule_spider_by_date.yaml
+++ b/.github/workflows/schedule_spider_by_date.yaml
@@ -25,8 +25,8 @@ jobs:
       QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
       QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: "3.10"
     - name: Prepare environment

--- a/.github/workflows/schedule_spider_yearly.yaml
+++ b/.github/workflows/schedule_spider_yearly.yaml
@@ -31,8 +31,8 @@ jobs:
       QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
       QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: '3.10'
     - name: Prepare environment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,8 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
       - name: Install dependencies

--- a/.github/workflows/update_spider_status.yaml
+++ b/.github/workflows/update_spider_status.yaml
@@ -20,8 +20,8 @@ jobs:
     env:
       QUERIDODIARIO_DATABASE_URL: ${{ secrets.QUERIDODIARIO_DATABASE_URL }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: '3.10'
     - name: Prepare environment


### PR DESCRIPTION
## Descrição

Fixa todas as GitHub Actions usadas nos workflows pelo hash do commit da release mais recente, em vez de uma tag mutável (`@v2`), seguindo a recomendação de segurança do GitHub Actions (mitiga risco de a tag ser reapontada para um commit malicioso).

Formato usado: `uses: <action>@<sha>  # vX.Y.Z`

## Alterações

Em todos os 8 workflows (`tests.yml`, `deploy.yml`, `daily_crawl.yaml`, `monthly_crawl.yaml`, `schedule_spider.yaml`, `schedule_spider_by_date.yaml`, `schedule_spider_yearly.yaml`, `update_spider_status.yaml`):

- `actions/checkout@v2` → `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1`
- `actions/setup-python@v2` → `actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0`

Nenhum outro parâmetro dos steps foi alterado (ex.: `python-version` de cada workflow permanece igual).

## Testes

- YAML de todos os workflows validado com `yaml.safe_load`
- SHAs confirmados via `gh api repos/actions/<action>/git/refs/tags/<tag>` (tags leves apontando direto pro commit)