### PR TITLE
feat: habilita/desabilita spider via API em vez de acesso direto ao banco

### DIFF
--- a/.github/workflows/update_spider_status.yaml
+++ b/.github/workflows/update_spider_status.yaml
@@ -18,7 +18,8 @@ jobs:
   update-status:
     runs-on: ubuntu-latest
     env:
-      QUERIDODIARIO_DATABASE_URL: ${{ secrets.QUERIDODIARIO_DATABASE_URL }}
+      QUERIDODIARIO_API_URL: ${{ secrets.QUERIDODIARIO_API_URL }}
+      QUERIDODIARIO_API_KEY: ${{ secrets.QUERIDODIARIO_API_KEY }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
     - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0

--- a/querido_diario_raspadores/gazette/utils/api_client.py
+++ b/querido_diario_raspadores/gazette/utils/api_client.py
@@ -24,9 +24,11 @@ RETRY_STATUS_FORCELIST = [429, 500, 502, 503, 504]
 class QueridoDiarioAPIClient:
     """Client for the ``/scraper/*`` endpoints of the Querido Diário API.
 
-    Retries with exponential backoff are enabled for GET and POST requests.
-    Retrying POSTs is safe because the server-side inserts are idempotent
-    (``ON CONFLICT DO NOTHING`` over unique constraints).
+    Retries with exponential backoff are enabled for GET, POST and PATCH
+    requests. Retrying POSTs is safe because the server-side inserts are
+    idempotent (``ON CONFLICT DO NOTHING`` over unique constraints), and
+    retrying PATCHes is safe because they only replace boolean/scalar
+    fields (e.g. ``enabled``), not partial/incremental updates.
     """
 
     def __init__(self, base_url, api_key, timeout=DEFAULT_TIMEOUT):
@@ -38,7 +40,11 @@ class QueridoDiarioAPIClient:
             total=RETRY_TOTAL,
             backoff_factor=RETRY_BACKOFF_FACTOR,
             status_forcelist=RETRY_STATUS_FORCELIST,
-            allowed_methods=["GET", "POST"],  # POST is idempotent server-side
+            allowed_methods=[
+                "GET",
+                "POST",
+                "PATCH",
+            ],  # POST/PATCH are idempotent server-side
         )
         adapter = HTTPAdapter(max_retries=retry)
         self.session.mount("https://", adapter)
@@ -53,6 +59,13 @@ class QueridoDiarioAPIClient:
 
     def _post(self, path, payload):
         response = self.session.post(
+            f"{self.base_url}{path}", json=payload, timeout=self.timeout
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _patch(self, path, payload):
+        response = self.session.patch(
             f"{self.base_url}{path}", json=payload, timeout=self.timeout
         )
         response.raise_for_status()
@@ -111,13 +124,7 @@ class QueridoDiarioAPIClient:
 
         PATCH /scraper/spiders/{spider_name}
         """
-        response = self.session.patch(
-            f"{self.base_url}/scraper/spiders/{spider_name}",
-            json={"enabled": enabled},
-            timeout=self.timeout,
-        )
-        response.raise_for_status()
-        return response.json()
+        return self._patch(f"/scraper/spiders/{spider_name}", {"enabled": enabled})
 
     def sync_spiders(self, territory_spider_map):
         """Register new/modified spiders and their territory mapping.

--- a/querido_diario_raspadores/gazette/utils/api_client.py
+++ b/querido_diario_raspadores/gazette/utils/api_client.py
@@ -6,8 +6,8 @@ with an API Key sent in the ``X-API-Key`` header.
 
 Configuration (environment variables or Scrapy settings):
     - ``QUERIDODIARIO_API_URL``: base URL of the API
-      (e.g. ``https://queridodiario.ok.org.br/api``... base host only,
-      the ``/scraper/*`` path is appended by the client)
+      (e.g. ``https://api.queridodiario.org.br``; the ``/scraper/*`` path
+      is appended by the client)
     - ``QUERIDODIARIO_API_KEY``: API Key for the scraper endpoints
 """
 
@@ -105,6 +105,19 @@ class QueridoDiarioAPIClient:
         params = {"spider": spider_name, "since": str(since_date)}
         data = self._get("/scraper/job-stats", params=params)
         return data["job_stats"]
+
+    def set_spider_enabled(self, spider_name, enabled):
+        """Enable or disable a spider.
+
+        PATCH /scraper/spiders/{spider_name}
+        """
+        response = self.session.patch(
+            f"{self.base_url}/scraper/spiders/{spider_name}",
+            json={"enabled": enabled},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return response.json()
 
     def sync_spiders(self, territory_spider_map):
         """Register new/modified spiders and their territory mapping.

--- a/querido_diario_raspadores/scheduler.py
+++ b/querido_diario_raspadores/scheduler.py
@@ -3,10 +3,8 @@ import datetime
 import click
 from decouple import config
 from scrapinghub import ScrapinghubClient
-from sqlalchemy import create_engine, update
-from sqlalchemy.orm import sessionmaker
 
-from gazette.database.models import QueridoDiarioSpider
+from gazette.utils.api_client import QueridoDiarioAPIClient
 from gazette.utils.database import get_enabled_spiders
 
 YESTERDAY = datetime.date.today() - datetime.timedelta(days=1)
@@ -16,12 +14,8 @@ def _job_settings():
     return {
         "FILES_STORE": config("FILES_STORE"),
         "FILES_STORE_SECONDARY": config("FILES_STORE_SECONDARY", default=""),
-        # Gazettes are persisted through the API when QUERIDODIARIO_API_URL
-        # is set. QUERIDODIARIO_DATABASE_URL is kept only while job_stats
-        # (phase 2) has not migrated to the API.
         "QUERIDODIARIO_API_URL": config("QUERIDODIARIO_API_URL", default=""),
         "QUERIDODIARIO_API_KEY": config("QUERIDODIARIO_API_KEY", default=""),
-        "QUERIDODIARIO_DATABASE_URL": config("QUERIDODIARIO_DATABASE_URL", default=""),
         "AWS_ACCESS_KEY_ID": config("AWS_ACCESS_KEY_ID"),
         "AWS_SECRET_ACCESS_KEY": config("AWS_SECRET_ACCESS_KEY"),
         "AWS_ENDPOINT_URL": config("AWS_ENDPOINT_URL"),
@@ -45,6 +39,12 @@ def _get_enabled_spiders(start_date=None, end_date=None):
 def _get_project():
     client = ScrapinghubClient(config("SHUB_APIKEY"))
     return client.get_project(config("SCRAPY_CLOUD_PROJECT_ID"))
+
+
+def _get_api_client():
+    return QueridoDiarioAPIClient(
+        config("QUERIDODIARIO_API_URL"), config("QUERIDODIARIO_API_KEY")
+    )
 
 
 def _schedule_job(start, full, spider_name, project=None, end=None):
@@ -112,18 +112,7 @@ def schedule_spider(spider_name, start, end):
     help="Spider name",
 )
 def enable_spider(spider_name):
-    engine = create_engine(config("QUERIDODIARIO_DATABASE_URL"))
-    Session = sessionmaker(bind=engine)
-    session = Session()
-
-    stmt = (
-        update(QueridoDiarioSpider)
-        .where(QueridoDiarioSpider.spider_name == spider_name)
-        .values(enabled=True)
-    )
-
-    session.execute(stmt)
-    session.commit()
+    _get_api_client().set_spider_enabled(spider_name, True)
 
 
 @cli.command()
@@ -133,18 +122,7 @@ def enable_spider(spider_name):
     help="Spider name",
 )
 def disable_spider(spider_name):
-    engine = create_engine(config("QUERIDODIARIO_DATABASE_URL"))
-    Session = sessionmaker(bind=engine)
-    session = Session()
-
-    stmt = (
-        update(QueridoDiarioSpider)
-        .where(QueridoDiarioSpider.spider_name == spider_name)
-        .values(enabled=False)
-    )
-
-    session.execute(stmt)
-    session.commit()
+    _get_api_client().set_spider_enabled(spider_name, False)
 
 
 @cli.command()

--- a/querido_diario_raspadores/tests/test_scheduler.py
+++ b/querido_diario_raspadores/tests/test_scheduler.py
@@ -33,6 +33,39 @@ def test_schedule_job_reuses_provided_project(monkeypatch):
     )
 
 
+def test_enable_spider_uses_api_client(monkeypatch):
+    api_client = Mock()
+    monkeypatch.setattr(scheduler, "_get_api_client", Mock(return_value=api_client))
+
+    scheduler.enable_spider.callback(spider_name="test_spider")
+
+    api_client.set_spider_enabled.assert_called_once_with("test_spider", True)
+
+
+def test_disable_spider_uses_api_client(monkeypatch):
+    api_client = Mock()
+    monkeypatch.setattr(scheduler, "_get_api_client", Mock(return_value=api_client))
+
+    scheduler.disable_spider.callback(spider_name="test_spider")
+
+    api_client.set_spider_enabled.assert_called_once_with("test_spider", False)
+
+
+def test_job_settings_do_not_include_database_url(monkeypatch):
+    monkeypatch.setenv("FILES_STORE", "test")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "test")
+    monkeypatch.setenv("AWS_REGION_NAME", "test")
+    monkeypatch.setenv("SPIDERMON_DISCORD_FAKE", "True")
+    monkeypatch.setenv("SPIDERMON_DISCORD_WEBHOOK_URL", "test")
+    monkeypatch.setenv("ZYTE_SMARTPROXY_APIKEY", "test")
+
+    job_settings = scheduler._job_settings()
+
+    assert "QUERIDODIARIO_DATABASE_URL" not in job_settings
+
+
 def test_schedule_enabled_spiders_creates_project_once(monkeypatch):
     project = Mock()
     get_project = Mock(return_value=project)


### PR DESCRIPTION
## Summary
- `enable_spider`/`disable_spider` (`scheduler.py`, usados pelo workflow `update_spider_status.yaml`) passam a chamar `PATCH /scraper/spiders/{spider_name}` via `QueridoDiarioAPIClient`, em vez de abrir conexão SQLAlchemy direta com o Postgres.
- `QUERIDODIARIO_DATABASE_URL` removida de `_job_settings()` — não é mais enviada como job setting pra Zyte, já que `ApiPipeline`, `StatsPersist` e os monitors do Spidermon já usam a API desde a migração anterior.
- Workflow `update_spider_status.yaml` atualizado para usar os secrets `QUERIDODIARIO_API_URL`/`QUERIDODIARIO_API_KEY` em vez de `QUERIDODIARIO_DATABASE_URL`.
- Motivo: o novo deployment (Kubernetes/Revoada) não expõe o PostgreSQL publicamente para a Zyte/GitHub Actions.

Depende de okfn-brasil/querido-diario-api#108 (endpoint novo).

## Test plan
- [x] `pytest tests/test_scheduler.py` — 6/6 passando (3 testes novos: enable/disable via client mockado, `_job_settings()` sem `QUERIDODIARIO_DATABASE_URL`).
- [ ] Após merge do #108 na API, atualizar o secret `QUERIDODIARIO_API_URL` (feito em paralelo) e validar `enable-spider`/`disable-spider` manualmente via workflow_dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)