### PR TITLE
fix: adapta BaseDiofSpider ao novo formato paginado da API diof.io.org.br

### DIFF
--- a/querido_diario_raspadores/gazette/spiders/base/diof.py
+++ b/querido_diario_raspadores/gazette/spiders/base/diof.py
@@ -74,20 +74,25 @@ class BaseDiofSpider(BaseGazetteSpider):
         for interval in monthly_window(
             self.start_date, self.end_date, format="%Y-%m-%d"
         ):
-            data = {
-                "cod_cliente": f"{self.client_id}",
-                "dat_envio_ini": f"{interval.start}",
-                "dat_envio_fim": f"{interval.end}",
-                "des_observacao": "",
-                "edicao": None,
-            }
-            yield JsonRequest(
-                url=f"{self.api_url}/diario-oficial/edicoes-anteriores-group",
-                data=data,
-                callback=self.parse_items,
-            )
+            yield from self._edicoes_request(interval, page=1)
 
-    def parse_items(self, response):
+    def _edicoes_request(self, interval, page):
+        data = {
+            "cod_cliente": f"{self.client_id}",
+            "dat_envio_ini": f"{interval.start}",
+            "dat_envio_fim": f"{interval.end}",
+            "des_observacao": "",
+            "edicao": None,
+            "page": page,
+        }
+        yield JsonRequest(
+            url=f"{self.api_url}/diario-oficial/edicoes-anteriores-group",
+            data=data,
+            callback=self.parse_items,
+            cb_kwargs={"interval": interval, "page": page},
+        )
+
+    def parse_items(self, response, interval, page):
         """
         The SAI service appears to be migrating its backend to consume a DIOF API,
         but some gazettes are only collectible through the old URL. So, this method
@@ -95,7 +100,13 @@ class BaseDiofSpider(BaseGazetteSpider):
         it using the old URL.
         """
 
-        for gazette_date in json.loads(response.text):
+        payload = json.loads(response.text)
+
+        # A API passou a envelopar a lista de datas num objeto
+        # {"data": [...], "page", "pages", "count"} com paginação — antes
+        # era só a lista, sem paginação. `total_pages` pode faltar em
+        # respostas antigas cacheadas/mocks; assume 1 nesse caso.
+        for gazette_date in payload.get("data", []):
             for gazette in gazette_date["elements"]:
                 date = gazette["dat_envio"]
                 path = gazette["des_arquivoa4"]
@@ -121,6 +132,10 @@ class BaseDiofSpider(BaseGazetteSpider):
                         "optional_url": second_option_url,
                     },
                 )
+
+        total_pages = payload.get("pages") or 1
+        if page < total_pages:
+            yield from self._edicoes_request(interval, page=page + 1)
 
     def collect_gazette(self, response, metadata, optional_url):
         if response.status != 200:

--- a/querido_diario_raspadores/tests/test_diof.py
+++ b/querido_diario_raspadores/tests/test_diof.py
@@ -1,7 +1,11 @@
 import asyncio
+import json
 from datetime import date
 
+from scrapy.http import TextResponse
+
 from gazette.spiders.base.diof import BaseDiofSpider
+from gazette.utils.dates import DateRange
 
 
 class DiofSpiderForTest(BaseDiofSpider):
@@ -16,6 +20,16 @@ async def collect_start_requests(spider):
     return [request async for request in spider.start()]
 
 
+def make_response(
+    payload, url="https://diof.io.org.br/api/diario-oficial/edicoes-anteriores-group"
+):
+    return TextResponse(
+        url=url,
+        body=json.dumps(payload).encode("utf-8"),
+        encoding="utf-8",
+    )
+
+
 def test_start_builds_client_info_request():
     spider = DiofSpiderForTest()
 
@@ -25,3 +39,84 @@ def test_start_builds_client_info_request():
     assert start_requests[0].url.endswith("/dados-cliente/info/")
     assert start_requests[0].headers["Origin"] == b"https://example.com"
     assert start_requests[0].callback == spider.interval_request
+
+
+def test_parse_items_unwraps_the_data_envelope():
+    # A API passou a envelopar a lista de datas num objeto
+    # {"data": [...], "page", "pages", "count"} em vez de retornar a lista
+    # diretamente.
+    spider = DiofSpiderForTest()
+    spider.client_id = "123"
+    interval = DateRange(start=date(2026, 9, 1), end=date(2026, 9, 12))
+    payload = {
+        "data": [
+            {
+                "key": "2026-09-10T00:00:00",
+                "elements": [
+                    {
+                        "cod_documento": 42,
+                        "dat_envio": "2026-09-10T14:14:13",
+                        "des_arquivoa4": "some_file_id",
+                    }
+                ],
+            }
+        ],
+        "page": 1,
+        "pages": 1,
+        "count": 1,
+    }
+
+    requests = list(
+        spider.parse_items(make_response(payload), interval=interval, page=1)
+    )
+
+    assert len(requests) == 1
+    gazette_request = requests[0]
+    assert gazette_request.url.endswith("/diario-oficial/download/some_file_id.pdf")
+    assert gazette_request.cb_kwargs["metadata"]["edition_number"] == "42"
+    assert gazette_request.cb_kwargs["metadata"]["date"] == date(2026, 9, 10)
+
+
+def test_parse_items_requests_the_next_page_when_there_is_one():
+    spider = DiofSpiderForTest()
+    spider.client_id = "123"
+    interval = DateRange(start=date(2026, 8, 1), end=date(2026, 9, 12))
+    payload = {"data": [], "page": 1, "pages": 3, "count": 15}
+
+    results = list(
+        spider.parse_items(make_response(payload), interval=interval, page=1)
+    )
+
+    assert len(results) == 1
+    next_page_request = results[0]
+    assert next_page_request.callback == spider.parse_items
+    assert next_page_request.cb_kwargs == {"interval": interval, "page": 2}
+    assert json.loads(next_page_request.body)["page"] == 2
+
+
+def test_parse_items_stops_on_the_last_page():
+    spider = DiofSpiderForTest()
+    spider.client_id = "123"
+    interval = DateRange(start=date(2026, 8, 1), end=date(2026, 9, 12))
+    payload = {"data": [], "page": 3, "pages": 3, "count": 15}
+
+    results = list(
+        spider.parse_items(make_response(payload), interval=interval, page=3)
+    )
+
+    assert results == []
+
+
+def test_parse_items_treats_missing_pages_field_as_single_page():
+    # respostas antigas (ou mocks incompletos) podem não ter o campo
+    # "pages" — não deve tentar paginar indefinidamente nesse caso.
+    spider = DiofSpiderForTest()
+    spider.client_id = "123"
+    interval = DateRange(start=date(2026, 8, 1), end=date(2026, 9, 12))
+    payload = {"data": []}
+
+    results = list(
+        spider.parse_items(make_response(payload), interval=interval, page=1)
+    )
+
+    assert results == []


### PR DESCRIPTION
## Problema

O `al_igaci` (e outros spiders baseados em `BaseDiofSpider`) quebra com:

```
TypeError: string indices must be integers, not 'str'
```

Log real: https://github.com/okfn-brasil/querido-diario/actions/runs/34697886809 (job `al_igaci`)

## Causa raiz

A API `diof.io.org.br/api/diario-oficial/edicoes-anteriores-group` passou a envelopar a resposta num objeto `{"data": [...], "page", "pages", "count"}` em vez de retornar a lista de datas diretamente. O código antigo fazia `for gazette_date in json.loads(response.text)` esperando uma lista — como agora é um dict, isso itera sobre as *chaves* (`"data"`, `"page"`, `"pages"`, `"count"`, todas strings) e quebra ao tentar `gazette_date["elements"]` numa string.

**Achado extra:** essa mudança também trouxe paginação real do lado da API. Confirmado contra o endpoint ao vivo (cliente de teste, ~6 semanas de janela): `count: 30` documentos, mas só a primeira de `pages: 6` páginas veio na resposta. Sem tratar isso, qualquer coleta com janela maior que a diária (backfill, recuperação de spider desabilitado por um tempo, etc.) estaria perdendo a maior parte dos diários silenciosamente — sem erro nenhum, só menos itens do que deveria.

**Blast radius:** 21 spiders herdam de `BaseDiofSpider` (AL: igaci; SE: estancia; BA: luis_eduardo_magalhaes, arataca, riachao_das_neves, santa_luzia, aracas, antas, jeremoabo, itatim, lauro_de_freitas, aramari, apuarema, jaborandi, anage, correntina, almadina, andorinha, abare, adustina, maragogipe).

## Correção

`parse_items` agora:
1. Desembrulha a resposta via `payload["data"]` em vez de iterar o dict inteiro.
2. Seleção do `page` no corpo da requisição e segue paginando até `page == pages`.

## Test plan

- [x] Testes novos: desembrulho do envelope, paginação (segue pra próxima página, para na última), resposta sem campo `pages` (não deve tentar paginar indefinidamente)
- [x] Validado manualmente contra a API ao vivo (`al_igaci`, cod_cliente 10986): 5 diários + 1 request de próxima página retornados corretamente pra uma janela com `pages: 6`
- [x] Suíte completa (`uv run pytest tests/`) passando: 115 testes
- [x] pre-commit (black/isort/ruff/bandit) passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)