### PR TITLE
fix: remove uso de pkg_resources (removido pelo setuptools recente)

### DIFF
--- a/data_collection/gazette/database/models.py
+++ b/data_collection/gazette/database/models.py
@@ -1,8 +1,8 @@
 import csv
 import datetime as dt
 import logging
+from importlib.resources import files
 
-import pkg_resources
 from sqlalchemy import (
     Boolean,
     Column,
@@ -36,9 +36,7 @@ def load_territories(engine):
         return
 
     logger.info("Populating 'territories' table - Please wait!")
-    territories_file = pkg_resources.resource_filename(
-        "gazette", "resources/territories.csv"
-    )
+    territories_file = str(files("gazette").joinpath("resources/territories.csv"))
     with open(territories_file, encoding="utf-8") as csvfile:
         reader = csv.DictReader(csvfile)
         territories = []

--- a/data_collection/gazette/settings.py
+++ b/data_collection/gazette/settings.py
@@ -1,4 +1,5 @@
-import pkg_resources
+from importlib.resources import files
+
 from decouple import config
 
 BOT_NAME = "gazette"
@@ -34,7 +35,7 @@ EXTENSIONS = {
 }
 SPIDERMON_ENABLED = config("SPIDERMON_ENABLED", default=True, cast=bool)
 SPIDERMON_VALIDATION_SCHEMAS = [
-    pkg_resources.resource_filename("gazette", "resources/gazette_schema.json")
+    str(files("gazette").joinpath("resources/gazette_schema.json"))
 ]
 
 SPIDERMON_VALIDATION_ADD_ERRORS_TO_ITEMS = True

--- a/data_collection/tests/test_settings_and_models.py
+++ b/data_collection/tests/test_settings_and_models.py
@@ -1,0 +1,23 @@
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from gazette import settings
+from gazette.database.models import Territory, create_tables, load_territories
+
+
+def test_spidermon_validation_schema_path_exists():
+    schemas = settings.SPIDERMON_VALIDATION_SCHEMAS
+    assert len(schemas) == 1
+    assert os.path.isfile(schemas[0])
+
+
+def test_load_territories_populates_table_from_package_resource():
+    engine = create_engine("sqlite://")
+    create_tables(engine)
+
+    load_territories(engine)
+
+    session = sessionmaker(bind=engine)()
+    assert session.query(Territory).count() > 0


### PR DESCRIPTION
## Resumo

Depois do merge de #1465 (migração para a stack `scrapy:2.14`, Python 3.13), o deploy em produção passou a falhar num novo ponto: o crawl real (não mais o `shub deploy`) quebrava com

```
ModuleNotFoundError: No module named 'pkg_resources'
  File "/app/__main__.egg/gazette/settings.py", line 1, in <module>
    import pkg_resources
```

**Causa raiz:** `setuptools` >= ~81 removeu o módulo `pkg_resources` (deprecado havia anos). Confirmei localmente instalando `setuptools==83.0.0` (a versão que a stack `2.14` traz) num venv limpo: `import pkg_resources` continua falhando mesmo com o setuptools presente. Ou seja, nem pinar uma versão de setuptools seria uma solução robusta — a dependência certa é sair do `pkg_resources`.

## Mudanças

- `gazette/settings.py` e `gazette/database/models.py`: troca as duas chamadas de `pkg_resources.resource_filename()` por `importlib.resources.files()` (stdlib, não depende do setuptools).
- Adiciona `data_collection/tests/test_settings_and_models.py`: **nenhum teste da suíte importava `gazette.settings` ou exercitava `load_territories()`** antes — por isso esse import quebrado passou despercebido mesmo com os 74 testes existentes passando. Os 2 novos testes:
  - garantem que o path do schema do Spidermon existe de fato no disco;
  - rodam `load_territories()` contra um SQLite em memória e verificam que a tabela é populada a partir do `territories.csv` empacotado.

## Test plan

- [x] Reproduzido o cenário de produção: venv limpo sem `pkg_resources`/`setuptools` disponível (Python 3.13) — os imports antigos falhavam, os novos funcionam.
- [x] `pytest data_collection/tests/` — 76 testes passando (74 existentes + 2 novos)
- [x] `pre-commit run` nos arquivos alterados — passou
- [ ] CI deve rodar verde nesta PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)