### PR TITLE
fix: torna schedule_enabled_spiders resiliente a falhas pontuais na Scrapy Cloud

### DIFF
--- a/querido_diario_raspadores/scheduler.py
+++ b/querido_diario_raspadores/scheduler.py
@@ -1,6 +1,9 @@
 import datetime
+import logging
+import time
 
 import click
+import requests
 from decouple import config
 from scrapinghub import ScrapinghubClient
 
@@ -8,6 +11,13 @@ from gazette.utils.api_client import QueridoDiarioAPIClient
 from gazette.utils.database import get_enabled_spiders
 
 YESTERDAY = datetime.date.today() - datetime.timedelta(days=1)
+
+logger = logging.getLogger(__name__)
+
+# Scrapy Cloud (Zyte) ocasionalmente derruba a conexão no meio de um
+# "run job" (RemoteDisconnected) sem nenhum problema real do nosso lado.
+SCHEDULE_JOB_RETRY_ATTEMPTS = 3
+SCHEDULE_JOB_RETRY_BACKOFF_SECONDS = 5  # 5s, 10s
 
 
 def _job_settings():
@@ -59,10 +69,27 @@ def _schedule_job(start, full, spider_name, project=None, end=None):
             job_args["end"] = end
 
     spider = project.spiders.get(spider_name)
-    spider.jobs.run(
-        job_settings=job_settings,
-        job_args=job_args,
-    )
+
+    for attempt in range(1, SCHEDULE_JOB_RETRY_ATTEMPTS + 1):
+        try:
+            spider.jobs.run(
+                job_settings=job_settings,
+                job_args=job_args,
+            )
+            return
+        except requests.exceptions.RequestException:
+            if attempt == SCHEDULE_JOB_RETRY_ATTEMPTS:
+                raise
+            delay = SCHEDULE_JOB_RETRY_BACKOFF_SECONDS * (2 ** (attempt - 1))
+            logger.warning(
+                "Falha de conexão ao agendar '%s' na Scrapy Cloud "
+                "(tentativa %d/%d), tentando de novo em %ds",
+                spider_name,
+                attempt,
+                SCHEDULE_JOB_RETRY_ATTEMPTS,
+                delay,
+            )
+            time.sleep(delay)
 
 
 @click.group()
@@ -147,12 +174,26 @@ def schedule_job(start, full, spider_name):
 @cli.command()
 def schedule_enabled_spiders():
     project = _get_project()
+    failed_spiders = []
     for spider_name in _get_enabled_spiders(start_date=YESTERDAY):
-        _schedule_job(
-            start=YESTERDAY,
-            full=False,
-            spider_name=spider_name,
-            project=project,
+        try:
+            _schedule_job(
+                start=YESTERDAY,
+                full=False,
+                spider_name=spider_name,
+                project=project,
+            )
+        except requests.exceptions.RequestException:
+            logger.exception(
+                "Falha ao agendar '%s' na Scrapy Cloud, pulando pro próximo spider",
+                spider_name,
+            )
+            failed_spiders.append(spider_name)
+
+    if failed_spiders:
+        raise click.ClickException(
+            f"Falha ao agendar {len(failed_spiders)} spider(s): "
+            f"{', '.join(failed_spiders)}"
         )
 
 

--- a/querido_diario_raspadores/tests/test_scheduler.py
+++ b/querido_diario_raspadores/tests/test_scheduler.py
@@ -1,5 +1,8 @@
 from unittest.mock import Mock
 
+import click
+import pytest
+import requests
 from scrapinghub.hubstorage.serialization import MSGPACK_AVAILABLE
 
 import scheduler
@@ -85,3 +88,62 @@ def test_schedule_enabled_spiders_creates_project_once(monkeypatch):
     assert all(
         call.kwargs["project"] is project for call in schedule_job.call_args_list
     )
+
+
+def test_schedule_job_retries_on_connection_error(monkeypatch):
+    project = Mock()
+    monkeypatch.setattr(scheduler, "_job_settings", Mock(return_value={}))
+    monkeypatch.setattr(scheduler.time, "sleep", Mock())
+
+    run = project.spiders.get.return_value.jobs.run
+    run.side_effect = [requests.exceptions.ConnectionError("boom"), None]
+
+    scheduler._schedule_job(
+        start="2026-08-01", full=False, spider_name="test_spider", project=project
+    )
+
+    assert run.call_count == 2
+
+
+def test_schedule_job_raises_after_exhausting_retries(monkeypatch):
+    project = Mock()
+    monkeypatch.setattr(scheduler, "_job_settings", Mock(return_value={}))
+    monkeypatch.setattr(scheduler.time, "sleep", Mock())
+
+    run = project.spiders.get.return_value.jobs.run
+    run.side_effect = requests.exceptions.ConnectionError("boom")
+
+    with pytest.raises(requests.exceptions.ConnectionError):
+        scheduler._schedule_job(
+            start="2026-08-01", full=False, spider_name="test_spider", project=project
+        )
+
+    assert run.call_count == scheduler.SCHEDULE_JOB_RETRY_ATTEMPTS
+
+
+def test_schedule_enabled_spiders_continues_after_one_spider_fails(monkeypatch):
+    project = Mock()
+    monkeypatch.setattr(scheduler, "_get_project", Mock(return_value=project))
+    monkeypatch.setattr(
+        scheduler,
+        "_get_enabled_spiders",
+        Mock(return_value=["first_spider", "second_spider", "third_spider"]),
+    )
+    schedule_job = Mock(
+        side_effect=[
+            None,
+            requests.exceptions.ConnectionError("boom"),
+            None,
+        ]
+    )
+    monkeypatch.setattr(scheduler, "_schedule_job", schedule_job)
+
+    with pytest.raises(click.ClickException, match="second_spider"):
+        scheduler.schedule_enabled_spiders.callback()
+
+    # os três spiders foram tentados, mesmo o segundo tendo falhado
+    assert schedule_job.call_count == 3
+    scheduled_names = [
+        call.kwargs["spider_name"] for call in schedule_job.call_args_list
+    ]
+    assert scheduled_names == ["first_spider", "second_spider", "third_spider"]


### PR DESCRIPTION
## Problema

O agendamento diário (`schedule_enabled_spiders`) falhou por completo hoje:
https://github.com/okfn-brasil/querido-diario/actions/runs/34697886809/job/103564421732

```
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

O erro acontece dentro de `spider.jobs.run(...)` (chamada à Scrapy Cloud/Zyte, não relacionada à nossa API/Postgres) — parece uma instabilidade pontual do lado da Zyte. O problema real é que **um único spider com esse erro derruba o agendamento de todos os spiders seguintes**, já que `schedule_enabled_spiders` não tem nenhum tratamento de erro por spider.

## Correção

- `_schedule_job` agora tenta de novo (3 tentativas, backoff 5s/10s) quando `spider.jobs.run()` levanta `requests.exceptions.RequestException` — cobre blips de rede transitórios.
- `schedule_enabled_spiders` isola falha por spider: se um spider esgotar as tentativas, loga o erro e segue pros próximos. Ao final, se algum spider falhou, o comando sai com erro (`click.ClickException`, listando quais spiders falharam) — mantém visibilidade no CI sem bloquear o agendamento dos demais.

Escopo: só `schedule_enabled_spiders` (usado no crawl diário). Os outros comandos que também chamam `_schedule_job` em loop (`last_month_schedule_enabled_spiders`, `schedule_all_spiders_by_date`) ganham o retry de `_schedule_job` automaticamente, mas não a isolação por spider — posso estender se fizer sentido.

## Test plan

- [x] Testes novos cobrindo retry (sucesso após 1 falha, exaustão das tentativas) e isolação por spider
- [x] Suíte completa (`uv run pytest tests/`) passando: 111 testes
- [x] `black`/`isort`/`ruff`/`bandit` (pre-commit) passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdMDA5GSzUVdc2qTFSTEKH