### PR TITLE
Adiciona spider de Xambioá-TO

### DIFF
--- a/querido_diario_raspadores/gazette/spiders/to/to_xambioa.py
+++ b/querido_diario_raspadores/gazette/spiders/to/to_xambioa.py
@@ -1,0 +1,45 @@
+from datetime import date
+
+from scrapy import Request
+from w3lib.url import add_or_replace_parameter
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class ToXambioaSpider(BaseGazetteSpider):
+    TERRITORY_ID = "1722107"
+    name = "to_xambioa"
+    allowed_domains = ["diariooficial.xambioa.to.gov.br"]
+    start_date = date(2021, 5, 24)
+    base_url = "https://diariooficial.xambioa.to.gov.br/api/diarios"
+
+    async def start(self):
+        url = f"{self.base_url}?calendar=true&situacao=2&per_page=100&page=1"
+        yield Request(url)
+
+    def parse(self, response):
+        response_data = response.json()
+
+        for edition in response_data["data"]:
+            edition_date = date.fromisoformat(edition["data"])
+            if not self.start_date <= edition_date <= self.end_date:
+                continue
+
+            file_url = edition["media_legacy"] or edition["midias"][0]["url"]
+            edition_type = edition["tipo"]["descricao"]
+
+            yield Gazette(
+                date=edition_date,
+                edition_number=edition["numero"],
+                file_urls=[file_url],
+                is_extra_edition=edition_type == "Edição Especial",
+                power="executive_legislative",
+            )
+
+        current_page = response_data["current_page"]
+        if current_page < response_data["last_page"]:
+            next_page_url = add_or_replace_parameter(
+                response.url, "page", current_page + 1
+            )
+            yield Request(next_page_url)


### PR DESCRIPTION
**AO ABRIR** uma *Pull Request* de um novo raspador (*spider*), marque com um `X` cada um dos items da checklist abaixo. Caso algum item não seja marcado, JUSTIFIQUE o motivo.

#### Layout do site publicador de diários oficiais
Marque apenas um dos itens a seguir:
- [x] O *layout* não se parece com nenhum caso [da lista de *layouts* padrão](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/lista-sistemas-replicaveis.html)
- [ ] É um *layout* padrão e esta PR adiciona a spider base do padrão ao projeto junto com alguns municípios que fazem parte do padrão.
- [ ] É um *layout* padrão e todos os municípios adicionados usam a [classe de spider base](https://github.com/okfn-brasil/querido-diario/tree/main/querido_diario_raspadores/gazette/spiders/base) adequada para o padrão.

As outras opções não se aplicam porque o portal atual utiliza NúcleoGov/Next.js e não possui uma classe-base compatível no projeto.

#### Código da(s) spider(s)
- [x] O(s) raspador(es) adicionado(s) tem os [atributos de classe exigidos](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider).
- [x] O(s) raspador(es) adicionado(s) cria(m) objetos do tipo Gazette coletando todos [os metadados necessários](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#Gazette).
- [x] O atributo de classe [start_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.start_date) foi preenchido com a data da edição de diário oficial mais antiga disponível no site.
- [x] Explicitar o atributo de classe [end_date](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#UFMunicipioSpider.end_date) não se fez necessário.
- [x] Não utilizo `custom_settings` em meu raspador.

#### Testes
- [x] Uma coleta-teste **da última edição** foi feita. O arquivo de `.log` deste teste está anexado na PR.
- [x] Uma coleta-teste **por intervalo arbitrário** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.
- [x] Uma coleta-teste **completa** foi feita. Os arquivos de `.log` e `.csv` deste teste estão anexados na PR.

#### Verificações
- [x] Eu experimentei abrir alguns arquivos de diários oficiais coletados pelo meu raspador e verifiquei eles [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#diarios-oficiais-data-collection-data) não encontrando problemas.
- [x] Eu verifiquei os arquivos `.csv` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#tabela-da-coleta-arquivo-csv) não encontrando problemas.
- [x] Eu verifiquei os arquivos de `.log` gerados pela minha coleta [conforme a documentação](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/raspadores.html#log-arquivo-log) não encontrando problemas.

#### Descrição

Closes #1024

Esta PR adiciona o spider `to_xambioa`, responsável pela coleta dos diários oficiais de Xambioá-TO.

A investigação anterior estava correta para a versão antiga do portal: a listagem mensal não disponibilizava o dia completo da publicação, impedindo o preenchimento seguro de `Gazette.date`.

Desde então, o portal migrou para uma aplicação NúcleoGov/Next.js. A rota `/todas/` e os endpoints utilizados por `BaseDiarioOficialBRSpider` não estão mais disponíveis. Apesar de o domínio conter `diariooficial`, o site atual não é compatível com essa classe-base.

O frontend atual utiliza a API JSON `/api/diarios`, que fornece a data completa, o número e o tipo da edição, a URL do PDF e os dados de paginação. Por isso, o spider herda diretamente de `BaseGazetteSpider`.

A paginação é reconstruída preservando os parâmetros `calendar=true` e `situacao=2`, pois o campo `next_page_url` retornado pela API não mantém esses filtros.

Resultados dos testes:

- última edição e período recente: 5 itens e 5 PDFs;
- intervalo histórico: 5 itens e 5 PDFs;
- coleta completa: 510 itens e 510 PDFs;
- período completo: `2021-05-24` a `2026-08-04`;
- 516 respostas HTTP 200 na coleta completa;
- 510 URLs de PDF únicas;
- nenhuma duplicata;
- 2 edições especiais identificadas;
- todos os itens passaram pela validação do schema.

Os avisos presentes nos logs são gerais do ambiente local: `StatsPersist` desabilitado por ausência de `QUERIDODIARIO_API_URL` e avisos de depreciação do middleware compartilhado. Não houve erro do spider.

#### Artefatos dos testes
[completa_final.csv](https://github.com/user-attachments/files/30803057/completa_final.csv)
[completa_final.log](https://github.com/user-attachments/files/30803058/completa_final.log)
[intervalo.csv](https://github.com/user-attachments/files/30803059/intervalo.csv)
[intervalo.log](https://github.com/user-attachments/files/30803060/intervalo.log)
[ultima_final.csv](https://github.com/user-attachments/files/30803061/ultima_final.csv)
[ultima_final.log](https://github.com/user-attachments/files/30803062/ultima_final.log)
